### PR TITLE
Override javadoc plugin to a working version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
 		<scijava.jvm.version>11</scijava.jvm.version>
 		<scijava.jvm.build.version>[11,11.9999]</scijava.jvm.build.version>
 
+		<!-- NB: Old version of javadoc plugin avoids modularity conflicts -->
+		<maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+		<doclint>none</doclint>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>


### PR DESCRIPTION
The 3.1.0 (and 3.2.0) version of the plugin emits errors like:

```
$ mvn install javadoc:javadoc
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.0:javadoc (default-cli) on project scijava-ops: An error has occurred in Javadoc report generation:
[ERROR] Exit code: 1 - error: module org.scijava reads package org.scijava from both org.scijava.ops and org.scijava
[ERROR] error: module org.scijava reads package org.scijava.util from both org.scijava.ops and org.scijava
[ERROR] error: module org.scijava.ops reads package org.scijava from both org.scijava and org.scijava.ops
[ERROR] error: module org.scijava.ops reads package org.scijava.util from both org.scijava and org.scijava.ops
[ERROR] error: the unnamed module reads package org.scijava from both org.scijava.ops and org.scijava
[ERROR] error: the unnamed module reads package org.scijava.util from both org.scijava.ops and org.scijava
```

Whereas 3.0.1 works.