### PR TITLE
Separate OpEnvironment and OpService

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/eval/OpEvaluator.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/eval/OpEvaluator.java
@@ -148,7 +148,7 @@ public class OpEvaluator extends AbstractStandardStackEvaluator {
 		Nil<Object> outType = new Nil<>() {};
 
 		// Try executing the op.
-		Functions.ArityN<Object> func = Functions.matchN(ops, opName, outType, inTypes);
+		Functions.ArityN<Object> func = Functions.matchN(ops.env(), opName, outType, inTypes);
 		return func.apply(argValues);
 	}
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/LabelRegionToPolygonConverter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/LabelRegionToPolygonConverter.java
@@ -66,7 +66,7 @@ public class LabelRegionToPolygonConverter extends
 	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
 		if (contourFunc == null) {
-			contourFunc = Functions.match(ops, "geom.contour", new Nil<RandomAccessibleInterval<BoolType>>() {}, new Nil<Boolean>() {},
+			contourFunc = Functions.match(ops.env(), "geom.contour", new Nil<RandomAccessibleInterval<BoolType>>() {}, new Nil<Boolean>() {},
 					new Nil<Polygon2D>() {});
 		}
 		// FIXME: can we make this faster?

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/mesh/RAIToMeshConverter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/mesh/RAIToMeshConverter.java
@@ -67,7 +67,7 @@ public class RAIToMeshConverter <B extends BooleanType<B>> extends
 	@Override
 	public <T> T convert(Object src, Class<T> dest) {
 		if (marchingCubesFunc == null) {
-			marchingCubesFunc = Functions.match(ops, "geom.marchingCubes", new Nil<RandomAccessibleInterval<B>>() {},
+			marchingCubesFunc = Functions.match(ops.env(), "geom.marchingCubes", new Nil<RandomAccessibleInterval<B>>() {},
 					new Nil<Mesh>() {});
 		}
 		if (src instanceof IterableInterval<?>) {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/AbstractHelp.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/AbstractHelp.java
@@ -33,9 +33,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.ops.matcher.OpCandidate;
-import org.scijava.ops.matcher.OpInfo;
 
 /**
  * Base class for help operations.

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
@@ -53,7 +53,7 @@ public class HelpForName extends AbstractHelp implements BiFunction<String, OpSe
 
 	@Override
 	public String apply(String name, OpService ops) {
-		final Iterable<OpInfo> allOps = ops.infos(name);
+		final Iterable<OpInfo> allOps = ops.env().infos(name);
 		help(allOps);
 		return help;
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
@@ -32,9 +32,9 @@ package net.imagej.ops2.help;
 import java.util.function.BiFunction;
 
 import org.scijava.Priority;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpService;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/AbstractOpTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/AbstractOpTest.java
@@ -52,8 +52,9 @@ import org.scijava.Context;
 import org.scijava.cache.CacheService;
 import org.scijava.ops.OpService;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.core.builder.OpBuilder;
+import org.scijava.plugin.PluginService;
 import org.scijava.thread.ThreadService;
+import org.scijava.types.TypeService;
 
 /**
  * Base class for {@link Op} unit testing.
@@ -72,7 +73,8 @@ public abstract class AbstractOpTest{
 
 	@BeforeAll
 	public static void setUp() {
-		context = new Context(OpService.class, CacheService.class, ThreadService.class);
+		context = new Context(OpService.class, CacheService.class,
+			ThreadService.class, PluginService.class, TypeService.class);
 		ops = context.service(OpService.class);
 	}
 
@@ -83,10 +85,6 @@ public abstract class AbstractOpTest{
 		ops = null;
 	}
 	
-	protected static OpBuilder op(String name) {
-		return new OpBuilder(ops, name);
-	}
-
 	private int seed;
 
 	private int pseudoRandom() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/ColocalisationTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/ColocalisationTest.java
@@ -61,7 +61,9 @@ import org.scijava.cache.CacheService;
 import org.scijava.io.location.FileLocation;
 import org.scijava.ops.OpService;
 import org.scijava.ops.core.builder.OpBuilder;
+import org.scijava.plugin.PluginService;
 import org.scijava.thread.ThreadService;
+import org.scijava.types.TypeService;
 
 /** Abstract base class for coloc op unit tests. */
 public abstract class ColocalisationTest {
@@ -82,12 +84,12 @@ public abstract class ColocalisationTest {
 	public static void setUp() {
 		context = new Context(OpService.class, CacheService.class,
 			ThreadService.class, StatusService.class, SCIFIOService.class,
-			FormatService.class);
+			FormatService.class, PluginService.class, TypeService.class);
 		ops = context.service(OpService.class);
 	}
 	
 	protected static OpBuilder op(String name) {
-		return new OpBuilder(ops, name);
+		return ops.op(name);
 	}
 
 	/**

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/icq/LiICQTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/icq/LiICQTest.java
@@ -60,7 +60,7 @@ public class LiICQTest extends ColocalisationTest {
 		final Img<ByteType> img1 = TestImgGeneration.byteArray(true, 10, 15, 20);
 		final Img<ByteType> img2 = TestImgGeneration.byteArray(true, 10, 15, 20);
 
-		final Double icqValue = op("coloc.icq").input(img1, img2).outType(Double.class).apply();
+		final Double icqValue = ops.op("coloc.icq").input(img1, img2).outType(Double.class).apply();
 
 		assertEquals(0.5, icqValue, 0.0);
 	}
@@ -70,7 +70,7 @@ public class LiICQTest extends ColocalisationTest {
 	 */
 	@Test
 	public void liPositiveCorrTest() {
-		final Double icqValue = op("coloc.icq").input(positiveCorrelationImageCh1, positiveCorrelationImageCh2)
+		final Double icqValue = ops.op("coloc.icq").input(positiveCorrelationImageCh1, positiveCorrelationImageCh2)
 				.outType(Double.class).apply();
 		assertTrue(icqValue > 0.34 && icqValue < 0.35);
 	}
@@ -81,7 +81,7 @@ public class LiICQTest extends ColocalisationTest {
 	 */
 	@Test
 	public void liZeroCorrTest() {
-		final Object icqValue = op("coloc.icq").input(zeroCorrelationImageCh1, zeroCorrelationImageCh2).apply();
+		final Object icqValue = ops.op("coloc.icq").input(zeroCorrelationImageCh1, zeroCorrelationImageCh2).apply();
 
 		assertTrue(icqValue instanceof Double);
 		final double icq = (Double) icqValue;
@@ -101,10 +101,10 @@ public class LiICQTest extends ColocalisationTest {
 				0x01234567);
 		Img<FloatType> ch2 = ColocalisationTest.produceMeanBasedNoiseImage(new FloatType(), 24, 24, mean, spread, sigma,
 				0x98765432);
-		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op = Functions.match(ops, "coloc.icq",
+		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op = Functions.match(ops.env(), "coloc.icq",
 				new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<Double>() {});
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
 		assertEquals(0.72, value.getPValue(), 0.0);
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/kendallTau/KendallTauBRankTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/kendallTau/KendallTauBRankTest.java
@@ -105,7 +105,7 @@ public class KendallTauBRankTest extends AbstractOpTest {
 			//final PairIterator<DoubleType> iter = pairIterator(values1, values2);
 			final Iterable<Pair<IntType, IntType>> iter = new IterablePair<>(ArrayImgs.ints(values1, n), ArrayImgs.ints(values2, n));
 			double kendallValue1 = calculateNaive(iter.iterator());
-			double kendallValue2 = op("coloc.kendallTau").input(values1, values2).outType(Double.class).apply();
+			double kendallValue2 = ops.op("coloc.kendallTau").input(values1, values2).outType(Double.class).apply();
 			if (Double.isNaN(kendallValue1)) {
 				assertTrue(Double.isInfinite(kendallValue2) || Double.isNaN(
 					kendallValue2), "i: " + i + ", value2: " + kendallValue2);
@@ -127,14 +127,14 @@ public class KendallTauBRankTest extends AbstractOpTest {
 				0x98765432);
 		Nil<Iterable<FloatType>> nilI = new Nil<Iterable<FloatType>>() {};
 		Nil<RandomAccessibleInterval<FloatType>> nilRAI = new Nil<RandomAccessibleInterval<FloatType>>() {};
-		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op = Functions.match(ops,
+		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op = Functions.match(ops.env(),
 				"coloc.kendallTau", nilRAI, nilRAI, new Nil<Double>() {});
 //		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> raiOp = op(
 //				"transform.raiToIterable").input(op).outType(
 //						new Nil<BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double>>() {})
 //						.apply();
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
 		assertEquals(0.75, value.getPValue(), 0.0);
 	}
 
@@ -146,7 +146,7 @@ public class KendallTauBRankTest extends AbstractOpTest {
 	}
 	
 	private <T extends RealType<T>, U extends RealType<U>> void assertTau(final double expected, final Iterable<T> img1, final Iterable<U> img2) {
-		final double kendallValue = (double) op("coloc.kendallTau").input(img1, img2).apply();
+		final double kendallValue = (double) ops.op("coloc.kendallTau").input(img1, img2).apply();
 		assertEquals(expected, kendallValue, 1e-10);
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/maxTKendallTau/MTKTTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/maxTKendallTau/MTKTTest.java
@@ -147,7 +147,7 @@ public class MTKTTest extends ColocalisationTest {
 		}
 		Img<DoubleType> vImage1 = ArrayImgs.doubles(values1, values1.length);
 		Img<DoubleType> vImage2 = ArrayImgs.doubles(values2, values2.length);
-		double result = op("coloc.maxTKendallTau").input(vImage1, vImage2).outType(Double.class).apply();
+		double result = ops.op("coloc.maxTKendallTau").input(vImage1, vImage2).outType(Double.class).apply();
 		assertEquals(4.9E-324, result, 0.0);
 	}
 
@@ -163,7 +163,7 @@ public class MTKTTest extends ColocalisationTest {
 		}
 		Img<DoubleType> vImage1 = ArrayImgs.doubles(values1, values1.length);
 		Img<DoubleType> vImage2 = ArrayImgs.doubles(values2, values2.length);
-		double result = (Double) op("coloc.maxTKendallTau").input(vImage1, vImage2).apply();
+		double result = (Double) ops.op("coloc.maxTKendallTau").input(vImage1, vImage2).apply();
 		assertEquals(1.0, result, 0.0);
 	}
 
@@ -177,7 +177,7 @@ public class MTKTTest extends ColocalisationTest {
 				0x01234567);
 		Img<FloatType> ch2 = ColocalisationTest.produceMeanBasedNoiseImage(new FloatType(), 24, 24, mean, spread, sigma,
 				0x98765432);
-		double result = (Double) op("coloc.maxTKendallTau").input(ch1, ch2).apply();
+		double result = (Double) ops.op("coloc.maxTKendallTau").input(ch1, ch2).apply();
 		assertEquals(2.710687382741972, result, 0.0);
 	}
 
@@ -188,7 +188,7 @@ public class MTKTTest extends ColocalisationTest {
 				new long[] { 0, 0, 0 }, new long[] { 20, 20, 0 });
 		RandomAccessibleInterval<UnsignedByteType> cropCh2 = Views.interval(zeroCorrelationImageCh2,
 				new long[] { 0, 0, 0 }, new long[] { 20, 20, 0 });
-		double result = (Double) op("coloc.maxTKendallTau").input(cropCh1, cropCh2).apply();
+		double result = (Double) ops.op("coloc.maxTKendallTau").input(cropCh1, cropCh2).apply();
 		assertEquals(2.562373279563565, result, 0.0);
 	}
 
@@ -208,9 +208,9 @@ public class MTKTTest extends ColocalisationTest {
 		Img<DoubleType> vImage1 = ArrayImgs.doubles(values1, values1.length);
 		Img<DoubleType> vImage2 = ArrayImgs.doubles(values2, values2.length);
 		BiFunction<RandomAccessibleInterval<DoubleType>, RandomAccessibleInterval<DoubleType>, Double> op =
-			Functions.match(ops, "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<Double>() {});
+			Functions.match(ops.env(), "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<Double>() {});
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(vImage1, vImage2, op, 5, es).output(value).compute();
+		ops.op("coloc.pValue").input(vImage1, vImage2, op, 5, es).output(value).compute();
 		assertEquals(0.0, value.getPValue(), 0.0);
 	}
 
@@ -228,9 +228,9 @@ public class MTKTTest extends ColocalisationTest {
 		Img<DoubleType> vImage1 = ArrayImgs.doubles(values1, values1.length);
 		Img<DoubleType> vImage2 = ArrayImgs.doubles(values2, values2.length);
 		BiFunction<RandomAccessibleInterval<DoubleType>, RandomAccessibleInterval<DoubleType>, Double> op =
-			Functions.match(ops, "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<Double>() {});
+			Functions.match(ops.env(), "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {}, new Nil<Double>() {});
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(vImage1, vImage2, op, 5, es).output(value).compute();
+		ops.op("coloc.pValue").input(vImage1, vImage2, op, 5, es).output(value).compute();
 		assertEquals(0.0, value.getPValue(), 0.0);
 	}
 
@@ -246,9 +246,9 @@ public class MTKTTest extends ColocalisationTest {
 		Img<FloatType> ch2 = ColocalisationTest.produceMeanBasedNoiseImage(new FloatType(), 24, 24, mean, spread, sigma,
 				0x98765432);
 		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op =
-			Functions.match(ops, "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<Double>() {});
+			Functions.match(ops.env(), "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<Double>() {});
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, op, 10, es).output(value).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, op, 10, es).output(value).compute();
 		assertEquals(0.2, value.getPValue(), 0.0);
 	}
 
@@ -261,7 +261,7 @@ public class MTKTTest extends ColocalisationTest {
 		RandomAccessibleInterval<UnsignedByteType> cropCh2 = Views.interval(zeroCorrelationImageCh2,
 				new long[] { 0, 0, 0 }, new long[] { 20, 20, 0 });
 		BiFunction<RandomAccessibleInterval<UnsignedByteType>, RandomAccessibleInterval<UnsignedByteType>, Double> op =
-			Functions.match(ops, "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<UnsignedByteType>>() {}, new Nil<RandomAccessibleInterval<UnsignedByteType>>() {}, new Nil<Double>() {});
+			Functions.match(ops.env(), "coloc.maxTKendallTau", new Nil<RandomAccessibleInterval<UnsignedByteType>>() {}, new Nil<RandomAccessibleInterval<UnsignedByteType>>() {}, new Nil<Double>() {});
 		final int[] blockSize = new int[cropCh1.numDimensions()];
 		for (int d = 0; d < blockSize.length; d++) {
 			final long size = (long) Math.floor(Math.sqrt(cropCh1.dimension(d)));
@@ -270,7 +270,7 @@ public class MTKTTest extends ColocalisationTest {
 		RandomAccessibleInterval<UnsignedByteType> ch1 = ShuffledView.cropAtMin(cropCh1, blockSize);
 		RandomAccessibleInterval<UnsignedByteType> ch2 = ShuffledView.cropAtMin(cropCh2, blockSize);
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, op, 5, es).output(value).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, op, 5, es).output(value).compute();
 		assertEquals(0.2, value.getPValue(), 0.0);
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/pValue/DefaultPValueTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/pValue/DefaultPValueTest.java
@@ -97,13 +97,13 @@ public class DefaultPValueTest extends ColocalisationTest {
 					return r;
 				});
 
-		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> wrapped = ops
-			.wrap(op,
+		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> wrapped =
+			ops.env().opify(op,
 				new Nil<BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double>>()
 				{}.getType());
 
 		PValueResult output = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, wrapped, result.length - 1, es).output(output).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, wrapped, result.length - 1, es).output(output).compute();
 		Double actualPValue = output.getPValue();
 		Double actualColocValue = output.getColocValue();
 		double[] actualColocValuesArray = output.getColocValuesArray();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/pearsons/DefaultPearsonsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/pearsons/DefaultPearsonsTest.java
@@ -57,7 +57,7 @@ public class DefaultPearsonsTest extends ColocalisationTest {
 	 */
 	@Test
 	public void fastPearsonsZeroCorrTest(){
-		double result = op("coloc.pearsons").input(zeroCorrelationImageCh1, zeroCorrelationImageCh2).outType(Double.class).apply();
+		double result = ops.op("coloc.pearsons").input(zeroCorrelationImageCh1, zeroCorrelationImageCh2).outType(Double.class).apply();
 		assertEquals(0.0, result, 0.05);
 	}
 	
@@ -67,7 +67,7 @@ public class DefaultPearsonsTest extends ColocalisationTest {
 	 */
 	@Test
 	public void fastPearsonsPositiveCorrTest() {
-		double result = op("coloc.pearsons").input(positiveCorrelationImageCh1, positiveCorrelationImageCh2).outType(Double.class).apply();
+		double result = ops.op("coloc.pearsons").input(positiveCorrelationImageCh1, positiveCorrelationImageCh2).outType(Double.class).apply();
 		assertEquals(0.75, result, 0.01);
 	}
 	
@@ -86,7 +86,7 @@ public class DefaultPearsonsTest extends ColocalisationTest {
 					512, 512, mean, spread, sigma, 0x01234567);
 			RandomAccessibleInterval<FloatType> ch2 = produceMeanBasedNoiseImage(new FloatType(),
 					512, 512, mean, spread, sigma, 0x98765432);
-			double resultFast =  op("coloc.pearsons").input(ch1, ch2).outType(Double.class).apply();
+			double resultFast =  ops.op("coloc.pearsons").input(ch1, ch2).outType(Double.class).apply();
 			assertEquals(0.0, resultFast, 0.1);
 
 			/* If the means are the same, it causes a numerical problem in the classic implementation of Pearson's
@@ -107,9 +107,9 @@ public class DefaultPearsonsTest extends ColocalisationTest {
 		Img<FloatType> ch2 = ColocalisationTest.produceMeanBasedNoiseImage(new FloatType(), 24, 24,
 			mean, spread, sigma, 0x98765432);
 		BiFunction<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, Double> op =
-			Functions.match(ops, "coloc.pearsons", new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<Double>() {});
+			Functions.match(ops.env(), "coloc.pearsons", new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<RandomAccessibleInterval<FloatType>>() {}, new Nil<Double>() {});
 		PValueResult value = new PValueResult();
-		op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
+		ops.op("coloc.pValue").input(ch1, ch2, op, es).output(value).compute();
 		assertEquals(0.66, value.getPValue(), 0.0);
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/convert/ConvertIIsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/convert/ConvertIIsTest.java
@@ -57,14 +57,14 @@ public class ConvertIIsTest extends AbstractOpTest {
 	@BeforeEach
 	public void createImages() {
 		final FinalDimensions dims = FinalDimensions.wrap(new long[] {10, 10});
-		in = op("create.img").input(dims, new ShortType()).outType(new Nil<IterableInterval<ShortType>>() {}).apply();
+		in = ops.op("create.img").input(dims, new ShortType()).outType(new Nil<IterableInterval<ShortType>>() {}).apply();
 		addNoise(in);
-		out = op("create.img").input(dims, new ByteType()).outType(new Nil<Img<ByteType>>() {}).apply();
+		out = ops.op("create.img").input(dims, new ByteType()).outType(new Nil<Img<ByteType>>() {}).apply();
 	}
 
 	@Test
 	public void testClip() {
-		op("convert.clip").input(in).output(out).compute();
+		ops.op("convert.clip").input(in).output(out).compute();
 
 		final Cursor<ShortType> c = in.localizingCursor();
 		final RandomAccess<ByteType> ra = out.randomAccess();
@@ -77,7 +77,7 @@ public class ConvertIIsTest extends AbstractOpTest {
 
 	@Test
 	public void testCopy() {
-		op("convert.copy").input(in).output(out).compute();
+		ops.op("convert.copy").input(in).output(out).compute();
 
 		final Cursor<ShortType> c = in.localizingCursor();
 		final RandomAccess<ByteType> ra = out.randomAccess();
@@ -91,8 +91,8 @@ public class ConvertIIsTest extends AbstractOpTest {
 	// -- Helper methods --
 
 	private void addNoise(final IterableInterval<ShortType> image) {
-		IterableInterval<ShortType> copy = op("copy").input(image).outType(new Nil<IterableInterval<ShortType>>() {}).apply();
-		op("filter.addNoise").input(copy, -32768., 32767., 10000.).output(image).compute();
+		IterableInterval<ShortType> copy = ops.op("copy").input(image).outType(new Nil<IterableInterval<ShortType>>() {}).apply();
+		ops.op("filter.addNoise").input(copy, -32768., 32767., 10000.).output(image).compute();
 	}
 
 	private byte clip(final short value) {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/convert/ConvertMapTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/convert/ConvertMapTest.java
@@ -73,7 +73,7 @@ public class ConvertMapTest extends AbstractOpTest {
 				outC1.next().getRealDouble(), 0d);
 		}
 		
-		op("convert.float32").input(in).output(out).compute();
+		ops.op("convert.float32").input(in).output(out).compute();
 
 //		ops.run(Ops.Map.class, out, in, new ComplexToFloat32<UnsignedByteType>());
 
@@ -96,7 +96,7 @@ public class ConvertMapTest extends AbstractOpTest {
 		final byte[] outArray = { 4, 123, 18, 64, 90, 120, 12, 17, 73 };
 		final Img<UnsignedByteType> out = generateUnsignedByteImg(outArray);
 
-		op("convert.uint8").input(in).output(out).compute();
+		ops.op("convert.uint8").input(in).output(out).compute();
 //		ops.run(Ops.Map.class, out, in, new ComplexToUint8<FloatType>());
 
 		final Cursor<FloatType> inC = in.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyArrayImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyArrayImgTest.java
@@ -69,8 +69,9 @@ public class CopyArrayImgTest extends AbstractOpTest {
 	@Test
 	public void copyArrayImgNoOutputTest() {
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<UnsignedByteType> output = (RandomAccessibleInterval<UnsignedByteType>) new OpBuilder(
-				ops, "copy.img").input(input).apply();
+		final RandomAccessibleInterval<UnsignedByteType> output =
+			(RandomAccessibleInterval<UnsignedByteType>) ops.op("copy.img").input(
+				input).apply();
 
 		final Cursor<UnsignedByteType> inc = input.localizingCursor();
 		final RandomAccess<UnsignedByteType> outRA = output.randomAccess();
@@ -86,7 +87,7 @@ public class CopyArrayImgTest extends AbstractOpTest {
 	public void copyArrayImgWithOutputTest() {
 		final Img<UnsignedByteType> output = input.factory().create(input, input.firstElement());
 
-		op("copy.img").input(input).output(output).compute();
+		ops.op("copy.img").input(input).output(output).compute();
 
 		final Cursor<UnsignedByteType> inc = input.cursor();
 		final Cursor<UnsignedByteType> outc = output.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyIITest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyIITest.java
@@ -69,7 +69,7 @@ public class CopyIITest extends AbstractOpTest {
 
 	@Test
 	public void copyRAINoOutputTest() {
-		IterableInterval<DoubleType> output = op("copy.iterableInterval").input(input)
+		IterableInterval<DoubleType> output = ops.op("copy.iterableInterval").input(input)
 				.outType(new Nil<IterableInterval<DoubleType>>() {}).apply();
 
 		Cursor<DoubleType> inc = input.localizingCursor();
@@ -86,7 +86,7 @@ public class CopyIITest extends AbstractOpTest {
 	public void copyTypeTest() {
 		Img<FloatType> inputFloat = new ArrayImgFactory<>(new FloatType()).create(new int[] { 120, 100 });
 
-		Img<FloatType> output = op("copy.iterableInterval").input(inputFloat)
+		Img<FloatType> output = ops.op("copy.iterableInterval").input(inputFloat)
 				.outType(new Nil<Img<FloatType>>() {}).apply();
 
 		assertTrue(output.firstElement() instanceof FloatType,
@@ -97,7 +97,7 @@ public class CopyIITest extends AbstractOpTest {
 	public void copyRAIWithOutputTest() {
 		Img<DoubleType> output = input.factory().create(input, input.firstElement());
 
-		op("copy.iterableInterval").input(input).output(output).compute();
+		ops.op("copy.iterableInterval").input(input).output(output).compute();
 
 		final Cursor<DoubleType> inc = input.cursor();
 		final Cursor<DoubleType> outc = output.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyImgLabelingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyImgLabelingTest.java
@@ -54,9 +54,9 @@ public class CopyImgLabelingTest extends AbstractOpTest {
 
 	@BeforeEach
 	public void createData() {
-		input = op("create.imgLabeling").input(new FinalDimensions(10, 10), new IntType())
+		input = ops.op("create.imgLabeling").input(new FinalDimensions(10, 10), new IntType())
 				.outType(new Nil<ImgLabeling<String, IntType>>() {}).apply();
-		copy = op("create.imgLabeling").input(new FinalDimensions(10, 10), new IntType())
+		copy = ops.op("create.imgLabeling").input(new FinalDimensions(10, 10), new IntType())
 				.outType(new Nil<ImgLabeling<String, IntType>>() {}).apply();
 
 		final Cursor<LabelingType<String>> inc = input.cursor();
@@ -74,7 +74,7 @@ public class CopyImgLabelingTest extends AbstractOpTest {
 
 	@Test
 	public void copyImgLabeling() {
-		op("copy.imgLabeling").input(input).output(copy).compute();
+		ops.op("copy.imgLabeling").input(input).output(copy).compute();
 		assertNotNull(copy);
 
 		Cursor<LabelingType<String>> inCursor = input.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyImgTest.java
@@ -73,7 +73,7 @@ public class CopyImgTest extends AbstractOpTest {
 		copy(input, inputCopy);
 
 		final RandomAccessibleInterval<DoubleType> output =
-			op("copy.img").input(input).outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
+			ops.op("copy.img").input(input).outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 
 		final Cursor<DoubleType> inc = input.localizingCursor();
 		final RandomAccess<DoubleType> inCopyRA = inputCopy.randomAccess();
@@ -97,7 +97,7 @@ public class CopyImgTest extends AbstractOpTest {
 		final Img<DoubleType> output = input.factory().create(input, input
 			.firstElement());
 
-		op("copy.img").input(input).output(output).compute();
+		ops.op("copy.img").input(input).output(output).compute();
 
 		final Cursor<DoubleType> inc = input.cursor();
 		final Cursor<DoubleType> inCopyc = inputCopy.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyLabelingMappingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyLabelingMappingTest.java
@@ -56,7 +56,7 @@ public class CopyLabelingMappingTest extends AbstractOpTest {
 
 	@BeforeEach
 	public void createData() {
-		final ImgLabeling<String, IntType> imgL = op("create.imgLabeling")
+		final ImgLabeling<String, IntType> imgL = ops.op("create.imgLabeling")
 				.input(new FinalDimensions(10, 10), new IntType()) //
 				.outType(new Nil<ImgLabeling<String, IntType>>() {}) //
 				.apply();
@@ -78,7 +78,7 @@ public class CopyLabelingMappingTest extends AbstractOpTest {
 	@Test
 	public void copyLabelingWithoutOutputTest() {
 
-		LabelingMapping<String> out = op("copy.labelingMapping").input(input)
+		LabelingMapping<String> out = ops.op("copy.labelingMapping").input(input)
 				.outType(new Nil<LabelingMapping<String>>() {}).apply();
 
 		Iterator<String> outIt = out.getLabels().iterator();
@@ -91,9 +91,9 @@ public class CopyLabelingMappingTest extends AbstractOpTest {
 	@Test
 	public void copyLabelingWithOutputTest() {
 
-		LabelingMapping<String> out = op("create.labelingMapping").input().outType(new Nil<LabelingMapping<String>>() {}).create();
+		LabelingMapping<String> out = ops.op("create.labelingMapping").input().outType(new Nil<LabelingMapping<String>>() {}).create();
 
-		op("copy.labelingMapping").input(input).output(out).compute();
+		ops.op("copy.labelingMapping").input(input).output(out).compute();
 
 		Iterator<String> outIt = out.getLabels().iterator();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyRAITest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyRAITest.java
@@ -87,11 +87,11 @@ public class CopyRAITest extends AbstractOpTest {
 		final long[] start = new long[] { 16, 16, 16 };
 		final long[] end = new long[] { 47, 47, 47 };
 
-		input2 = op("create.img").input(new FinalDimensions(size1), new UnsignedByteType())
+		input2 = ops.op("create.img").input(new FinalDimensions(size1), new UnsignedByteType())
 				.outType(new Nil<Img<UnsignedByteType>>() {}).apply();
 
 		// create the same input but force it to be a planar image
-		inputPlanar = op("create.img")
+		inputPlanar = ops.op("create.img")
 				.input(new FinalDimensions(size1), new UnsignedByteType(),
 						new PlanarImgFactory<>(new UnsignedByteType()))
 				.outType(new Nil<Img<UnsignedByteType>>() {}).apply();
@@ -116,7 +116,7 @@ public class CopyRAITest extends AbstractOpTest {
 	@Test
 	public void copyRAINoOutputTest() {
 		@SuppressWarnings("unchecked")
-		final RandomAccessibleInterval<UnsignedByteType> output = op("copy.rai")
+		final RandomAccessibleInterval<UnsignedByteType> output = ops.op("copy.rai")
 			.input(input).outType(
 				new Nil<RandomAccessibleInterval<UnsignedByteType>>()
 				{}).apply();
@@ -135,7 +135,7 @@ public class CopyRAITest extends AbstractOpTest {
 	public void copyRAIWithOutputTest() {
 		final Img<UnsignedByteType> output = input.factory().create(input, input.firstElement());
 
-		op("copy.rai").input(input).output(output).compute();
+		ops.op("copy.rai").input(input).output(output).compute();
 
 		final Cursor<UnsignedByteType> inc = input.cursor();
 		final Cursor<UnsignedByteType> outc = output.cursor();
@@ -150,29 +150,29 @@ public class CopyRAITest extends AbstractOpTest {
 
 		// create a copy op
 		final Computers.Arity1<IntervalView<UnsignedByteType>, RandomAccessibleInterval<UnsignedByteType>> copy = Computers
-				.match(ops, "copy.rai", new Nil<IntervalView<UnsignedByteType>>() {},
+				.match(ops.env(), "copy.rai", new Nil<IntervalView<UnsignedByteType>>() {},
 						new Nil<RandomAccessibleInterval<UnsignedByteType>>() {});
 
 		assertNotNull(copy);
 
-		final Img<UnsignedByteType> out = op("create.img").input(new FinalDimensions(size2), new UnsignedByteType()) //
+		final Img<UnsignedByteType> out = ops.op("create.img").input(new FinalDimensions(size2), new UnsignedByteType()) //
 				.outType(new Nil<Img<UnsignedByteType>>() {}) //
 				.apply();
 
 		// copy view to output and assert that is equal to the mean of the view
 		copy.compute(view, out);
 		DoubleType sum = new DoubleType();
-		op("stats.mean").input(out).output(sum).compute();
+		ops.op("stats.mean").input(out).output(sum).compute();
 		assertEquals(sum.getRealDouble(), 100.0, delta);
 
 		// also try with a planar image
-		final Img<UnsignedByteType> outFromPlanar = op("create.img")
+		final Img<UnsignedByteType> outFromPlanar = ops.op("create.img")
 				.input(new FinalDimensions(size2), new UnsignedByteType()).outType(new Nil<Img<UnsignedByteType>>() {})
 				.apply();
 
 		copy.compute(viewPlanar, outFromPlanar);
 		DoubleType sumFromPlanar = new DoubleType();
-		op("stats.mean").input(outFromPlanar).output(sumFromPlanar).compute();
+		ops.op("stats.mean").input(outFromPlanar).output(sumFromPlanar).compute();
 		assertEquals(sumFromPlanar.getRealDouble(), 100.0, delta);
 
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyTypeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/copy/CopyTypeTest.java
@@ -53,7 +53,7 @@ public class CopyTypeTest extends AbstractOpTest {
 
 	@Test
 	public void copyTypeNoOutputTest() {
-		DoubleType out = op("copy.type").input(dt).outType(DoubleType.class).apply();
+		DoubleType out = ops.op("copy.type").input(dt).outType(DoubleType.class).apply();
 
 		assertEquals(dt.get(), out.get(), 0.0);
 	}
@@ -61,7 +61,7 @@ public class CopyTypeTest extends AbstractOpTest {
 	@Test
 	public void copyTypeWithOutputTest() {
 		DoubleType out = new DoubleType();
-		op("copy.type").input(out).output(dt).compute();
+		ops.op("copy.type").input(out).output(dt).compute();
 
 		assertEquals(dt.get(), out.get(), 0.0);
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateImgPlusTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateImgPlusTest.java
@@ -56,8 +56,8 @@ public class CreateImgPlusTest extends AbstractOpTest {
 
 	@Test
 	public void createImgPlusTest() {
-		BiFunction<Dimensions, DoubleType, Img<DoubleType>> createImgFunc = Functions.match(ops, "create.img", new Nil<Dimensions>() {}, new Nil<DoubleType>() {}, new Nil<Img<DoubleType>>() {});
-		Function<Img<DoubleType>, ImgPlus<DoubleType>> imgPlusFunction = Functions.match(ops, "create.imgPlus", new Nil<Img<DoubleType>>() {}, new Nil<ImgPlus<DoubleType>>() {});
+		BiFunction<Dimensions, DoubleType, Img<DoubleType>> createImgFunc = Functions.match(ops.env(), "create.img", new Nil<Dimensions>() {}, new Nil<DoubleType>() {}, new Nil<Img<DoubleType>>() {});
+		Function<Img<DoubleType>, ImgPlus<DoubleType>> imgPlusFunction = Functions.match(ops.env(), "create.imgPlus", new Nil<Img<DoubleType>>() {}, new Nil<ImgPlus<DoubleType>>() {});
 		assertEquals(imgPlusFunction.apply(createImgFunc.apply(new FinalDimensions(new long[] { 10, 9, 8 }), new DoubleType())).getClass(), ImgPlus.class);
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateImgTest.java
@@ -93,7 +93,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 			}
 
 			// create img
-			final Function<Interval, Img<?>> createFunc = Functions.match(ops, "create.img", new Nil<Interval>() {
+			final Function<Interval, Img<?>> createFunc = Functions.match(ops.env(), "create.img", new Nil<Interval>() {
 			}, new Nil<Img<?>>() {
 			});
 			final Img<?> img = createFunc.apply(new FinalInterval(min, max));
@@ -119,7 +119,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 			}
 
 			// create img
-			BiFunction<Dimensions, DoubleType, Img<DoubleType>> createFunc = Functions.match(ops, "create.img",
+			BiFunction<Dimensions, DoubleType, Img<DoubleType>> createFunc = Functions.match(ops.env(), "create.img",
 					new Nil<Dimensions>() {
 					}, new Nil<DoubleType>() {
 					}, new Nil<Img<DoubleType>>() {
@@ -134,13 +134,13 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	@Test
 	public void testImgFromImg() {
 		// create img
-		BiFunction<Dimensions, ByteType, Img<ByteType>> createFuncDimsType = Functions.match(ops, "create.img",
+		BiFunction<Dimensions, ByteType, Img<ByteType>> createFuncDimsType = Functions.match(ops.env(), "create.img",
 				new Nil<Dimensions>() {
 				}, new Nil<ByteType>() {
 				}, new Nil<Img<ByteType>>() {
 				});
 		final Img<ByteType> img = createFuncDimsType.apply(new FinalDimensions(1), new ByteType());
-		Function<Img<ByteType>, Img<ByteType>> createFuncImg = Functions.match(ops, "create.img",
+		Function<Img<ByteType>, Img<ByteType>> createFuncImg = Functions.match(ops.env(), "create.img",
 				new Nil<Img<ByteType>>() {
 				}, new Nil<Img<ByteType>>() {
 				});
@@ -155,12 +155,11 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	public void testImageFactory() {
 		final Dimensions dim = new FinalDimensions(10, 10, 10);
 
-		Functions.Arity3<Dimensions, DoubleType, ImgFactory<DoubleType>, Img<DoubleType>> createFunc = Functions.match(ops,
-				"create.img", new Nil<Dimensions>() {
-				}, new Nil<DoubleType>() {
-				}, new Nil<ImgFactory<DoubleType>>() {
-				}, new Nil<Img<DoubleType>>() {
-				});
+		Functions.Arity3<Dimensions, DoubleType, ImgFactory<DoubleType>, Img<DoubleType>> createFunc =
+			Functions.match(ops.env(), "create.img", new Nil<Dimensions>()
+			{}, new Nil<DoubleType>() {}, new Nil<ImgFactory<DoubleType>>() {},
+				new Nil<Img<DoubleType>>()
+				{});
 
 		@SuppressWarnings("unchecked")
 		final Img<DoubleType> arrayImg = createFunc.apply(dim, new DoubleType(), new ArrayImgFactory<>(new DoubleType()));
@@ -178,7 +177,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	public void testImageType() {
 		final Dimensions dim = new FinalDimensions(10, 10, 10);
 		
-		BiFunction<Dimensions, T, Img<T>> createFunc = Functions.match(ops, "create.img", new Nil<Dimensions>() {}, new Nil<T>() {}, new Nil<Img<T>>() {});
+		BiFunction<Dimensions, T, Img<T>> createFunc = Functions.match(ops.env(), "create.img", new Nil<Dimensions>() {}, new Nil<T>() {}, new Nil<Img<T>>() {});
 
 		assertEquals(BitType.class, ((Img<?>) createFunc.apply(dim,
 			(T) new BitType())).firstElement().getClass(), "Image Type: ");
@@ -202,7 +201,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	@Test
 	public void testCreateFromImgSameType() {
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		BiFunction<Dimensions, ByteType, Img<ByteType>> createFunc = Functions.match(ops, "create.img",
+		BiFunction<Dimensions, ByteType, Img<ByteType>> createFunc = Functions.match(ops.env(), "create.img",
 				new Nil<Dimensions>() {
 				}, new Nil<ByteType>() {
 				}, new Nil<Img<ByteType>>() {
@@ -218,7 +217,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	@Test
 	public void testCreateFromImgDifferentType() {
 		final Img<ByteType> input = PlanarImgs.bytes(10, 10, 10);
-		BiFunction<Dimensions, ShortType, Img<ShortType>> createFunc = Functions.match(ops, "create.img",
+		BiFunction<Dimensions, ShortType, Img<ShortType>> createFunc = Functions.match(ops.env(), "create.img",
 				new Nil<Dimensions>() {
 				}, new Nil<ShortType>() {
 				}, new Nil<Img<ShortType>>() {
@@ -236,7 +235,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 		final IntervalView<ByteType> input = Views.interval(PlanarImgs.bytes(10, 10, 10),
 				new FinalInterval(new long[] { 10, 10, 1 }));
 
-		BiFunction<Dimensions, ShortType, Img<ShortType>> createFunc = Functions.match(ops, "create.img",
+		BiFunction<Dimensions, ShortType, Img<ShortType>> createFunc = Functions.match(ops.env(), "create.img",
 				new Nil<Dimensions>() {
 				}, new Nil<ShortType>() {
 				}, new Nil<Img<ShortType>>() {
@@ -260,7 +259,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	public void testCreateFromIntegerArray() {
 		final Integer[] dims = new Integer[] { 25, 25, 10 };
 
-		Function<Integer[], Img<?>> createFunc = Functions.match(ops, "create.img", new Nil<Integer[]>() {
+		Function<Integer[], Img<?>> createFunc = Functions.match(ops.env(), "create.img", new Nil<Integer[]>() {
 		}, new Nil<Img<?>>() {
 		});
 		final Img<?> res = createFunc.apply(dims);
@@ -278,7 +277,7 @@ public class CreateImgTest<T extends RealType<T>> extends AbstractOpTest {
 	public void testCreateFromLongArray() {
 		final Long[] dims = new Long[] { 25l, 25l, 10l };
 
-		Function<Long[], Img<?>> createFunc = Functions.match(ops, "create.img", new Nil<Long[]>() {
+		Function<Long[], Img<?>> createFunc = Functions.match(ops.env(), "create.img", new Nil<Long[]>() {
 		}, new Nil<Img<?>>() {
 		});
 		final Img<?> res = createFunc.apply(dims);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernel2ndDerivBiGaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernel2ndDerivBiGaussTest.java
@@ -54,7 +54,7 @@ public class CreateKernel2ndDerivBiGaussTest extends AbstractOpTest {
 		final double[] sigmas = { sigma, 0.5 * sigma };
 
 		// test the main convenience function:
-		RandomAccessibleInterval<DoubleType> kernelD = op("create.kernel2ndDerivBiGauss")
+		RandomAccessibleInterval<DoubleType> kernelD = ops.op("create.kernel2ndDerivBiGauss")
 				.input(sigmas, 2, new DoubleType()).outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 
 		// sizes are okay?
@@ -88,21 +88,21 @@ public class CreateKernel2ndDerivBiGaussTest extends AbstractOpTest {
 		int wasCaught = 0;
 		try {
 			final double[] shortSigmas = { 2.0 * sigma };
-			kernelD = op("create.kernel2ndDerivBiGauss").input(shortSigmas, 2, new DoubleType())
+			kernelD = ops.op("create.kernel2ndDerivBiGauss").input(shortSigmas, 2, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
 		}
 		try {
 			final double[] negativeSigmas = { -1.0, 0.0 };
-			kernelD = op("create.kernel2ndDerivBiGauss").input(negativeSigmas, 2, new DoubleType())
+			kernelD = ops.op("create.kernel2ndDerivBiGauss").input(negativeSigmas, 2, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
 		}
 		try {
 			// wrong dimensionality
-			kernelD = op("create.kernel2ndDerivBiGauss").input(sigmas, 0, new DoubleType())
+			kernelD = ops.op("create.kernel2ndDerivBiGauss").input(sigmas, 0, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
@@ -111,7 +111,7 @@ public class CreateKernel2ndDerivBiGaussTest extends AbstractOpTest {
 
 		// does the general kernel calculation work?
 		// (should be pure real kernel)
-		RandomAccessibleInterval<ComplexDoubleType> kernelCD = op("create.kernel2ndDerivBiGauss")
+		RandomAccessibleInterval<ComplexDoubleType> kernelCD = ops.op("create.kernel2ndDerivBiGauss")
 				.input(sigmas, 2, new ComplexDoubleType())
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 		RandomAccess<ComplexDoubleType> samplerCD = kernelCD.randomAccess();
@@ -120,7 +120,7 @@ public class CreateKernel2ndDerivBiGaussTest extends AbstractOpTest {
 
 		// general plugin system works?
 		// @SuppressWarnings("unchecked")
-		kernelCD = op("create.kernel2ndDerivBiGauss").input(sigmas, 3, new ComplexDoubleType())
+		kernelCD = ops.op("create.kernel2ndDerivBiGauss").input(sigmas, 3, new ComplexDoubleType())
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelBiGaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelBiGaussTest.java
@@ -54,7 +54,7 @@ public class CreateKernelBiGaussTest extends AbstractOpTest {
 		final double[] sigmas = { sigma, 0.5 * sigma };
 
 		// test the main convenience function:
-		RandomAccessibleInterval<DoubleType> kernelD = op("create.kernelBiGauss")
+		RandomAccessibleInterval<DoubleType> kernelD = ops.op("create.kernelBiGauss")
 				.input(sigmas, 2, new DoubleType()).outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 
 		// sizes are okay?
@@ -88,21 +88,21 @@ public class CreateKernelBiGaussTest extends AbstractOpTest {
 		int wasCaught = 0;
 		try {
 			final double[] shortSigmas = { 2.0 * sigma };
-			kernelD = op("create.kernelBiGauss").input(shortSigmas, 2, new DoubleType())
+			kernelD = ops.op("create.kernelBiGauss").input(shortSigmas, 2, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
 		}
 		try {
 			final double[] negativeSigmas = { -1.0, 0.0 };
-			kernelD = op("create.kernelBiGauss").input(negativeSigmas, 2, new DoubleType())
+			kernelD = ops.op("create.kernelBiGauss").input(negativeSigmas, 2, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
 		}
 		try {
 			// wrong dimensionality
-			kernelD = op("create.kernelBiGauss").input(sigmas, 0, new DoubleType())
+			kernelD = ops.op("create.kernelBiGauss").input(sigmas, 0, new DoubleType())
 					.outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 		} catch (IllegalArgumentException e) {
 			++wasCaught;
@@ -111,7 +111,7 @@ public class CreateKernelBiGaussTest extends AbstractOpTest {
 
 		// does the general kernel calculation work?
 		// (should be pure real kernel)
-		RandomAccessibleInterval<ComplexDoubleType> kernelCD = op("create.kernelBiGauss")
+		RandomAccessibleInterval<ComplexDoubleType> kernelCD = ops.op("create.kernelBiGauss")
 				.input(sigmas, 2, new ComplexDoubleType())
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 		RandomAccess<ComplexDoubleType> samplerCD = kernelCD.randomAccess();
@@ -120,7 +120,7 @@ public class CreateKernelBiGaussTest extends AbstractOpTest {
 
 		// general plugin system works?
 		// @SuppressWarnings("unchecked")
-		kernelCD = op("create.kernelBiGauss").input(sigmas, 3, new ComplexDoubleType())
+		kernelCD = ops.op("create.kernelBiGauss").input(sigmas, 3, new ComplexDoubleType())
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelDiffractionTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelDiffractionTest.java
@@ -64,7 +64,7 @@ public class CreateKernelDiffractionTest extends AbstractOpTest {
 		final DoubleType type = new DoubleType(); // pixel type of created kernel
 
 		Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>> createFunc = ops
-				.findOp("create.kernelDiffraction",
+				.op("create.kernelDiffraction",
 						new Nil<Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>>>() {
 						}, new Nil[] { new Nil<Dimensions>() {
 						}, new Nil<Double>() {
@@ -147,7 +147,7 @@ public class CreateKernelDiffractionTest extends AbstractOpTest {
 		final DoubleType type = new DoubleType(); // pixel type of created kernel
 		
 		Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>> createFunc = ops
-				.findOp("create.kernelDiffraction",
+				.op("create.kernelDiffraction",
 						new Nil<Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>>>() {
 						}, new Nil[] { new Nil<Dimensions>() {
 						}, new Nil<Double>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelDiffractionTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelDiffractionTest.java
@@ -64,7 +64,7 @@ public class CreateKernelDiffractionTest extends AbstractOpTest {
 		final DoubleType type = new DoubleType(); // pixel type of created kernel
 
 		Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>> createFunc = ops
-				.op("create.kernelDiffraction",
+				.env().op("create.kernelDiffraction",
 						new Nil<Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>>>() {
 						}, new Nil[] { new Nil<Dimensions>() {
 						}, new Nil<Double>() {
@@ -147,7 +147,7 @@ public class CreateKernelDiffractionTest extends AbstractOpTest {
 		final DoubleType type = new DoubleType(); // pixel type of created kernel
 		
 		Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>> createFunc = ops
-				.op("create.kernelDiffraction",
+				.env().op("create.kernelDiffraction",
 						new Nil<Functions.Arity9<Dimensions, Double, Double, Double, Double, Double, Double, Double, DoubleType, Img<DoubleType>>>() {
 						}, new Nil[] { new Nil<Dimensions>() {
 						}, new Nil<Double>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelGaborTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelGaborTest.java
@@ -60,28 +60,28 @@ public class CreateKernelGaborTest extends AbstractOpTest {
 		final double[] period = { 4.0, 1.0 };
 
 		// define functions used in the test
-		Functions.Arity3<double[], double[], C, RandomAccessibleInterval<C>> createFunc = Functions.match(ops,
+		Functions.Arity3<double[], double[], C, RandomAccessibleInterval<C>> createFunc = Functions.match(ops.env(),
 				"create.kernelGabor", new Nil<double[]>() {
 				}, new Nil<double[]>() {
 				}, new Nil<C>() {
 				}, new Nil<RandomAccessibleInterval<C>>() {
 				});
 		BiFunction<Double, double[], RandomAccessibleInterval<DoubleType>> createFuncSingleSigma = Functions
-				.match(ops, "create.kernelGabor", new Nil<Double>() {
+				.match(ops.env(), "create.kernelGabor", new Nil<Double>() {
 				}, new Nil<double[]>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});
-		BiFunction<double[], double[], RandomAccessibleInterval<DoubleType>> createFuncDouble = Functions.match(ops,
+		BiFunction<double[], double[], RandomAccessibleInterval<DoubleType>> createFuncDouble = Functions.match(ops.env(),
 				"create.kernelGabor", new Nil<double[]>() {
 				}, new Nil<double[]>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});
-		BiFunction<double[], double[], RandomAccessibleInterval<FloatType>> createFuncFloat = Functions.match(ops,
+		BiFunction<double[], double[], RandomAccessibleInterval<FloatType>> createFuncFloat = Functions.match(ops.env(),
 				"create.kernelGabor", new Nil<double[]>() {
 				}, new Nil<double[]>() {
 				}, new Nil<RandomAccessibleInterval<FloatType>>() {
 				});
-		BiFunction<double[], double[], RandomAccessibleInterval<ComplexDoubleType>> createFuncComplexDouble = Functions.match(ops,
+		BiFunction<double[], double[], RandomAccessibleInterval<ComplexDoubleType>> createFuncComplexDouble = Functions.match(ops.env(),
 				"create.kernelGabor", new Nil<double[]>() {
 				}, new Nil<double[]>() {
 				}, new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelGaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelGaussTest.java
@@ -56,12 +56,12 @@ public class CreateKernelGaussTest extends AbstractOpTest {
 		final double sigma = 5.0;
 		final double[] sigmas = {sigma, sigma};
 		
-		BiFunction<Double, Integer, RandomAccessibleInterval<DoubleType>> createFunc = Functions.match(ops, "create.kernelGauss", new Nil<Double>() {}, new Nil<Integer>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {});
+		BiFunction<Double, Integer, RandomAccessibleInterval<DoubleType>> createFunc = Functions.match(ops.env(), "create.kernelGauss", new Nil<Double>() {}, new Nil<Integer>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {});
 
 		final RandomAccessibleInterval<DoubleType> gaussianKernel = //
 			createFunc.apply(sigma, sigmas.length);
 
-		Function<double[], RandomAccessibleInterval<DoubleType>> createFunc2 = Functions.match(ops, "create.kernelGauss", new Nil<double[]>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {});
+		Function<double[], RandomAccessibleInterval<DoubleType>> createFunc2 = Functions.match(ops.env(), "create.kernelGauss", new Nil<double[]>() {}, new Nil<RandomAccessibleInterval<DoubleType>>() {});
 				
 		
 		final RandomAccessibleInterval<DoubleType> gaussianKernel2 = //

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelLogTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateKernelLogTest.java
@@ -56,7 +56,7 @@ public class CreateKernelLogTest extends AbstractOpTest {
 		final double sigma = 5.0;
 		final double[] sigmas = { sigma, sigma };
 
-		BiFunction<Double, Integer, RandomAccessibleInterval<DoubleType>> func1 = Functions.match(ops,
+		BiFunction<Double, Integer, RandomAccessibleInterval<DoubleType>> func1 = Functions.match(ops.env(),
 				"create.kernelLog", new Nil<Double>() {
 				}, new Nil<Integer>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
@@ -65,7 +65,7 @@ public class CreateKernelLogTest extends AbstractOpTest {
 		final RandomAccessibleInterval<DoubleType> logKernel = //
 				func1.apply(sigma, sigmas.length);
 
-		Function<double[], RandomAccessibleInterval<DoubleType>> func2 = Functions.match(ops, "create.kernelLog",
+		Function<double[], RandomAccessibleInterval<DoubleType>> func2 = Functions.match(ops.env(), "create.kernelLog",
 				new Nil<double[]>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateLabelingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateLabelingTest.java
@@ -69,7 +69,7 @@ public class CreateLabelingTest extends AbstractOpTest {
 		final MersenneTwisterFast randomGenerator = new MersenneTwisterFast(SEED);
 
 		// TODO can we keep this?
-		BiFunction<Dimensions, IntType, ImgLabeling<String, IntType>> createFunc = Functions.match(ops,
+		BiFunction<Dimensions, IntType, ImgLabeling<String, IntType>> createFunc = Functions.match(ops.env(),
 				"create.imgLabeling", new Nil<Dimensions>() {
 				}, new Nil<IntType>() {
 				}, new Nil<ImgLabeling<String, IntType>>() {
@@ -100,7 +100,7 @@ public class CreateLabelingTest extends AbstractOpTest {
 		final Dimensions dim = new FinalDimensions(10, 10, 10);
 
 		Functions.Arity3<Dimensions, IntType, ImgFactory<IntType>, ImgLabeling<String, IntType>> createFunc = Functions
-				.match(ops, "create.imgLabeling", new Nil<Dimensions>() {
+				.match(ops.env(), "create.imgLabeling", new Nil<Dimensions>() {
 				}, new Nil<IntType>() {
 				}, new Nil<ImgFactory<IntType>>() {
 				}, new Nil<ImgLabeling<String, IntType>>() {
@@ -135,7 +135,7 @@ public class CreateLabelingTest extends AbstractOpTest {
 	@SuppressWarnings("unchecked")
 	private <I> ImgLabeling<I, ?> createLabelingWithType(final I type) {
 
-		BiFunction<Dimensions, IntType, ImgLabeling<I, IntType>> createFunc = Functions.match(ops,
+		BiFunction<Dimensions, IntType, ImgLabeling<I, IntType>> createFunc = Functions.match(ops.env(),
 				"create.imgLabeling", new Nil<Dimensions>() {
 				}, new Nil<IntType>() {
 				}, new Nil<ImgLabeling<I, IntType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateNativeTypeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateNativeTypeTest.java
@@ -54,11 +54,11 @@ public class CreateNativeTypeTest extends AbstractOpTest {
 	@Test
 	public <T extends NativeType<T>> void testCreateNativeType() {
 
-		Producer<NativeType> typeSource = ops.op("create.nativeType", new Nil<Producer<NativeType>>() {
+		Producer<NativeType> typeSource = ops.env().op("create.nativeType", new Nil<Producer<NativeType>>() {
 		}, new Nil[] {}, new Nil<NativeType>() {
 		});
 
-		Function<Class<T>, T> typeFunc = ops.op("create.nativeType", new Nil<Function<Class<T>, T>>() {
+		Function<Class<T>, T> typeFunc = ops.env().op("create.nativeType", new Nil<Function<Class<T>, T>>() {
 		}, new Nil[] { new Nil<Class<T>>() {
 		} }, new Nil<T>() {
 		});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateNativeTypeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/create/CreateNativeTypeTest.java
@@ -54,11 +54,11 @@ public class CreateNativeTypeTest extends AbstractOpTest {
 	@Test
 	public <T extends NativeType<T>> void testCreateNativeType() {
 
-		Producer<NativeType> typeSource = ops.findOp("create.nativeType", new Nil<Producer<NativeType>>() {
+		Producer<NativeType> typeSource = ops.op("create.nativeType", new Nil<Producer<NativeType>>() {
 		}, new Nil[] {}, new Nil<NativeType>() {
 		});
 
-		Function<Class<T>, T> typeFunc = ops.findOp("create.nativeType", new Nil<Function<Class<T>, T>>() {
+		Function<Class<T>, T> typeFunc = ops.op("create.nativeType", new Nil<Function<Class<T>, T>>() {
 		}, new Nil[] { new Nil<Class<T>>() {
 		} }, new Nil<T>() {
 		});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/deconvolve/DeconvolveTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/deconvolve/DeconvolveTest.java
@@ -88,7 +88,7 @@ public class DeconvolveTest extends AbstractOpTest {
 				long[], OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, //
 				OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, FloatType, //
 				ComplexFloatType, Integer, Boolean, Boolean, ExecutorService, //
-				RandomAccessibleInterval<FloatType>> deconvolveOp = ops.findOp("deconvolve.richardsonLucy",
+				RandomAccessibleInterval<FloatType>> deconvolveOp = ops.op("deconvolve.richardsonLucy",
 						new Nil<Functions.Arity11<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, //
 								long[], OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, //
 								OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, FloatType, //

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/deconvolve/DeconvolveTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/deconvolve/DeconvolveTest.java
@@ -75,12 +75,12 @@ public class DeconvolveTest extends AbstractOpTest {
 
 		incropped = Views.zeroMin(incropped);
 
-		RandomAccessibleInterval<FloatType> kernel = op("create.kernelGauss")
+		RandomAccessibleInterval<FloatType> kernel = ops.op("create.kernelGauss")
 				.input(new double[] { 4.0, 4.0 }, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		// convolve FFTF
-		final RandomAccessibleInterval<FloatType> convolved = op("filter.convolve").input(//
+		final RandomAccessibleInterval<FloatType> convolved = ops.op("filter.convolve").input(//
 				incropped, kernel, es).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		// find a RichardsonLucyF op
@@ -88,7 +88,7 @@ public class DeconvolveTest extends AbstractOpTest {
 				long[], OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, //
 				OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, FloatType, //
 				ComplexFloatType, Integer, Boolean, Boolean, ExecutorService, //
-				RandomAccessibleInterval<FloatType>> deconvolveOp = ops.op("deconvolve.richardsonLucy",
+				RandomAccessibleInterval<FloatType>> deconvolveOp = ops.env().op("deconvolve.richardsonLucy",
 						new Nil<Functions.Arity11<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>, //
 								long[], OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, //
 								OutOfBoundsFactory<FloatType, RandomAccessibleInterval<FloatType>>, FloatType, //

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/eval/EvalTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/eval/EvalTest.java
@@ -57,7 +57,7 @@ public class EvalTest extends AbstractOpTest {
 		final OpService opService = context.getService(OpService.class);
 
 		// TODO: can we use ops.run here?
-		Functions.Arity3<String, Map<String, Object>, OpService, Object> evaluator = ops.op("eval",
+		Functions.Arity3<String, Map<String, Object>, OpService, Object> evaluator = ops.env().op("eval",
 				new Nil<Functions.Arity3<String, Map<String, Object>, OpService, Object>>() {},
 				new Nil[] { new Nil<String>() {}, new Nil<Map<String, Object>>() {}, new Nil<OpService>() {} },
 				new Nil<Object>() {});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/eval/EvalTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/eval/EvalTest.java
@@ -57,7 +57,7 @@ public class EvalTest extends AbstractOpTest {
 		final OpService opService = context.getService(OpService.class);
 
 		// TODO: can we use ops.run here?
-		Functions.Arity3<String, Map<String, Object>, OpService, Object> evaluator = ops.findOp("eval",
+		Functions.Arity3<String, Map<String, Object>, OpService, Object> evaluator = ops.op("eval",
 				new Nil<Functions.Arity3<String, Map<String, Object>, OpService, Object>>() {},
 				new Nil[] { new Nil<String>() {}, new Nil<Map<String, Object>>() {}, new Nil<OpService>() {} },
 				new Nil<Object>() {});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/haralick/HaralickFeatureTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/haralick/HaralickFeatureTest.java
@@ -65,111 +65,111 @@ public class HaralickFeatureTest extends AbstractOpTest {
 
 	@Test
 	public void asm() {
-		DoubleType asm = (DoubleType) op("features.haralick.asm").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType asm = (DoubleType) ops.op("features.haralick.asm").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(0.002728531855956, asm.get(), EPSILON);
 	}
 
 	@Test
 	public void clusterPromenence() {
-		DoubleType clusterPromenence = (DoubleType) op("features.haralick.clusterPromenence").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType clusterPromenence = (DoubleType) ops.op("features.haralick.clusterPromenence").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(1.913756322645621e+07,
 				clusterPromenence.get(), EPSILON);
 	}
 
 	@Test
 	public void clusterShade() {
-		DoubleType clusterShade = (DoubleType) op("features.haralick.clusterShade").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType clusterShade = (DoubleType) ops.op("features.haralick.clusterShade").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(7.909331564367658e+03,
 				clusterShade.get(), EPSILON);
 	}
 
 	@Test
 	public void contrast() {
-		DoubleType contrast = (DoubleType) op("features.haralick.contrast").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType contrast = (DoubleType) ops.op("features.haralick.contrast").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(2.829684210526314e+03, contrast.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void correlation() {
-		DoubleType correlation = (DoubleType) op("features.haralick.correlation").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType correlation = (DoubleType) ops.op("features.haralick.correlation").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(-6.957913328178969e-03,
 				correlation.get(), EPSILON);
 	}
 
 	@Test
 	public void differenceEntropy() {
-		DoubleType entropy = (DoubleType) op("features.haralick.differenceEntropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType entropy = (DoubleType) ops.op("features.haralick.differenceEntropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(4.517886362509830,
 				entropy.get(), EPSILON);
 	}
 
 	@Test
 	public void differenceVariance() {
-		DoubleType variance = (DoubleType) op("features.haralick.differenceVariance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType variance = (DoubleType) ops.op("features.haralick.differenceVariance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(8.885861218836561e+02,
 				variance.get(), EPSILON);
 	}
 
 	@Test
 	public void entropy() {
-		DoubleType entropy = (DoubleType) op("features.haralick.entropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType entropy = (DoubleType) ops.op("features.haralick.entropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(5.914634251331289, entropy.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void ICM1() {
-		DoubleType icm1 = (DoubleType) op("features.haralick.icm1").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType icm1 = (DoubleType) ops.op("features.haralick.icm1").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(-1.138457766487823, icm1.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void ICM2() {
-		DoubleType icm2 = (DoubleType) op("features.haralick.icm2").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType icm2 = (DoubleType) ops.op("features.haralick.icm2").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(0.9995136931858095, icm2.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void IFDM() {
-		DoubleType ifdm = (DoubleType) op("features.haralick.ifdm").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType ifdm = (DoubleType) ops.op("features.haralick.ifdm").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(2.630092221760193e-02, ifdm.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void maxProbability() {
-		DoubleType maxProb = (DoubleType) op("features.haralick.maxProbability").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType maxProb = (DoubleType) ops.op("features.haralick.maxProbability").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(0.005263157894737,
 				maxProb.get(), EPSILON);
 	}
 
 	@Test
 	public void sumAverage() {
-		DoubleType sumAvg = (DoubleType) op("features.haralick.sumAverage").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType sumAvg = (DoubleType) ops.op("features.haralick.sumAverage").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(1.244210526315790e+02,
 				sumAvg.get(), EPSILON);
 	}
 
 	@Test
 	public void sumEntropy() {
-		DoubleType sumEntropy = (DoubleType) op("features.haralick.sumEntropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType sumEntropy = (DoubleType) ops.op("features.haralick.sumEntropy").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(5.007751063919794, sumEntropy.get(),
 				EPSILON);
 	}
 
 	@Test
 	public void sumVariance() {
-		DoubleType sumVariance = (DoubleType) op("features.haralick.sumVariance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType sumVariance = (DoubleType) ops.op("features.haralick.sumVariance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(1.705010667439121e+04,
 				sumVariance.get(), EPSILON);
 	}
 
 	@Test
 	public void textureHomogeneity() {
-		DoubleType homogeneity = (DoubleType) op("features.haralick.textureHomogeneity").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
+		DoubleType homogeneity = (DoubleType) ops.op("features.haralick.textureHomogeneity").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply(); 
 		assertEquals(0.061929185106950,
 				homogeneity.get(), EPSILON);
 	}
@@ -178,7 +178,7 @@ public class HaralickFeatureTest extends AbstractOpTest {
 	public void variance() {
 		// no reference found in matlab, formula verified
 		// (http://murphylab.web.cmu.edu/publications/boland/boland_node26.html)
-		DoubleType variance = (DoubleType) op("features.haralick.variance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
+		DoubleType variance = (DoubleType) ops.op("features.haralick.variance").input(img, 128, 1, MatrixOrientation2D.HORIZONTAL).apply();
 		assertEquals(5176.653047585449, variance.get(),
 				EPSILON);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/hog/HistogramOfOrientedGradients2DTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/hog/HistogramOfOrientedGradients2DTest.java
@@ -62,7 +62,7 @@ public class HistogramOfOrientedGradients2DTest extends AbstractOpTest {
 		Img<FloatType> hogInputImg = openFloatImg("HoG2DInput.png");
 
 		// use numOrientations = 9 and spanOfNeighborhood = 2 for test
-		RandomAccessibleInterval<FloatType> hogOp = op("features.hog").input(hogInputImg, 9, 2, es)
+		RandomAccessibleInterval<FloatType> hogOp = ops.op("features.hog").input(hogInputImg, 9, 2, es)
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		RandomAccess<FloatType> raOp = hogOp.randomAccess();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/lbp2d/LBP2dFeatureTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/lbp2d/LBP2dFeatureTest.java
@@ -49,7 +49,7 @@ public class LBP2dFeatureTest extends AbstractFeatureTest {
 
 	@Test
 	public void testLbp2d() {
-		final ArrayList<LongType> hist = op("features.lbp2d").input(random, 1, 4)
+		final ArrayList<LongType> hist = ops.op("features.lbp2d").input(random, 1, 4)
 				.outType(new Nil<ArrayList<LongType>>() {}).apply();
 
 		// Test values proved by calculating small toy example by hand.

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/tamura2d/Tamura2dFeatureTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/tamura2d/Tamura2dFeatureTest.java
@@ -48,27 +48,27 @@ public class Tamura2dFeatureTest extends AbstractFeatureTest {
 
 	@Test
 	public void testContrastFeature() {
-		assertEquals(63.7185, op("features.tamura.contrast").input(random).outType(
+		assertEquals(63.7185, ops.op("features.tamura.contrast").input(random).outType(
 			DoubleType.class).apply().get(), 1e-3, "tamura.contrast");
 	}
 
 	@Test
 	public void testDirectionalityFeature() {
-		assertEquals(0.007819, op("features.tamura.directionality").input(random,
+		assertEquals(0.007819, ops.op("features.tamura.directionality").input(random,
 			16).outType(DoubleType.class).apply().get(), 1e-3,
 			"tamura.directionality");
 	}
 
 	@Test
 	public void testCoarsenessFeature() {
-		assertEquals(43.614, op("features.tamura.coarseness").input(random).outType(
+		assertEquals(43.614, ops.op("features.tamura.coarseness").input(random).outType(
 			DoubleType.class).apply().get(), 1e-3, "tamura.coarseness");
 
 		// NB: according to the implementation, this 2x2 image should have exactly 0
 		// coarseness.
 		byte[] arr = new byte[] { 0, -1, 0, 0 };
 		Img<ByteType> in = ArrayImgs.bytes(arr, 2, 2);
-		assertEquals(0.0, op("features.tamura.coarseness").input(in).outType(
+		assertEquals(0.0, ops.op("features.tamura.coarseness").input(in).outType(
 			DoubleType.class).apply().get(), 0.0, "tamura.coarseness");
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/zernike/ZernikeFeatureTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/features/zernike/ZernikeFeatureTest.java
@@ -50,10 +50,10 @@ public class ZernikeFeatureTest extends AbstractFeatureTest {
 	@Test
 	public void testPhaseFeature() {
 
-		assertEquals(179.92297037263532, op("features.zernike.phase").input(ellipse,
+		assertEquals(179.92297037263532, ops.op("features.zernike.phase").input(ellipse,
 			4, 2).outType(new Nil<DoubleType>()
 		{}).apply().get(), EPSILON, "features.zernike.phase");
-		assertEquals(0.0802239034925816, op("features.zernike.phase").input(
+		assertEquals(0.0802239034925816, ops.op("features.zernike.phase").input(
 			rotatedEllipse, 4, 2).outType(new Nil<DoubleType>()
 		{}).apply().get(), EPSILON, "features.zernike.phase");
 	}
@@ -61,9 +61,9 @@ public class ZernikeFeatureTest extends AbstractFeatureTest {
 	@Test
 	public void testMagnitudeFeature() {
 
-		double v1 = op("features.zernike.magnitude").input(ellipse, 4, 2).outType(new Nil<DoubleType>() {})
+		double v1 = ops.op("features.zernike.magnitude").input(ellipse, 4, 2).outType(new Nil<DoubleType>() {})
 				.apply().get();
-		double v2 = op("features.zernike.magnitude").input(rotatedEllipse, 4, 2).outType(new Nil<DoubleType>() {})
+		double v2 = ops.op("features.zernike.magnitude").input(rotatedEllipse, 4, 2).outType(new Nil<DoubleType>() {})
 				.apply().get();
 
 		assertEquals(0.10985876611295191, v1, EPSILON,

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/FFTTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/FFTTest.java
@@ -79,10 +79,10 @@ public class FFTTest extends AbstractOpTest {
 
 			final Img<FloatType> inverse = TestImgGeneration.floatArray(false, dimensions);
 
-			final RandomAccessibleInterval<ComplexFloatType> out = op("filter.fft")
+			final RandomAccessibleInterval<ComplexFloatType> out = ops.op("filter.fft")
 					.input(in, null, true, new ComplexFloatType(), es)
 					.outType(new Nil<RandomAccessibleInterval<ComplexFloatType>>() {}).apply();
-			op("filter.ifft").input(out, es).output(inverse).compute();
+			ops.op("filter.ifft").input(out, es).output(inverse).compute();
 
 			assertImagesEqual(in, inverse, .00005f);
 		}
@@ -110,7 +110,7 @@ public class FFTTest extends AbstractOpTest {
 			long[] fftDimensions = new long[3];
 
 			// compute the dimensions that will result in the fastest FFT time
-			Pair<long[], long[]> fftSize = op("filter.fftSize")
+			Pair<long[], long[]> fftSize = ops.op("filter.fftSize")
 					.input(new FinalDimensions(originalDimensions), fastDimensions, fftDimensions, true, true)
 					.outType(new Nil<Pair<long[], long[]>>() {}).apply();
 
@@ -128,19 +128,19 @@ public class FFTTest extends AbstractOpTest {
 			// call FFT passing false for "fast" (in order to pass the optional
 			// parameter we have to pass null for the
 			// output parameter).
-			final RandomAccessibleInterval<ComplexFloatType> fft1 = op("filter.fft")
+			final RandomAccessibleInterval<ComplexFloatType> fft1 = ops.op("filter.fft")
 					.input(inOriginal, null, false, new ComplexFloatType(), es)
 					.outType(new Nil<RandomAccessibleInterval<ComplexFloatType>>() {}).apply();
 
 			// call FFT passing true for "fast" The FFT op will pad the input to the
 			// fast
 			// size.
-			final RandomAccessibleInterval<ComplexFloatType> fft2 = op("filter.fft")
+			final RandomAccessibleInterval<ComplexFloatType> fft2 = ops.op("filter.fft")
 					.input(inOriginal, null, true, new ComplexFloatType(), es)
 					.outType(new Nil<RandomAccessibleInterval<ComplexFloatType>>() {}).apply();
 
 			// call fft using the img that was created with the fast size
-			final RandomAccessibleInterval<ComplexFloatType> fft3 = op("filter.fft")
+			final RandomAccessibleInterval<ComplexFloatType> fft3 = ops.op("filter.fft")
 					.input(inFast, null, true, new ComplexFloatType(), es)
 					.outType(new Nil<RandomAccessibleInterval<ComplexFloatType>>() {}).apply();
 
@@ -158,18 +158,18 @@ public class FFTTest extends AbstractOpTest {
 			final Img<FloatType> inverseFast = TestImgGeneration.floatArray(false, fastDimensions);
 
 			// invert the "small" FFT
-			op("filter.ifft").input(fft1, es).output(inverseOriginalSmall).compute();
+			ops.op("filter.ifft").input(fft1, es).output(inverseOriginalSmall).compute();
 
 			// invert the "fast" FFT. The inverse will should be the original
 			// size.
-			op("filter.ifft").input(fft2, es).output(inverseOriginalFast).compute();
+			ops.op("filter.ifft").input(fft2, es).output(inverseOriginalFast).compute();
 
 			// invert the "fast" FFT that was acheived by explicitly using an
 			// image
 			// that had "fast" dimensions. The inverse will be the fast size
 			// this
 			// time.
-			op("filter.ifft").input(fft3, es).output(inverseFast).compute();
+			ops.op("filter.ifft").input(fft3, es).output(inverseFast).compute();
 
 			// assert that the inverse images are equal to the original
 			assertImagesEqual(inverseOriginalSmall, inOriginal, .0001f);
@@ -181,14 +181,14 @@ public class FFTTest extends AbstractOpTest {
 	@Test
 	public void testPadShiftKernel() {
 		long[] dims = new long[] { 1024, 1024 };
-		Img<ComplexDoubleType> test = op("create.img").input(new FinalDimensions(dims), new ComplexDoubleType())
+		Img<ComplexDoubleType> test = ops.op("create.img").input(new FinalDimensions(dims), new ComplexDoubleType())
 				.outType(new Nil<Img<ComplexDoubleType>>() {}).apply();
 
-		RandomAccessibleInterval<ComplexDoubleType> shift = op("filter.padShiftKernel")
+		RandomAccessibleInterval<ComplexDoubleType> shift = ops.op("filter.padShiftKernel")
 				.input(test, new FinalDimensions(dims))
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 
-		RandomAccessibleInterval<ComplexDoubleType> shift2 = op("filter.padShiftKernelFFTMethods")
+		RandomAccessibleInterval<ComplexDoubleType> shift2 = ops.op("filter.padShiftKernelFFTMethods")
 				.input(test, new FinalDimensions(dims))
 				.outType(new Nil<RandomAccessibleInterval<ComplexDoubleType>>() {}).apply();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/NonLinearFiltersTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/NonLinearFiltersTest.java
@@ -86,7 +86,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMaxFilter() {
-		op("filter.max").input(in, shape, oobFactory).output(out).compute();
+		ops.op("filter.max").input(in, shape, oobFactory).output(out).compute();
 
 		byte max = Byte.MIN_VALUE;
 
@@ -104,7 +104,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMeanFilter() {
-		op("filter.mean").input(in, shape, oobFactory).output(out).compute();
+		ops.op("filter.mean").input(in, shape, oobFactory).output(out).compute();
 
 		double sum = 0.0;
 
@@ -123,7 +123,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMedianFilter() {
-		op("filter.median").input(in, shape, oobFactory).output(out).compute();
+		ops.op("filter.median").input(in, shape, oobFactory).output(out).compute();
 
 		ArrayList<ByteType> items = new ArrayList<>();
 		NeighborhoodsIterableInterval<ByteType> neighborhoods = shape
@@ -143,7 +143,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMinFilter() {
-		op("filter.min").input(in, shape, oobFactory).output(out).compute();
+		ops.op("filter.min").input(in, shape, oobFactory).output(out).compute();
 
 		byte min = Byte.MAX_VALUE;
 
@@ -161,7 +161,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testSigmaFilter() {
-		op("filter.sigma").input(in, shape, oobFactory, 1.0, 0.0).output(out).compute();
+		ops.op("filter.sigma").input(in, shape, oobFactory, 1.0, 0.0).output(out).compute();
 	}
 
 	/**
@@ -170,7 +170,7 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testVarianceFilter() {
-		op("filter.variance").input(in, shape, oobFactory).output(out).compute();
+		ops.op("filter.variance").input(in, shape, oobFactory).output(out).compute();
 
 		double sum = 0.0;
 		double sumSq = 0.0;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/bilateral/DefaultBilateralTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/bilateral/DefaultBilateralTest.java
@@ -48,7 +48,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = TestImgGeneration.byteArray(false, 6, 6);
 
-		op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
 
 		final byte[] expected = { 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3, 2, 8, 7, 6, 4, 3,
 				2, 8, 7, 6, 4, 3, 2 };
@@ -65,7 +65,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 		final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
 		final Img<ByteType> out = TestImgGeneration.byteArray(false, 2, 2);
 
-		op("filter.bilateral").input(in, 15.0, 5.0, 1).output(out).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 1).output(out).compute();
 
 		Cursor<ByteType> cout = out.cursor();
 		final byte[] expected = { 5, 5, 5, 5 };
@@ -85,8 +85,8 @@ public class DefaultBilateralTest extends AbstractOpTest {
 		final Img<ByteType> out = TestImgGeneration.byteArray(false, 6, 6);
 		final Img<ByteType> cellOut = TestImgGeneration.byteArray(false, 6, 6);
 
-		op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
-		op("filter.bilateral").input(in, 15.0, 5.0, 2).output(cellOut).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 2).output(cellOut).compute();
 
 		Cursor<ByteType> cout = out.cursor();
 		Cursor<ByteType> cCellOut = cellOut.cursor();
@@ -106,7 +106,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 	// final Img<ByteType> gaussOut = generateByteArrayTestImg(false, 6, 6);
 	// final Img<ByteType> bilateralOut = generateByteTestCellImg(false, 6, 6);
 	//
-	// op("filter.bilateral").input(bilateralOut, in, 15, 5,
+	// ops.op("filter.bilateral").input(bilateralOut, in, 15, 5,
 	// 2).apply();
 	// final double sigma = 5;
 	// ops.run(GaussRAISingleSigma.class, gaussOut, in, sigma);
@@ -120,7 +120,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = TestImgGeneration.byteArray(false, 6, 6);
 
-		op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
 
 		Cursor<ByteType> cout = out.cursor();
 		while (cout.hasNext()) {
@@ -136,7 +136,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 		final Img<ByteType> in = ArrayImgs.bytes(data, 6, 6);
 		final Img<ByteType> out = TestImgGeneration.byteArray(false, 6, 6);
 
-		op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
+		ops.op("filter.bilateral").input(in, 15.0, 5.0, 2).output(out).compute();
 
 		final byte[] expected = { -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6,
 				-4, -3, -2, -8, -7, -6, -4, -3, -2, -8, -7, -6, -4, -3, -2 };
@@ -156,7 +156,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 	// final Img<ByteType> in = ArrayImgs.bytes(data, 2, 2);
 	// final Img<ByteType> out = generateByteArrayTestImg(false, 2, 2, 2);
 	//
-	// op("filter.bilateral").input(in, 15.0, 5.0, 2, out).apply();
+	// ops.op("filter.bilateral").input(in, 15.0, 5.0, 2, out).apply();
 	//
 	// final byte[] expected = { 2, 2, 2, 2, 2, 2, 2, 2 };
 	//
@@ -172,7 +172,7 @@ public class DefaultBilateralTest extends AbstractOpTest {
 	// final Img<ByteType> in = ArrayImgs.bytes(data, 2, 3);
 	// final Img<ByteType> out = generateByteArrayTestImg(false, 3, 2);
 	//
-	// op("filter.bilateral").input(in, 15.0, 5.0, 2, out).apply();
+	// ops.op("filter.bilateral").input(in, 15.0, 5.0, 2, out).apply();
 	//
 	// final byte[] expected = { 1, 1, 1, 1, 1, 1 };
 	// Cursor<ByteType> cout = out.cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/convolve/ConvolveTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/convolve/ConvolveTest.java
@@ -81,7 +81,7 @@
 //
 //		// make sure it runs
 //		@SuppressWarnings("unchecked")
-//		final Img<FloatType> out1 = (Img<FloatType>) op("filter.convolve").input(
+//		final Img<FloatType> out1 = (Img<FloatType>) ops.op("filter.convolve").input(
 //			in, kernel);
 //
 //		assertEquals(out1.dimension(0), 20);
@@ -97,7 +97,7 @@
 //
 //		// make sure it runs
 //		@SuppressWarnings("unchecked")
-//		final Img<FloatType> out2 = (Img<FloatType>) op("filter.convolve").input(in,
+//		final Img<FloatType> out2 = (Img<FloatType>) ops.op("filter.convolve").input(in,
 //			kernel);
 //
 //		assertEquals(out2.dimension(0), 20);
@@ -132,13 +132,13 @@
 //		FloatType outSum3 = new FloatType();
 //
 //		// calculate sum of input and kernel
-//		op("stats.sum").input(in, inSum).apply();
-//		op("stats.sum").input(kernel, kernelSum).apply();
+//		ops.op("stats.sum").input(in, inSum).apply();
+//		ops.op("stats.sum").input(kernel, kernelSum).apply();
 //
 //		// convolve and calculate the sum of output
 //		@SuppressWarnings("unchecked")
 //		// should match to ConvolveFFTF
-//		final Img<FloatType> out = (Img<FloatType>) op("filter.convolve").input(in,
+//		final Img<FloatType> out = (Img<FloatType>) ops.op("filter.convolve").input(in,
 //			kernel, borderSize);
 //
 //		// create an output for the next test
@@ -149,19 +149,19 @@
 //
 //		// Op used to pad the input
 //		final BinaryFunctionOp<RandomAccessibleInterval<FloatType>, Dimensions, RandomAccessibleInterval<FloatType>> padOp =
-//			(BinaryFunctionOp) Functions.match(ops, PadInputFFTMethods.class,
+//			(BinaryFunctionOp) Functions.match(ops.env(), PadInputFFTMethods.class,
 //				RandomAccessibleInterval.class, RandomAccessibleInterval.class,
 //				Dimensions.class, true);
 //
 //		// Op used to pad the kernel
 //		final BinaryFunctionOp<RandomAccessibleInterval<FloatType>, Dimensions, RandomAccessibleInterval<FloatType>> padKernelOp =
-//			(BinaryFunctionOp) Functions.match(ops, PadShiftKernelFFTMethods.class,
+//			(BinaryFunctionOp) Functions.match(ops.env(), PadShiftKernelFFTMethods.class,
 //				RandomAccessibleInterval.class, RandomAccessibleInterval.class,
 //				Dimensions.class, true);
 //
 //		// Op used to create the complex FFTs
 //		UnaryFunctionOp<Dimensions, RandomAccessibleInterval<ComplexFloatType>> createOp =
-//			(UnaryFunctionOp) Functions.match(ops, CreateOutputFFTMethods.class,
+//			(UnaryFunctionOp) Functions.match(ops.env(), CreateOutputFFTMethods.class,
 //				RandomAccessibleInterval.class, Dimensions.class,
 //				new ComplexFloatType(), true);
 //
@@ -189,15 +189,15 @@
 //			new FinalDimensions(paddedSize));
 //
 //		// run convolve using the rai version with the memory created above
-//		op("filter.convolve").input(paddedInput, paddedKernel, fftImage,
+//		ops.op("filter.convolve").input(paddedInput, paddedKernel, fftImage,
 //			fftKernel, out2);
 //
-//		op("filter.convolve").input(paddedInput, paddedKernel, fftImage,
+//		ops.op("filter.convolve").input(paddedInput, paddedKernel, fftImage,
 //			fftKernel, true, false, es, out3);
 //
-//		op("stats.sum").input(Views.iterable(out), outSum).apply();
-//		op("stats.sum").input(out2, outSum2).apply();
-//		op("stats.sum").input(out3, outSum3).apply();
+//		ops.op("stats.sum").input(Views.iterable(out), outSum).apply();
+//		ops.op("stats.sum").input(out2, outSum2).apply();
+//		ops.op("stats.sum").input(out3, outSum3).apply();
 //
 //		// multiply input sum by kernelSum and assert it is the same as outSum
 //		inSum.mul(kernelSum);
@@ -235,7 +235,7 @@
 //
 //		int[] size = new int[] { xSize, ySize, zSize };
 //
-//		Img<DoubleType> phantom = (Img<DoubleType>) op("create.img").input(size).apply();
+//		Img<DoubleType> phantom = (Img<DoubleType>) ops.op("create.img").input(size).apply();
 //
 //		RandomAccess<DoubleType> randomAccess = phantom.randomAccess();
 //
@@ -269,9 +269,9 @@
 //		DoubleType max = new DoubleType();
 //		DoubleType min = new DoubleType();
 //
-//		op("stats.sum").input(Views.iterable(convolved), sum).apply();
-//		op("stats.max").input(Views.iterable(convolved), max).apply();
-//		op("stats.min").input(Views.iterable(convolved), min).apply();
+//		ops.op("stats.sum").input(Views.iterable(convolved), sum).apply();
+//		ops.op("stats.max").input(Views.iterable(convolved), max).apply();
+//		ops.op("stats.min").input(Views.iterable(convolved), min).apply();
 //
 //		assertEquals(sum.getRealDouble(), 8750.00, 0.001);
 //		assertEquals(max.getRealDouble(), 3.155, 0.001);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivative/PartialDerivativeFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivative/PartialDerivativeFilterTest.java
@@ -80,7 +80,7 @@ public class PartialDerivativeFilterTest extends AbstractOpTest {
 			}
 		}
 
-		RandomAccessibleInterval<FloatType> out = op("filter.partialDerivative").input(img, 0)
+		RandomAccessibleInterval<FloatType> out = ops.op("filter.partialDerivative").input(img, 0)
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		FloatType type = Util.getTypeFromInterval(out).createVariable();
@@ -161,7 +161,7 @@ public class PartialDerivativeFilterTest extends AbstractOpTest {
 			}
 		}
 
-		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = op("filter.partialDerivative")
+		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = ops.op("filter.partialDerivative")
 				.input(img).outType(new Nil<CompositeIntervalView<FloatType, RealComposite<FloatType>>>() {}).apply();
 
 		CompositeView<FloatType, RealComposite<FloatType>>.CompositeRandomAccess outRA = out.randomAccess();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGaussTest.java
@@ -57,14 +57,14 @@ public class DefaultDerivativeGaussTest extends AbstractOpTest {
 		final RandomAccessibleInterval<FloatType> input = TestImgGeneration
 			.floatArray(false, 30, 30, 30);
 
-		final Img<DoubleType> output = op("create.img").input(input)
+		final Img<DoubleType> output = ops.op("create.img").input(input)
 				.outType(new Nil<Img<DoubleType>>() {}).apply();
 
 		final int[] derivatives = new int[] { 1, 0 };
 		final double[] sigmas = new double[] { 1, 1 };
 		IllegalArgumentException e = Assertions.assertThrows(
 			IllegalArgumentException.class, () -> {
-				op("filter.derivativeGauss").input(input, sigmas, derivatives).output(
+				ops.op("filter.derivativeGauss").input(input, sigmas, derivatives).output(
 					output).compute();
 			});
 
@@ -75,11 +75,11 @@ public class DefaultDerivativeGaussTest extends AbstractOpTest {
 	@Test
 	public void regressionTest() {
 		final int width = 10;
-		final Img<DoubleType> input = op("create.img")
+		final Img<DoubleType> input = ops.op("create.img")
 				.input(new FinalDimensions(width, width), new DoubleType()).outType(new Nil<Img<DoubleType>>() {})
 				.apply();
 
-		final Img<DoubleType> output = op("create.img").input(input, new DoubleType())
+		final Img<DoubleType> output = ops.op("create.img").input(input, new DoubleType())
 				.outType(new Nil<Img<DoubleType>>() {}).apply();
 
 		// Draw a line on the image
@@ -93,7 +93,7 @@ public class DefaultDerivativeGaussTest extends AbstractOpTest {
 		// filter the image
 		final int[] derivatives = new int[] { 1, 0 };
 		final double[] sigmas = new double[] { 0.5, 0.5 };
-		op("filter.derivativeGauss").input(input, sigmas, derivatives).output(output).compute();
+		ops.op("filter.derivativeGauss").input(input, sigmas, derivatives).output(output).compute();
 
 		final Cursor<DoubleType> cursor = output.localizingCursor();
 		int currentPixel = 0;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/dog/DoGTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/dog/DoGTest.java
@@ -69,7 +69,7 @@ public class DoGTest extends AbstractOpTest {
 		final Img<ByteType> out2 = TestImgGeneration.byteArray(false, dims);
 		final OutOfBoundsFactory<ByteType, Img<ByteType>> outOfBounds = new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
 
-		op("filter.DoG").input(in, sigmas1, sigmas2, outOfBounds, es).output(out1).compute();
+		ops.op("filter.DoG").input(in, sigmas1, sigmas2, outOfBounds, es).output(out1).compute();
 
 		// test against native imglib2 implementation
 		DifferenceOfGaussian.DoG(sigmas1, sigmas2, Views.extendMirrorSingle(in), out2,
@@ -87,10 +87,10 @@ public class DoGTest extends AbstractOpTest {
 	public void dogRAISingleSigmasTest() {
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
 		final OutOfBoundsFactory<ByteType, Img<ByteType>> outOfBounds = new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
-		final RandomAccessibleInterval<ByteType> res = op("create.img")
+		final RandomAccessibleInterval<ByteType> res = ops.op("create.img")
 				.input(TestImgGeneration.byteArray(true, new long[] { 10, 10 }), new ByteType())
 				.outType(new Nil<RandomAccessibleInterval<ByteType>>() {}).apply();
-		op("filter.DoG").input(TestImgGeneration.byteArray(true, new long[] { 10, 10 }), 1., 2., outOfBounds, es)
+		ops.op("filter.DoG").input(TestImgGeneration.byteArray(true, new long[] { 10, 10 }), 1., 2., outOfBounds, es)
 				.output(res).compute();
 
 		Assertions.assertNotNull(res);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/gauss/GaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/gauss/GaussTest.java
@@ -62,13 +62,13 @@ public class GaussTest extends AbstractOpTest {
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
 
 		final Img<ByteType> in = TestImgGeneration.byteArray(true, new long[] { 10, 10 });
-		final Img<ByteType> out1 = op("create.img").input(in, Util.getTypeFromInterval(in))
+		final Img<ByteType> out1 = ops.op("create.img").input(in, Util.getTypeFromInterval(in))
 				.outType(new Nil<Img<ByteType>>() {}).apply();
 		final double sigma = 5;
-		final Img<ByteType> out2 = op("create.img").input(in, Util.getTypeFromInterval(in))
+		final Img<ByteType> out2 = ops.op("create.img").input(in, Util.getTypeFromInterval(in))
 				.outType(new Nil<Img<ByteType>>() {}).apply();
 
-		op("filter.gauss").input(in, es, sigma).output(out1).compute();
+		ops.op("filter.gauss").input(in, es, sigma).output(out1).compute();
 		try {
 			Gauss3.gauss(sigma, Views.extendMirrorSingle(in), out2);
 		} catch (IncompatibleTypeException e) {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/hessian/HessianFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/hessian/HessianFilterTest.java
@@ -79,7 +79,7 @@ public class HessianFilterTest extends AbstractOpTest {
 			}
 		}
 
-		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = op("filter.hessian").input(img)
+		CompositeIntervalView<FloatType, RealComposite<FloatType>> out = ops.op("filter.hessian").input(img)
 				.outType(new Nil<CompositeIntervalView<FloatType, RealComposite<FloatType>>>() {}).apply();
 
 		Cursor<RealComposite<FloatType>> outCursor = Views.iterable(out).cursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/mean/MeanFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/mean/MeanFilterTest.java
@@ -18,11 +18,11 @@ public class MeanFilterTest extends AbstractOpTest{
 	@Test
 	public void meanFilterTest() {
 		
-		Img<ByteType> img = op("create.img").input(new FinalInterval(5, 5), new ByteType()).outType(new Nil<Img<ByteType>>() {}).apply();
+		Img<ByteType> img = ops.op("create.img").input(new FinalInterval(5, 5), new ByteType()).outType(new Nil<Img<ByteType>>() {}).apply();
 		RectangleShape shape = new RectangleShape(1, false);
 		OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>> oobf = new OutOfBoundsBorderFactory<>();
-		Img<ByteType> output = op("create.img").input(img).outType(new Nil<Img<ByteType>>() {}).apply();
-		op("filter.mean").input(img, shape, oobf).output(output).compute();
+		Img<ByteType> output = ops.op("create.img").input(img).outType(new Nil<Img<ByteType>>() {}).apply();
+		ops.op("filter.mean").input(img, shape, oobf).output(output).compute();
 		
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/sobel/SobelFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/sobel/SobelFilterTest.java
@@ -77,7 +77,7 @@ public class SobelFilterTest extends AbstractOpTest {
 				counterY = 0;
 			}
 		}
-		RandomAccessibleInterval<FloatType> out = op("filter.sobel").input(img)
+		RandomAccessibleInterval<FloatType> out = ops.op("filter.sobel").input(img)
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		RandomAccess<FloatType> outRA = out.randomAccess();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/tubeness/TubenessTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/tubeness/TubenessTest.java
@@ -59,9 +59,9 @@ public class TubenessTest extends AbstractOpTest {
 		final double sigma = scale / Math.sqrt(2);
 
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
-		Img<DoubleType> actual = op("create.img").input(input, new DoubleType())
+		Img<DoubleType> actual = ops.op("create.img").input(input, new DoubleType())
 				.outType(new Nil<Img<DoubleType>>() {}).apply();
-		op("filter.tubeness").input(input, es, sigma).output(actual).compute();
+		ops.op("filter.tubeness").input(input, es, sigma).output(actual).compute();
 
 		assertTrue(AssertIterations.equal(expected, actual));
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/vesselness/FrangiVesselnessTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/vesselness/FrangiVesselnessTest.java
@@ -50,8 +50,10 @@ import org.scijava.Context;
 import org.scijava.cache.CacheService;
 import org.scijava.ops.OpService;
 import org.scijava.ops.core.builder.OpBuilder;
+import org.scijava.plugin.PluginService;
 import org.scijava.script.ScriptService;
 import org.scijava.thread.ThreadService;
+import org.scijava.types.TypeService;
 
 /**
  * Tests the Frangi Vesselness operation.
@@ -65,7 +67,9 @@ public class FrangiVesselnessTest{
 
 	@BeforeAll
 	public static void setUp() {
-		context = new Context(OpService.class, CacheService.class, ThreadService.class, ScriptService.class);
+		context = new Context(OpService.class, CacheService.class,
+			ThreadService.class, ScriptService.class, PluginService.class,
+			TypeService.class);
 		ops = context.service(OpService.class);
 	}
 
@@ -77,7 +81,7 @@ public class FrangiVesselnessTest{
 	}
 	
 	private static OpBuilder op(String name) {
-		return new OpBuilder(ops, name);
+		return ops.op(name);
 	}
 	
 	private Img<FloatType> openFloatImg(
@@ -92,7 +96,7 @@ public class FrangiVesselnessTest{
 
 		// load in input image and expected output image.
 		Img<DoubleType> inputImg = ArrayImgs.doubles(256, 256);
-		op("image.equation")
+		ops.op("image.equation")
 				.input("Math.tan(0.3*p[0]) + Math.tan(0.1*p[1])", context.getService(ScriptService.class))
 				.output(inputImg).compute();
 		Img<FloatType> expectedOutput = ((Img<FloatType>) openFloatImg("Result.tif"));
@@ -110,7 +114,7 @@ public class FrangiVesselnessTest{
 		double[] spacing = { 1, 1 };
 
 		// run the op
-		op("filter.frangiVesselness").input(inputImg, spacing, scale).output(actualOutput).compute();
+		ops.op("filter.frangiVesselness").input(inputImg, spacing, scale).output(actualOutput).compute();
 
 		// compare the output image data to that stored in the file.
 		Cursor<FloatType> cursor = Views.iterable(actualOutput).localizingCursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/MeshFeatureTests.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/MeshFeatureTests.java
@@ -56,7 +56,7 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void boxivityMesh() {
 		try {
-			op("geom.boxivity").input(mesh).apply();
+			ops.op("geom.boxivity").input(mesh).apply();
 		} catch (IllegalArgumentException e) {
 			// DefaultSmallestOrientedBoundingBox is not implemented.
 		}
@@ -66,7 +66,7 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	public void compactness() {
 		// formula verified and ground truth computed with matlab
 		assertEquals(0.572416357359835,
-				op("geom.compactness").input(mesh).outType(DoubleType.class).apply().get(), EPSILON, "geom.compactness");
+				ops.op("geom.compactness").input(mesh).outType(DoubleType.class).apply().get(), EPSILON, "geom.compactness");
 	}
 
 	@Test
@@ -80,20 +80,20 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	public void convexityMesh() {
 		// formula verified and ground truth computed with matlab
 		assertEquals(0.983930494866521,
-				op("geom.convexity").input(mesh).outType(DoubleType.class).apply().get(), EPSILON, "geom.convexity");
+				ops.op("geom.convexity").input(mesh).outType(DoubleType.class).apply().get(), EPSILON, "geom.convexity");
 	}
 
 	@Test
 	public void mainElongation() {
 		// formula verified and ground truth computed with matlab
 		assertEquals(0.2079585956045953,
-				(op("geom.mainElongation").input(mesh).outType(DoubleType.class).apply()).get(),
+				(ops.op("geom.mainElongation").input(mesh).outType(DoubleType.class).apply()).get(),
 				EPSILON, "geom.mainElongation");
 	}
 
 	@Test
 	public void marchingCubes() {
-		final Mesh result = (Mesh) op("geom.marchingCubes").input(ROI, null, null).apply();
+		final Mesh result = (Mesh) ops.op("geom.marchingCubes").input(ROI, null, null).apply();
 		assertEquals(mesh.triangles().size(), result.triangles().size());
 		final Iterator<Triangle> expectedFacets = mesh.triangles().iterator();
 		final Iterator<Triangle> actualFacets = result.triangles().iterator();
@@ -116,7 +116,7 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void medianElongation() {
 		// formula verified and ground truth computed with matlab
-		assertEquals(0.30059118825775455, op("geom.medianElongation").input(mesh)
+		assertEquals(0.30059118825775455, ops.op("geom.medianElongation").input(mesh)
 			.outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.medianElongation");
 	}
@@ -124,49 +124,49 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void sizeConvexHullMesh() {
 		// ground truth computed with matlab
-		assertEquals(304.5, op("geom.sizeConvexHull").input(mesh).outType(
+		assertEquals(304.5, ops.op("geom.sizeConvexHull").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.sizeConvexHull");
 	}
 
 	@Test
 	public void sizeMesh() {
 		// ground truth computed with matlab
-		assertEquals(257.5, op("geom.size").input(mesh).outType(DoubleType.class)
+		assertEquals(257.5, ops.op("geom.size").input(mesh).outType(DoubleType.class)
 			.apply().get(), EPSILON, "geom.size");
 	}
 
 	@Test
 	public void solidityMesh() {
 		// formula verified and ground truth computed with matlab
-		assertEquals(0.845648604269294, op("geom.solidity").input(mesh).outType(
+		assertEquals(0.845648604269294, ops.op("geom.solidity").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.solidity");
 	}
 
 	@Test
 	public void spareness() {
 		// formula verified
-		assertEquals(0.7884710437076516, op("geom.spareness").input(mesh).outType(
+		assertEquals(0.7884710437076516, ops.op("geom.spareness").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.spareness");
 	}
 
 	@Test
 	public void sphericity() {
 		// formula verified and ground truth computed with matlab
-		assertEquals(0.830304411183464, op("geom.sphericity").input(mesh).outType(
+		assertEquals(0.830304411183464, ops.op("geom.sphericity").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.sphericity");
 	}
 
 	@Test
 	public void surfaceArea() {
 		// ground truth computed with matlab
-		assertEquals(235.7390893402464, op("geom.boundarySize").input(mesh).outType(
+		assertEquals(235.7390893402464, ops.op("geom.boundarySize").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.boundarySize");
 	}
 
 	@Test
 	public void surfaceAreaConvexHull() {
 		// ground truth computed with matlab
-		assertEquals(231.9508788339317, op("geom.boundarySizeConvexHull").input(
+		assertEquals(231.9508788339317, ops.op("geom.boundarySizeConvexHull").input(
 			mesh).outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.boundarySizeConvexHull");
 	}
@@ -174,14 +174,14 @@ public class MeshFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void verticesCountConvexHullMesh() {
 		// verified with matlab
-		assertEquals(57, op("geom.verticesCountConvexHull").input(mesh).outType(
+		assertEquals(57, ops.op("geom.verticesCountConvexHull").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.verticesCountConvexHull");
 	}
 
 	@Test
 	public void verticesCountMesh() {
 		// verified with matlab
-		assertEquals(184, op("geom.verticesCount").input(mesh).outType(
+		assertEquals(184, ops.op("geom.verticesCount").input(mesh).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.verticesCount");
 
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/PolygonFeatureTests.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/PolygonFeatureTests.java
@@ -66,7 +66,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void boundarySizeConvexHull() {
 		// ground truth computed with matlab
-		assertEquals(272.1520849298494, op("geom.boundarySizeConvexHull")
+		assertEquals(272.1520849298494, ops.op("geom.boundarySizeConvexHull")
 				.input(contour).outType(DoubleType.class).apply().get(), EPSILON, "geom.boundarySizeConvexHull");
 	}
 
@@ -74,7 +74,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	public void boundingBox() {
 		// ground truth verified with matlab
 		final List<? extends RealLocalizable> received = GeomUtils
-				.vertices((op("geom.boundingBox").input(contour).outType(Polygon2D.class).apply()));
+				.vertices((ops.op("geom.boundingBox").input(contour).outType(Polygon2D.class).apply()));
 		final RealPoint[] expected = new RealPoint[] { new RealPoint(1, 6), new RealPoint(1, 109),
 				new RealPoint(78, 109), new RealPoint(78, 6) };
 		assertEquals(expected.length, received.size(), "Number of polygon points differs.");
@@ -90,7 +90,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	public void boxivity() {
 		// ground truth computed with matlab
 		assertEquals(0.6045142846804,
-				op("geom.boxivity").input(contour).outType(DoubleType.class).apply().get(), EPSILON, "geom.boxivity");
+				ops.op("geom.boxivity").input(contour).outType(DoubleType.class).apply().get(), EPSILON, "geom.boxivity");
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 		// ground truth computed with matlab (according to this formula:
 		// circularity = 4pi(area/perimeter^2))
 		assertEquals(0.3566312416783,
-				op("geom.circularity").input(contour).outType(DoubleType.class).apply().get(), EPSILON, "geom.circularity");
+				ops.op("geom.circularity").input(contour).outType(DoubleType.class).apply().get(), EPSILON, "geom.circularity");
 	}
 
 	// TODO: this test checks LabelRegionToPolygonConverter, which is a Scijava
@@ -107,7 +107,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void contour() {
 		// ground truth computed with matlab
-		final Polygon2D test = op("geom.contour").input(ROI, true).outType(Polygon2D.class).apply();
+		final Polygon2D test = ops.op("geom.contour").input(ROI, true).outType(Polygon2D.class).apply();
 		final List<? extends RealLocalizable> expected = GeomUtils.vertices(contour);
 		final List<? extends RealLocalizable> received = GeomUtils.vertices(test);
 		assertEquals(expected.size(), received.size(),
@@ -125,7 +125,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void convexHull2D() {
 		// ground truth computed with matlab
-		final Polygon2D test = op("geom.convexHull").input(contour).outType(Polygon2D.class).apply();
+		final Polygon2D test = ops.op("geom.convexHull").input(contour).outType(Polygon2D.class).apply();
 		final List<? extends RealLocalizable> received = GeomUtils.vertices(test);
 		final RealPoint[] expected = new RealPoint[] { new RealPoint(1, 30), new RealPoint(2, 29), new RealPoint(26, 6),
 				new RealPoint(31, 6), new RealPoint(42, 9), new RealPoint(49, 22), new RealPoint(72, 65),
@@ -145,7 +145,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void convexity() {
 		// formula verified and value computed with matlab
-		assertEquals(0.7735853919277, op("geom.convexity").input(contour).outType(
+		assertEquals(0.7735853919277, ops.op("geom.convexity").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.convexity");
 	}
 
@@ -154,21 +154,21 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 		// formula is verified, result depends on major- and minor-axis
 		// implementation
 		assertEquals(0.863668314823,
-				op("geom.eccentricity").input(contour).outType(DoubleType.class).apply().get(),
+				ops.op("geom.eccentricity").input(contour).outType(DoubleType.class).apply().get(),
 				EPSILON, "geom.eccentricity");
 	}
 
 	@Test
 	public void elongation() {
 		// formula verified and result computed with matlab
-		assertEquals(0.401789429879, op("geom.mainElongation").input(contour)
+		assertEquals(0.401789429879, ops.op("geom.mainElongation").input(contour)
 			.outType(DoubleType.class).apply().get(), EPSILON, "geom.mainElongation");
 	}
 
 	@Test
 	public void feretsDiameterForAngle() {
 		// ground truth based on minimum ferets diameter and angle
-		assertEquals(58.5849810104945, op("geom.feretsDiameter").input(contour,
+		assertEquals(58.5849810104945, ops.op("geom.feretsDiameter").input(contour,
 			153.434948822922).outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.feretsDiameter");
 	}
@@ -179,14 +179,14 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 		// implementation, which is used in ImageJ1. If a new version of ellipse
 		// and fitting ellipse is available in imglib2, this version will be
 		// replaced and the numbers will change.
-		assertEquals(94.1937028134837, op("geom.majorAxis").input(contour).outType(
+		assertEquals(94.1937028134837, ops.op("geom.majorAxis").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.majorAxis");
 	}
 
 	@Test
 	public void maximumFeretsAngle() {
 		// ground truth computed with matlab
-		assertEquals(81.170255332091, op("geom.maximumFeretsAngle").input(contour)
+		assertEquals(81.170255332091, ops.op("geom.maximumFeretsAngle").input(contour)
 			.outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.maximumFeretsAngle");
 	}
@@ -194,7 +194,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void minimumFeretsDiameter() {
 		// ground truth computed with matlab
-		assertEquals(58.5849810104945, op("geom.minimumFeretsDiameter").input(
+		assertEquals(58.5849810104945, ops.op("geom.minimumFeretsDiameter").input(
 			contour).outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.minimumFeretsDiameter");
 	}
@@ -202,7 +202,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void minimumFeretsAngle() {
 		// ground truth computed with matlab
-		assertEquals(153.434948822922, op("geom.minimumFeretsAngle").input(contour)
+		assertEquals(153.434948822922, ops.op("geom.minimumFeretsAngle").input(contour)
 			.outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.minimumFeretAngle");
 	}
@@ -210,7 +210,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	@Test
 	public void maximumFeretsDiameter() {
 		// ground truth computed with matlab
-		assertEquals(104.2353107157071, op("geom.maximumFeretsDiameter").input(
+		assertEquals(104.2353107157071, ops.op("geom.maximumFeretsDiameter").input(
 			contour).outType(DoubleType.class).apply().get(), EPSILON,
 			"geom.maximumFeretsDiameter");
 	}
@@ -221,28 +221,28 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 		// implementation, which is used in ImageJ1. If a new version of ellipse
 		// and fitting ellipse is available in imglib2, this version will be
 		// replaced and the numbers will change.
-		assertEquals(47.4793300114545, op("geom.minorAxis").input(contour).outType(
+		assertEquals(47.4793300114545, ops.op("geom.minorAxis").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.minorAxis");
 	}
 
 	@Test
 	public void perimeterLength() {
 		// ground truth computed with matlab
-		assertEquals(351.8061325481604, op("geom.boundarySize").input(contour)
+		assertEquals(351.8061325481604, ops.op("geom.boundarySize").input(contour)
 			.outType(DoubleType.class).apply().get(), EPSILON, "geom.boundarySize");
 	}
 
 	@Test
 	public void roundness() {
 		// formula is verified, ground truth is verified with matlab
-		assertEquals(0.504060553872, op("geom.roundness").input(contour).outType(
+		assertEquals(0.504060553872, ops.op("geom.roundness").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "roundness");
 	}
 
 	@Test
 	public void size() {
 		// ground truth computed with matlab
-		assertEquals(3512.5, op("geom.size").input(contour).outType(
+		assertEquals(3512.5, ops.op("geom.size").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.size");
 
 	}
@@ -251,7 +251,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	public void smallesEnclosingRectangle() {
 		// ground truth verified with matlab
 		final List<? extends RealLocalizable> received = GeomUtils
-				.vertices((op("geom.smallestEnclosingBoundingBox").input(contour)
+				.vertices((ops.op("geom.smallestEnclosingBoundingBox").input(contour)
 						.outType(Polygon2D.class).apply()));
 		final RealPoint[] expected = new RealPoint[] { new RealPoint(37.229184188393, -0.006307821699),
 				new RealPoint(-14.757779646762, 27.800672834315), new RealPoint(31.725820016821, 114.704793944491),
@@ -270,21 +270,21 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 
 	@Test
 	public void sizeConvexHullPolygon() {
-		assertEquals(4731, op("geom.sizeConvexHull").input(contour).outType(
+		assertEquals(4731, ops.op("geom.sizeConvexHull").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.sizeConvexHull");
 	}
 
 	@Test
 	public void solidity2D() {
 		// formula is verified, ground truth computed with matlab
-		assertEquals(0.742443458043, op("geom.solidity").input(contour).outType(
+		assertEquals(0.742443458043, ops.op("geom.solidity").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.solidity");
 	}
 
 	@Test
 	public void verticesCountConvexHull() {
 		// verified with matlab
-		assertEquals(14, op("geom.verticesCountConvexHull").input(contour).outType(
+		assertEquals(14, ops.op("geom.verticesCountConvexHull").input(contour).outType(
 			DoubleType.class).apply().get(), EPSILON, "geom.verticesCountConvexHull");
 	}
 
@@ -292,7 +292,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	public void verticesCount() {
 		// verified with matlab
 		assertEquals(305,
-				op("geom.verticesCount").input(contour).outType(DoubleType.class).apply().get(),
+				ops.op("geom.verticesCount").input(contour).outType(DoubleType.class).apply().get(),
 				EPSILON, "geom.verticesCount");
 	}
 
@@ -323,7 +323,7 @@ public class PolygonFeatureTests extends AbstractFeatureTest {
 	public void centroid() {
 		// ground truth computed with matlab
 		final RealPoint expected = new RealPoint(38.144483985765, 59.404175563464);
-		final RealPoint result = (RealPoint) op("geom.centroid").input(contour).apply();
+		final RealPoint result = (RealPoint) ops.op("geom.centroid").input(contour).apply();
 		assertEquals(expected.getDoublePosition(0), result.getDoublePosition(0),
 			EPSILON, "Centroid X");
 		assertEquals(expected.getDoublePosition(1), result.getDoublePosition(1),

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/QuickHull3DTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/geom/QuickHull3DTest.java
@@ -60,8 +60,8 @@ public class QuickHull3DTest extends AbstractOpTest {
 	public void quickhull_100_000_Test() {
 		Mesh df = randomPoints(100000, 20150818);
 
-		final Mesh convexHull = op("geom.convexHull").input(df).outType(Mesh.class).apply();
-		final double epsilon = op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
+		final Mesh convexHull = ops.op("geom.convexHull").input(df).outType(Mesh.class).apply();
+		final double epsilon = ops.op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
 		assertEquals(175, convexHull.vertices().size());
 		assertConvex(convexHull, epsilon);
 	}
@@ -74,8 +74,8 @@ public class QuickHull3DTest extends AbstractOpTest {
 		df.vertices().add(0, 0, 1);
 		df.vertices().add(0, 1, 0);
 
-		final Mesh convexHull = op("geom.convexHull").input(df).outType(Mesh.class).apply();
-		final double epsilon = op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
+		final Mesh convexHull = ops.op("geom.convexHull").input(df).outType(Mesh.class).apply();
+		final double epsilon = ops.op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
 		assertEquals(4, convexHull.vertices().size());
 		assertConvex(convexHull, epsilon);
 	}
@@ -90,8 +90,8 @@ public class QuickHull3DTest extends AbstractOpTest {
 		df.vertices().add(-4.7, 0.4, -4.2);
 		df.vertices().add(-1.9, 2.2, -3.3);
 
-		final Mesh convexHull = op("geom.convexHull").input(df).outType(Mesh.class).apply();
-		final double epsilon = op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
+		final Mesh convexHull = ops.op("geom.convexHull").input(df).outType(Mesh.class).apply();
+		final double epsilon = ops.op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
 		assertEquals(5, convexHull.vertices().size());
 		assertConvex(convexHull, epsilon);
 	}
@@ -115,8 +115,8 @@ public class QuickHull3DTest extends AbstractOpTest {
 		v.add(0.3544683273457627, -0.450828987127942, -0.0827870439577727);
 		v.add(0.1667164640191164, 0.003605551555385444, -0.4014989499947977);
 
-		final Mesh convexHull = op("geom.convexHull").input(df).outType(Mesh.class).apply();
-		final double epsilon = op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
+		final Mesh convexHull = ops.op("geom.convexHull").input(df).outType(Mesh.class).apply();
+		final double epsilon = ops.op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
 		assertEquals(12, convexHull.vertices().size());
 		assertConvex(convexHull, epsilon);
 	}
@@ -167,8 +167,8 @@ public class QuickHull3DTest extends AbstractOpTest {
 		v.add(-0.312260808713977, -0.1674135249735914, 0.2808831662692904);
 		v.add(-0.1966306233747216, 0.2291105671125563, -0.3387042454804333);
 
-		final Mesh convexHull = op("geom.convexHull").input(df).outType(Mesh.class).apply();
-		final double epsilon = op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
+		final Mesh convexHull = ops.op("geom.convexHull").input(df).outType(Mesh.class).apply();
+		final double epsilon = ops.op("geom.convexHullEpsilon").input(df).outType(double.class).apply();
 		assertEquals(20, convexHull.vertices().size());
 		assertConvex(convexHull, epsilon);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/identity/IdentityTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/identity/IdentityTest.java
@@ -46,17 +46,17 @@ public class IdentityTest extends AbstractOpTest {
 	public void testIdentity() {
 		Byte b = 35;
 		final Object ib = b;
-		op("identity").input(b).mutate();
+		ops.op("identity").input(b).mutate();
 		assertSame(b, ib);
 
 		int i = 23;
 		final Object ii = i; 
-		op("identity").input(i).mutate();
+		ops.op("identity").input(i).mutate();
 		assertSame(i, ii);
 
 		String s = "hello";
 		final Object is = s;
-		op("identity").input(s).mutate();
+		ops.op("identity").input(s).mutate();
 		assertSame(s, is);
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/ascii/ASCIITest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/ascii/ASCIITest.java
@@ -62,9 +62,9 @@ public class ASCIITest extends AbstractOpTest {
 			}
 		}
 		final Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(array, width, len);
-		final Pair<UnsignedByteType, UnsignedByteType> minMax = op("stats.minMax").input(img)
+		final Pair<UnsignedByteType, UnsignedByteType> minMax = ops.op("stats.minMax").input(img)
 				.outType(new Nil<Pair<UnsignedByteType, UnsignedByteType>>() {}).apply();
-		final String ascii = op("image.ascii").input(img, minMax.getA(), minMax.getB())
+		final String ascii = ops.op("image.ascii").input(img, minMax.getA(), minMax.getB())
 				.outType(String.class).apply();
 		for (int i = 0; i < len; i++) {
 			for (int j = 0; j < width; j++) {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DefaultDistanceTransformTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DefaultDistanceTransformTest.java
@@ -56,26 +56,26 @@ public class DefaultDistanceTransformTest extends AbstractOpTest {
 		ThreadService ts = context.getService(ThreadService.class);
 
 		// create 4D image
-		final RandomAccessibleInterval<BitType> in = op("create.img")
+		final RandomAccessibleInterval<BitType> in = ops.op("create.img")
 				.input(new FinalInterval(20, 20, 5, 3), new BitType())
 				.outType(new Nil<RandomAccessibleInterval<BitType>>() {}).apply();
 		generate4DImg(in);
 
 		// create output image
-		RandomAccessibleInterval<FloatType> out = op("create.img").input(in, new FloatType())
+		RandomAccessibleInterval<FloatType> out = ops.op("create.img").input(in, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		/*
 		 * test normal DT
 		 */
-		op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
+		ops.op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
 		compareResults(out, in, new double[] { 1, 1, 1, 1 });
 
 		/*
 		 * test calibrated DT
 		 */
 		final double[] calibration = new double[] { 3.74, 5.19, 1.21, 2.21 };
-		op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
+		ops.op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
 				.compute();
 		compareResults(out, in, calibration);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DistanceTransform2DTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DistanceTransform2DTest.java
@@ -55,26 +55,26 @@ public class DistanceTransform2DTest extends AbstractOpTest {
 		ThreadService ts = context.getService(ThreadService.class);
 
 		// create 2D image
-		final RandomAccessibleInterval<BitType> in = op("create.img")
+		final RandomAccessibleInterval<BitType> in = ops.op("create.img")
 				.input(new FinalInterval(20, 20), new BitType())
 				.outType(new Nil<RandomAccessibleInterval<BitType>>() {}).apply();
 		generate2DImg(in);
 
 		// create output image
-		RandomAccessibleInterval<FloatType> out = op("create.img").input(in, new FloatType())
+		RandomAccessibleInterval<FloatType> out = ops.op("create.img").input(in, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		/*
 		 * test normal DT
 		 */
-		op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
+		ops.op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
 		compareResults(out, in, new double[] { 1, 1 });
 
 		/*
 		 * test calibrated DT
 		 */
 		final double[] calibration = new double[] { 2.54, 1.77 };
-		op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
+		ops.op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
 				.compute();
 		compareResults(out, in, calibration);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DistanceTransform3DTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/distancetransform/DistanceTransform3DTest.java
@@ -57,26 +57,26 @@ public class DistanceTransform3DTest extends AbstractOpTest {
 		ThreadService ts = context.getService(ThreadService.class);
 
 		// create 3D image
-		final RandomAccessibleInterval<BitType> in = op("create.img")
+		final RandomAccessibleInterval<BitType> in = ops.op("create.img")
 				.input(new FinalInterval(20, 20, 5), new BitType())
 				.outType(new Nil<RandomAccessibleInterval<BitType>>() {}).apply();
 		generate3DImg(in);
 
 		// create output image
-		RandomAccessibleInterval<FloatType> out = op("create.img").input(in, new FloatType())
+		RandomAccessibleInterval<FloatType> out = ops.op("create.img").input(in, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 
 		/*
 		 * test normal DT
 		 */
-		op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
+		ops.op("image.distanceTransform").input(in, ts.getExecutorService()).output(out).compute();
 		compareResults(out, in, new double[] { 1, 1, 1 });
 
 		/*
 		 * test calibrated DT
 		 */
 		final double[] calibration = new double[] { 3.74, 5.19, 1.21 };
-		op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
+		ops.op("image.distanceTransform").input(in, calibration, ts.getExecutorService()).output(out)
 				.compute();
 		compareResults(out, in, calibration);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/equation/CoordinateEquationTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/equation/CoordinateEquationTest.java
@@ -70,21 +70,21 @@ public class CoordinateEquationTest extends AbstractOpTest {
 	@Test
 	public void testEquation2DOp() {
 
-		final IterableInterval<DoubleType> image = op("create.img").input(dimensions,
+		final IterableInterval<DoubleType> image = ops.op("create.img").input(dimensions,
 				new DoubleType()).outType(new Nil<IterableInterval<DoubleType>>() {}).apply();
 
 		// implement x^2+y^2 taking into account the calibration
 		final Function<long[], Double> op = (coords) -> Math.pow(start[0] + coords[0] * spacing[0], 2)
 				+ Math.pow(start[1] + coords[1] * spacing[1], 2);
 		
-		final Function<long[], Double> wrapped = ops.wrap(op,
+		final Function<long[], Double> wrapped = ops.env().opify(op,
 			new Nil<Function<long[], Double>>()
 			{}.getType());
 		
-		op("image.equation").input(wrapped).output(image).compute();
+		ops.op("image.equation").input(wrapped).output(image).compute();
 
 		DoubleType sum = new DoubleType();
-		op("stats.sum").input(image).output(sum).compute();
+		ops.op("stats.sum").input(image).output(sum).compute();
 
 		assertEquals(6801.346801346799, sum.getRealDouble(), 0.00001);
 
@@ -100,7 +100,7 @@ public class CoordinateEquationTest extends AbstractOpTest {
 
 		final Dimensions dimensions4D = new FinalDimensions(size4D);
 
-		final Img<ShortType> image = op("create.img").input(dimensions4D,
+		final Img<ShortType> image = ops.op("create.img").input(dimensions4D,
 			new ShortType()).outType(new Nil<Img<ShortType>>()
 		{}).apply();
 
@@ -113,11 +113,11 @@ public class CoordinateEquationTest extends AbstractOpTest {
 			return result;
 		};
 
-		Function<long[], Double> wrapped = ops.wrap(op,
+		Function<long[], Double> wrapped = ops.env().opify(op,
 			new Nil<Function<long[], Double>>()
 			{}.getType());
 
-		op("image.equation").input(wrapped).output(image).compute();
+		ops.op("image.equation").input(wrapped).output(image).compute();
 
 		final RandomAccess<ShortType> ra = image.randomAccess();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/fill/FillTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/fill/FillTest.java
@@ -56,7 +56,7 @@ public class FillTest extends AbstractOpTest {
 
 	@Test
 	public void testDefaultFill() {
-		op("image.fill").input(new ByteType((byte) 10)).output(out).compute();
+		ops.op("image.fill").input(new ByteType((byte) 10)).output(out).compute();
 
 		for (ByteType px : out)
 			assertEquals(px.get(), 10);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/histogram/DefaultHistogramTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/histogram/DefaultHistogramTest.java
@@ -31,7 +31,7 @@ public class DefaultHistogramTest extends AbstractOpTest {
 	@Test
 	public void testRegression() {
 		Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(data, 8, 8);
-		Histogram1d<UnsignedByteType> histogram = op("image.histogram").input(img, 10)
+		Histogram1d<UnsignedByteType> histogram = ops.op("image.histogram").input(img, 10)
 				.outType(new Nil<Histogram1d<UnsignedByteType>>() {}).apply();
 
 		Assertions.assertEquals(false, histogram.hasTails());

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/IntegralImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/IntegralImgTest.java
@@ -78,13 +78,13 @@ public class IntegralImgTest extends AbstractOpTest {
 	public void testIntegralImageSimilarity() {
 		// should match DefaultIntegralImg
 		Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<DoubleType>> defaultOp = Computers
-				.match(ops, "image.integral", new Nil<RandomAccessibleInterval<ByteType>>() {
+				.match(ops.env(), "image.integral", new Nil<RandomAccessibleInterval<ByteType>>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});
 		defaultOp.compute(in, out1);
 
 		// should match WrappedIntegralImg
-		out2 = op("image.integral").input(
+		out2 = ops.op("image.integral").input(
 				in).outType(new Nil<RandomAccessibleInterval<DoubleType>>() {}).apply();
 
 		// Remove 0s from integralImg by shifting its interval by +1

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/SquareIntegralImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/SquareIntegralImgTest.java
@@ -65,7 +65,7 @@ public class SquareIntegralImgTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testSquareIntegralImageCorrectness() {
-		op("image.squareIntegral").input(generateKnownByteArrayTestImg()).output(out).compute();
+		ops.op("image.squareIntegral").input(generateKnownByteArrayTestImg()).output(out).compute();
 
 		Img<ByteType> bytes = generateKnownSquareIntegralImage();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/invert/InvertTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/invert/InvertTest.java
@@ -276,7 +276,7 @@ public class InvertTest extends AbstractOpTest {
 		min.setReal(type.getMinValue());
 		final T max = type.copy();
 		max.setReal(type.getMaxValue());
-		op("image.invert").input(in).output(out).compute();
+		ops.op("image.invert").input(in).output(out).compute();
 
 		defaultCompare(in, out, min, max);
 	}
@@ -284,7 +284,7 @@ public class InvertTest extends AbstractOpTest {
 	private <T extends RealType<T>> void assertDefaultInvertMinMaxProvided(final Img<T> in, final Img<T> out,
 			final T min, final T max) {
 
-		op("image.invert").input(in, min, max).output(out).compute();
+		ops.op("image.invert").input(in, min, max).output(out).compute();
 
 		defaultCompare(in, out, min, max);
 	}
@@ -314,7 +314,7 @@ public class InvertTest extends AbstractOpTest {
 			final T min, final T max) {
 
 		// unsigned type test
-		op("image.invert").input(in, min, max).output(out).compute();
+		ops.op("image.invert").input(in, min, max).output(out).compute();
 
 		integerCompare(in, out, min, max);
 
@@ -322,7 +322,7 @@ public class InvertTest extends AbstractOpTest {
 
 	private <T extends IntegerType<T>> void assertIntegerInvert(final Img<T> in, final Img<T> out) {
 
-		op("image.invert").input(in).output(out).compute();
+		ops.op("image.invert").input(in).output(out).compute();
 
 		Cursor<T> inCursor = in.localizingCursor();
 		Cursor<T> outCursor = out.localizingCursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
@@ -57,11 +57,11 @@ public class NormalizeTest extends AbstractOpTest {
 		Img<ByteType> in = TestImgGeneration.byteArray(true, 5, 5);
 		Img<ByteType> out = in.factory().create(in, new ByteType());
 
-		op("image.normalize").input(in).output(out).compute();
+		ops.op("image.normalize").input(in).output(out).compute();
 
-		final Pair<ByteType, ByteType> minMax = op("stats.minMax").input(in)
+		final Pair<ByteType, ByteType> minMax = ops.op("stats.minMax").input(in)
 				.outType(new Nil<Pair<ByteType, ByteType>>() {}).apply();
-		final Pair<ByteType, ByteType> minMax2 = op("stats.minMax").input(out)
+		final Pair<ByteType, ByteType> minMax2 = ops.op("stats.minMax").input(out)
 				.outType(new Nil<Pair<ByteType, ByteType>>() {}).apply();
 
 		assertEquals(minMax2.getA().get(), Byte.MIN_VALUE);
@@ -70,9 +70,9 @@ public class NormalizeTest extends AbstractOpTest {
 		final ByteType min = new ByteType((byte) in.firstElement().getMinValue());
 		final ByteType max = new ByteType((byte) in.firstElement().getMaxValue());
 
-		final IterableInterval<ByteType> lazyOut = op("image.normalize").input(in)
+		final IterableInterval<ByteType> lazyOut = ops.op("image.normalize").input(in)
 				.outType(new Nil<IterableInterval<ByteType>>() {}).apply();
-		final IterableInterval<ByteType> notLazyOut = op("image.normalize")
+		final IterableInterval<ByteType> notLazyOut = ops.op("image.normalize")
 				.input(in, minMax.getA(), minMax.getB(), min, max).outType(new Nil<IterableInterval<ByteType>>() {})
 				.apply();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigmaTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigmaTest.java
@@ -66,75 +66,75 @@ public class WatershedBinarySingleSigmaTest extends AbstractOpTest {
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
 
 		// threshold it
-		RandomAccessibleInterval<BitType> thresholdedImg = op("create.img").input(watershedTestImg, new BitType())
+		RandomAccessibleInterval<BitType> thresholdedImg = ops.op("create.img").input(watershedTestImg, new BitType())
 				.outType(new Nil<RandomAccessibleInterval<BitType>>() {}).apply();
-		op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
+		ops.op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
 				.output(Views.flatIterable(thresholdedImg)).compute();
 
 		// compute inverted distance transform and smooth it with gaussian
 		// filtering
-		final RandomAccessibleInterval<FloatType> distMap = op("create.img").input(thresholdedImg, new FloatType())
+		final RandomAccessibleInterval<FloatType> distMap = ops.op("create.img").input(thresholdedImg, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
-		final RandomAccessibleInterval<FloatType> invertedDistMap = op("create.img").input(distMap, new FloatType())
+		ops.op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
+		final RandomAccessibleInterval<FloatType> invertedDistMap = ops.op("create.img").input(distMap, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap)).compute();
+		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap)).compute();
 
 		Double sigma = 3.0;
-		final RandomAccessibleInterval<FloatType> gauss = op("create.img").input(invertedDistMap, new FloatType())
+		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img").input(invertedDistMap, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("filter.gauss").input(invertedDistMap, es, sigma).output(gauss).compute();
+		ops.op("filter.gauss").input(invertedDistMap, es, sigma).output(gauss).compute();
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out1 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out1 = ops.op("image.watershed")
 				.input(thresholdedImg, true, false, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut1 = op("image.watershed").input(gauss, true, false, thresholdedImg)
+		final ImgLabeling<Integer, IntType> expOut1 = ops.op("image.watershed").input(gauss, true, false, thresholdedImg)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut1, out1);
 
-		final ImgLabeling<Integer, IntType> out2 = op("image.watershed").input(thresholdedImg, true, false, sigma, es)
+		final ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed").input(thresholdedImg, true, false, sigma, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut2 = op("image.watershed").input(gauss, true, false)
+		final ImgLabeling<Integer, IntType> expOut2 = ops.op("image.watershed").input(gauss, true, false)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut2, out2);
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out3 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed")
 				.input(thresholdedImg, true, true, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut3 = op("image.watershed").input(gauss, true, true, thresholdedImg)
+		final ImgLabeling<Integer, IntType> expOut3 = ops.op("image.watershed").input(gauss, true, true, thresholdedImg)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut3, out3);
 
-		final ImgLabeling<Integer, IntType> out4 = op("image.watershed").input(thresholdedImg, true, true, sigma, es)
+		final ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed").input(thresholdedImg, true, true, sigma, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut4 = op("image.watershed").input(gauss, true, true)
+		final ImgLabeling<Integer, IntType> expOut4 = ops.op("image.watershed").input(gauss, true, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut4, out4);
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out5 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out5 = ops.op("image.watershed")
 				.input(thresholdedImg, false, true, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut5 = op("image.watershed").input(gauss, false, true, thresholdedImg)
+		final ImgLabeling<Integer, IntType> expOut5 = ops.op("image.watershed").input(gauss, false, true, thresholdedImg)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut5, out5);
 
-		final ImgLabeling<Integer, IntType> out6 = op("image.watershed").input(thresholdedImg, false, true, sigma, es)
+		final ImgLabeling<Integer, IntType> out6 = ops.op("image.watershed").input(thresholdedImg, false, true, sigma, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut6 = op("image.watershed").input(gauss, false, true)
+		final ImgLabeling<Integer, IntType> expOut6 = ops.op("image.watershed").input(gauss, false, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut6, out6);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinaryTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinaryTest.java
@@ -66,83 +66,83 @@ public class WatershedBinaryTest extends AbstractOpTest {
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
 
 		// threshold it
-		RandomAccessibleInterval<BitType> thresholdedImg = op("create.img")
+		RandomAccessibleInterval<BitType> thresholdedImg = ops.op("create.img")
 				.input(watershedTestImg, new BitType()).outType(new Nil<RandomAccessibleInterval<BitType>>() {})
 				.apply();
-		op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
+		ops.op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
 				.output(Views.flatIterable(thresholdedImg)).compute();
 
 		// compute inverted distance transform and smooth it with gaussian
 		// filtering
-		final RandomAccessibleInterval<FloatType> distMap = op("create.img")
+		final RandomAccessibleInterval<FloatType> distMap = ops.op("create.img")
 				.input(thresholdedImg, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {})
 				.apply();
-		op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
-		final RandomAccessibleInterval<FloatType> invertedDistMap = op("create.img")
+		ops.op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
+		final RandomAccessibleInterval<FloatType> invertedDistMap = ops.op("create.img")
 				.input(distMap, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 		double[] sigma = { 3.0, 3.0, 0.0 };
-		op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap))
+		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap))
 				.compute();
 
-		final RandomAccessibleInterval<FloatType> gauss = op("create.img")
+		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img")
 				.input(invertedDistMap, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {})
 				.apply();
-		op("filter.gauss").input(invertedDistMap, es, new double[] { sigma[0], sigma[1] }).output(gauss)
+		ops.op("filter.gauss").input(invertedDistMap, es, new double[] { sigma[0], sigma[1] }).output(gauss)
 				.compute();
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out1 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out1 = ops.op("image.watershed")
 				.input(thresholdedImg, true, false, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut1 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> expOut1 = ops.op("image.watershed")
 				.input(gauss, true, false, thresholdedImg).outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut1, out1);
 
-		final ImgLabeling<Integer, IntType> out2 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed")
 				.input(thresholdedImg, true, false, sigma, es).outType(new Nil<ImgLabeling<Integer, IntType>>() {})
 				.apply();
 
-		final ImgLabeling<Integer, IntType> expOut2 = op("image.watershed").input(gauss, true, false)
+		final ImgLabeling<Integer, IntType> expOut2 = ops.op("image.watershed").input(gauss, true, false)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut2, out2);
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out3 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed")
 				.input(thresholdedImg, true, true, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut3 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> expOut3 = ops.op("image.watershed")
 				.input(gauss, true, true, thresholdedImg).outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut3, out3);
 
-		final ImgLabeling<Integer, IntType> out4 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed")
 				.input(thresholdedImg, true, true, sigma, es).outType(new Nil<ImgLabeling<Integer, IntType>>() {})
 				.apply();
 
-		final ImgLabeling<Integer, IntType> expOut4 = op("image.watershed").input(gauss, true, true)
+		final ImgLabeling<Integer, IntType> expOut4 = ops.op("image.watershed").input(gauss, true, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut4, out4);
 
 		// compute result
-		final ImgLabeling<Integer, IntType> out5 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out5 = ops.op("image.watershed")
 				.input(thresholdedImg, false, true, sigma, thresholdedImg, es)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
-		final ImgLabeling<Integer, IntType> expOut5 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> expOut5 = ops.op("image.watershed")
 				.input(gauss, false, true, thresholdedImg).outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut5, out5);
 
-		final ImgLabeling<Integer, IntType> out6 = op("image.watershed")
+		final ImgLabeling<Integer, IntType> out6 = ops.op("image.watershed")
 				.input(thresholdedImg, false, true, sigma, es).outType(new Nil<ImgLabeling<Integer, IntType>>() {})
 				.apply();
 
-		final ImgLabeling<Integer, IntType> expOut6 = op("image.watershed").input(gauss, false, true)
+		final ImgLabeling<Integer, IntType> expOut6 = ops.op("image.watershed").input(gauss, false, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(expOut6, out6);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedSeededTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedSeededTest.java
@@ -88,7 +88,7 @@ public class WatershedSeededTest extends AbstractOpTest {
 		ra.get().set(true);
 
 		// compute labeled seeds
-		final ImgLabeling<Integer, IntType> labeledSeeds = op("labeling.cca")
+		final ImgLabeling<Integer, IntType> labeledSeeds = ops.op("labeling.cca")
 				.input(bits, es, StructuringElement.EIGHT_CONNECTED)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
@@ -111,13 +111,13 @@ public class WatershedSeededTest extends AbstractOpTest {
 		 * use 8-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out = op("image.watershed").input(in, seeds, true, false)
+		ImgLabeling<Integer, IntType> out = ops.op("image.watershed").input(in, seeds, true, false)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out, seeds, mask, false, false);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out2 = op("image.watershed").input(in, seeds, true, true)
+		ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed").input(in, seeds, true, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out2, seeds, mask, true, false);
@@ -126,13 +126,13 @@ public class WatershedSeededTest extends AbstractOpTest {
 		 * use 4-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out3 = op("image.watershed").input(in, seeds, false, false)
+		ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed").input(in, seeds, false, false)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out3, seeds, mask, false, false);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out4 = op("image.watershed").input(in, seeds, false, true)
+		ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed").input(in, seeds, false, true)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out4, seeds, mask, true, false);
@@ -158,13 +158,13 @@ public class WatershedSeededTest extends AbstractOpTest {
 		 * use 8-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out = op("image.watershed").input(in, seeds, true, false, mask)
+		ImgLabeling<Integer, IntType> out = ops.op("image.watershed").input(in, seeds, true, false, mask)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out, seeds, mask, false, true);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out2 = op("image.watershed").input(in, seeds, true, true, mask)
+		ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed").input(in, seeds, true, true, mask)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out2, seeds, mask, true, true);
@@ -173,13 +173,13 @@ public class WatershedSeededTest extends AbstractOpTest {
 		 * use 4-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out3 = op("image.watershed").input(in, seeds, false, false, mask)
+		ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed").input(in, seeds, false, false, mask)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out3, seeds, mask, false, true);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out4 = op("image.watershed").input(in, seeds, false, true, mask)
+		ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed").input(in, seeds, false, true, mask)
 				.outType(new Nil<ImgLabeling<Integer, IntType>>() {}).apply();
 
 		assertResults(in, out4, seeds, mask, true, true);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedTest.java
@@ -71,24 +71,33 @@ public class WatershedTest extends AbstractOpTest {
 		ExecutorService es = context.getService(ThreadService.class).getExecutorService();
 
 		// threshold it
-		RandomAccessibleInterval<BitType> thresholdedImg = op("create.img")
+		RandomAccessibleInterval<BitType> thresholdedImg = ops.op("create.img")
 				.input(watershedTestImg, new BitType()).outType(new Nil<RandomAccessibleInterval<BitType>>() {})
 				.apply();
-		op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
+		ops.op("threshold.apply").input(Views.flatIterable(watershedTestImg), new FloatType(1))
 				.output(Views.flatIterable(thresholdedImg)).compute();
 
 		// compute inverted distance transform and smooth it with gaussian
 		// filtering
 
-		final RandomAccessibleInterval<FloatType> distMap = new OpBuilder(ops,
-				"create.img").input(thresholdedImg, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
-		final RandomAccessibleInterval<FloatType> invertedDistMap = new OpBuilder(
-				ops, "create.img").input(distMap, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap)).compute();
-		final RandomAccessibleInterval<FloatType> gauss = new OpBuilder(ops,
-				"create.img").input(invertedDistMap, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		op("filter.gauss").input(invertedDistMap, es, new double[] { 3, 3 }).output(gauss).compute();
+		final RandomAccessibleInterval<FloatType> distMap = ops.op("create.img")
+			.input(thresholdedImg, new FloatType()).outType(
+				new Nil<RandomAccessibleInterval<FloatType>>()
+				{}).apply();
+		ops.op("image.distanceTransform").input(thresholdedImg, es).output(distMap)
+			.compute();
+		final RandomAccessibleInterval<FloatType> invertedDistMap = ops.op(
+			"create.img").input(distMap, new FloatType()).outType(
+				new Nil<RandomAccessibleInterval<FloatType>>()
+				{}).apply();
+		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(
+			invertedDistMap)).compute();
+		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img")
+			.input(invertedDistMap, new FloatType()).outType(
+				new Nil<RandomAccessibleInterval<FloatType>>()
+				{}).apply();
+		ops.op("filter.gauss").input(invertedDistMap, es, new double[] { 3, 3 })
+			.output(gauss).compute();
 
 		testWithoutMask(gauss);
 
@@ -108,13 +117,13 @@ public class WatershedTest extends AbstractOpTest {
 		 * use 8-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out = op("image.watershed")
+		ImgLabeling<Integer, IntType> out = ops.op("image.watershed")
 				.input(in, true, false).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out, mask, true, false, false);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out2 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed")
 				.input(in, true, true).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out2, mask, true, true, false);
@@ -123,13 +132,13 @@ public class WatershedTest extends AbstractOpTest {
 		 * use 4-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out3 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed")
 				.input(in, false, false).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out3, mask, false, false, false);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out4 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed")
 				.input(in, false, true).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out4, mask, false, true, false);
@@ -155,13 +164,13 @@ public class WatershedTest extends AbstractOpTest {
 		 * use 8-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out = op("image.watershed")
+		ImgLabeling<Integer, IntType> out = ops.op("image.watershed")
 				.input(in, true, false, mask).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out, mask, true, false, true);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out2 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out2 = ops.op("image.watershed")
 				.input(in, true, true, mask).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out2, mask, true, true, true);
@@ -170,13 +179,13 @@ public class WatershedTest extends AbstractOpTest {
 		 * use 4-connected neighborhood
 		 */
 		// compute result without watersheds
-		ImgLabeling<Integer, IntType> out3 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out3 = ops.op("image.watershed")
 				.input(in, false, false, mask).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out3, mask, false, false, true);
 
 		// compute result with watersheds
-		ImgLabeling<Integer, IntType> out4 = op("image.watershed")
+		ImgLabeling<Integer, IntType> out4 = ops.op("image.watershed")
 				.input(in, false, true, mask).outType(new Nil<ImgLabeling<Integer, IntType>>(){}).apply();
 
 		assertResults(in, out4, mask, false, true, true);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
@@ -74,13 +74,13 @@ public class ImageMomentsTest extends AbstractOpTest {
 	public void testMoments() {
 
 		DoubleType moment00 = new DoubleType();
-		op("imageMoments.moment00").input(img).output(moment00).compute();
+		ops.op("imageMoments.moment00").input(img).output(moment00).compute();
 		DoubleType moment10 = new DoubleType();
-		op("imageMoments.moment10").input(img).output(moment10).compute();
+		ops.op("imageMoments.moment10").input(img).output(moment10).compute();
 		DoubleType moment01 = new DoubleType();
-		op("imageMoments.moment01").input(img).output(moment01).compute();
+		ops.op("imageMoments.moment01").input(img).output(moment01).compute();
 		DoubleType moment11 = new DoubleType();
-		op("imageMoments.moment11").input(img).output(moment11).compute();
+		ops.op("imageMoments.moment11").input(img).output(moment11).compute();
 		assertEquals(1277534.0, moment00.getRealDouble(), EPSILON, "ImageMoments.Moment00");
 		assertEquals(6.3018047E7, moment10.getRealDouble(), EPSILON, "ImageMoments.Moment10");
 		assertEquals(6.3535172E7, moment01.getRealDouble(), EPSILON, "ImageMoments.Moment01");
@@ -93,31 +93,31 @@ public class ImageMomentsTest extends AbstractOpTest {
 	@Test
 	public void testCentralMoments() {
 		assertEquals(-5275876.956702709,
-				op("imageMoments.centralMoment11").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment11").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment11");
 		assertEquals(1.0694469880269902E9,
-				op("imageMoments.centralMoment02").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment02").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment02");
 		assertEquals(1.0585772432642114E9,
-				op("imageMoments.centralMoment20").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment20").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment20");
 		assertEquals(5478324.271281097,
-				op("imageMoments.centralMoment12").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment12").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment12");
 		assertEquals(-2.1636455685489437E8,
-				op("imageMoments.centralMoment21").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment21").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment21");
 		assertEquals(1.7355602329912126E8,
-				op("imageMoments.centralMoment30").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment30").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment30");
 		assertEquals(-4.099421316116555E8,
-				op("imageMoments.centralMoment03").input(img).outType(DoubleType.class).apply()
+				ops.op("imageMoments.centralMoment03").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment03");
 	}
@@ -128,37 +128,37 @@ public class ImageMomentsTest extends AbstractOpTest {
 	@Test
 	public void testNormalizedCentralMoments() {
 		assertEquals(-3.2325832933879204E-6,
-				op("imageMoments.normalizedCentralMoment11").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment11").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment11");
 
 		assertEquals(6.552610106398286E-4,
-				op("imageMoments.normalizedCentralMoment02").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment02").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment02");
 
 		assertEquals(6.486010078361372E-4,
-				op("imageMoments.normalizedCentralMoment20").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment20").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment20");
 
 		assertEquals(2.969727272701925E-9,
-				op("imageMoments.normalizedCentralMoment12").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment12").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment12");
 
 		assertEquals(-1.1728837022440002E-7,
-				op("imageMoments.normalizedCentralMoment21").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment21").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment21");
 
 		assertEquals(9.408242926327751E-8,
-				op("imageMoments.normalizedCentralMoment30").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment30").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment30");
 
 		assertEquals(-2.22224218245127E-7,
-				op("imageMoments.normalizedCentralMoment03").input(img).outType(DoubleType.class)
+				ops.op("imageMoments.normalizedCentralMoment03").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
 				EPSILON, "ImageMoments.NormalizedCentralMoment03");
 	}
@@ -168,25 +168,25 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testHuMoments() {
-		assertEquals(0.001303862018475966, op("imageMoments.huMoment1").input(img)
+		assertEquals(0.001303862018475966, ops.op("imageMoments.huMoment1").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment1");
-		assertEquals(8.615401633994056e-11, op("imageMoments.huMoment2").input(img)
+		assertEquals(8.615401633994056e-11, ops.op("imageMoments.huMoment2").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment2");
-		assertEquals(2.406124306990366e-14, op("imageMoments.huMoment3").input(img)
+		assertEquals(2.406124306990366e-14, ops.op("imageMoments.huMoment3").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment3");
-		assertEquals(1.246879188175627e-13, op("imageMoments.huMoment4").input(img)
+		assertEquals(1.246879188175627e-13, ops.op("imageMoments.huMoment4").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment4");
-		assertEquals(-6.610443880647384e-27, op("imageMoments.huMoment5").input(img)
+		assertEquals(-6.610443880647384e-27, ops.op("imageMoments.huMoment5").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment5");
-		assertEquals(1.131019166855569e-18, op("imageMoments.huMoment6").input(img)
+		assertEquals(1.131019166855569e-18, ops.op("imageMoments.huMoment6").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment6");
-		assertEquals(1.716256940536518e-27, op("imageMoments.huMoment7").input(img)
+		assertEquals(1.716256940536518e-27, ops.op("imageMoments.huMoment7").input(img)
 			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
 			"ImageMoments.HuMoment7");
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/labeling/MergeLabelingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/labeling/MergeLabelingTest.java
@@ -58,7 +58,7 @@ public class MergeLabelingTest extends AbstractOpTest {
 	@BeforeEach
 	public void setUpTest() {
 		super.setUp();
-		in1 = op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
+		in1 = ops.op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
 				.outType(new Nil<ImgLabeling<Integer, ByteType>>() {}).apply();
 		RandomAccess<LabelingType<Integer>> randomAccess = in1.randomAccess();
 		randomAccess.setPosition(new int[] { 0, 0 });
@@ -70,7 +70,7 @@ public class MergeLabelingTest extends AbstractOpTest {
 		randomAccess.setPosition(new int[] { 1, 1 });
 		randomAccess.get().add(3);
 
-		in2 = op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
+		in2 = ops.op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
 				.outType(new Nil<ImgLabeling<Integer, ByteType>>() {}).apply();
 		randomAccess = in2.randomAccess();
 		randomAccess.setPosition(new int[] { 0, 0 });
@@ -82,13 +82,13 @@ public class MergeLabelingTest extends AbstractOpTest {
 		randomAccess.setPosition(new int[] { 1, 1 });
 		randomAccess.get().add(13);
 
-		out = op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
+		out = ops.op("create.imgLabeling").input(new FinalInterval(2, 2), new ByteType())
 				.outType(new Nil<ImgLabeling<Integer, ByteType>>() {}).apply();
 	}
 
 	@Test
 	public void testMerging() {
-		final ImgLabeling<Integer, ByteType> run = op("labeling.merge").input(in1, in2)
+		final ImgLabeling<Integer, ByteType> run = ops.op("labeling.merge").input(in1, in2)
 				.outType(new Nil<ImgLabeling<Integer, ByteType>>() {}).apply();
 		assertTrue(run.firstElement().contains(0));
 		assertTrue(run.firstElement().contains(10));
@@ -97,14 +97,14 @@ public class MergeLabelingTest extends AbstractOpTest {
 
 	@Test
 	public void testMask() {
-		final Img<BitType> mask = op("create.img").input(in1, new BitType())
+		final Img<BitType> mask = ops.op("create.img").input(in1, new BitType())
 				.outType(new Nil<Img<BitType>>() {}).apply();
 		final RandomAccess<BitType> maskRA = mask.randomAccess();
 		maskRA.setPosition(new int[] { 0, 0 });
 		maskRA.get().set(true);
 		maskRA.setPosition(new int[] { 1, 1 });
 		maskRA.get().set(true);
-		out = op("labeling.merge").input(in1, in2, mask)
+		out = ops.op("labeling.merge").input(in1, in2, mask)
 				.outType(new Nil<ImgLabeling<Integer, ByteType>>() {}).apply();
 		final RandomAccess<LabelingType<Integer>> outRA = out.randomAccess();
 		outRA.setPosition(new int[] { 0, 0 });

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/linalg/rotate/Rotate3dTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/linalg/rotate/Rotate3dTest.java
@@ -57,7 +57,7 @@ public class Rotate3dTest extends AbstractOpTest {
 		final AxisAngle4d axisAngle = new AxisAngle4d(Math.PI / 2.0, 0, 0, 1);
 		final Vector3d expected = xAxis.rotate(new Quaterniond(axisAngle));
 
-		final Vector3d result = op("linalg.rotate").input(in, axisAngle).outType(Vector3d.class).apply();
+		final Vector3d result = ops.op("linalg.rotate").input(in, axisAngle).outType(Vector3d.class).apply();
 
 		assertEquals(expected, result, "Rotation is incorrect");
 	}
@@ -67,7 +67,7 @@ public class Rotate3dTest extends AbstractOpTest {
 		final Vector3d xAxis = new Vector3d(1, 0, 0);
 		final Vector3d in = new Vector3d(xAxis);
 
-		final Vector3d result = op("linalg.rotate").input(in, IDENTITY).outType(Vector3d.class).apply();
+		final Vector3d result = ops.op("linalg.rotate").input(in, IDENTITY).outType(Vector3d.class).apply();
 
 		assertNotSame(in, result, "Op should create a new object for output");
 		assertEquals(xAxis, result, "Rotation is incorrect");

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/linalg/rotate/Rotate3fTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/linalg/rotate/Rotate3fTest.java
@@ -58,7 +58,7 @@ public class Rotate3fTest extends AbstractOpTest {
 			1);
 		final Vector3f expected = xAxis.rotate(new Quaternionf(axisAngle));
 
-		final Vector3f result = op("linalg.rotate").input(in, axisAngle).outType(Vector3f.class).apply();
+		final Vector3f result = ops.op("linalg.rotate").input(in, axisAngle).outType(Vector3f.class).apply();
 
 		assertEquals(expected, result, "Rotation is incorrect");
 	}
@@ -68,7 +68,7 @@ public class Rotate3fTest extends AbstractOpTest {
 		final Vector3f xAxis = new Vector3f(1, 0, 0);
 		final Vector3f in = new Vector3f(xAxis);
 
-		final Vector3f result = op("linalg.rotate").input(in, IDENTITY).outType(Vector3f.class).apply();
+		final Vector3f result = ops.op("linalg.rotate").input(in, IDENTITY).outType(Vector3f.class).apply();
 
 		assertNotSame(in, result, "Op should create a new object for output");
 		assertEquals(xAxis, result, "Rotation is incorrect");

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/logic/BooleanTypeLogicTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/logic/BooleanTypeLogicTest.java
@@ -47,84 +47,84 @@ public class BooleanTypeLogicTest extends AbstractOpTest {
 
 	@Test
 	public void testAnd() {
-		assertTrue(op("logic.and").input(new BitType(true), new BitType(true)).outType(BitType.class)
+		assertTrue(ops.op("logic.and").input(new BitType(true), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertFalse(op("logic.and").input(new BitType(true), new BitType(false)).outType(BitType.class)
+		assertFalse(ops.op("logic.and").input(new BitType(true), new BitType(false)).outType(BitType.class)
 				.apply().get());
-		assertFalse(op("logic.and").input(new BitType(false), new BitType(true)).outType(BitType.class)
+		assertFalse(ops.op("logic.and").input(new BitType(false), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertFalse(op("logic.and").input(new BitType(false), new BitType(false)).outType(BitType.class)
+		assertFalse(ops.op("logic.and").input(new BitType(false), new BitType(false)).outType(BitType.class)
 				.apply().get());
 	}
 
 	@Test
 	public void testComparableGreaterThan() {
-		assertTrue(op("logic.greaterThan").input(5.0, 3.0).outType(BitType.class).apply().get());
-		assertFalse(op("logic.greaterThan").input(5.0, 6.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.greaterThan").input(5.0, 3.0).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.greaterThan").input(5.0, 6.0).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testComparableGreaterThanOrEqual() {
-		assertTrue(op("logic.greaterThanOrEqual").input(5.0, 3.0).outType(BitType.class).apply().get());
-		assertTrue(op("logic.greaterThanOrEqual").input(5.0, 5.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.greaterThanOrEqual").input(5.0, 3.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.greaterThanOrEqual").input(5.0, 5.0).outType(BitType.class).apply().get());
 		assertFalse(
-				op("logic.greaterThanOrEqual").input(5.0, 6.0).outType(BitType.class).apply().get());
+				ops.op("logic.greaterThanOrEqual").input(5.0, 6.0).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testComparableLessThan() {
-		assertFalse(op("logic.lessThan").input(5.0, 3.0).outType(BitType.class).apply().get());
-		assertTrue(op("logic.lessThan").input(5.0, 6.0).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.lessThan").input(5.0, 3.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.lessThan").input(5.0, 6.0).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testComparableLessThanOrEqual() {
-		assertFalse(op("logic.lessThanOrEqual").input(5.0, 3.0).outType(BitType.class).apply().get());
-		assertTrue(op("logic.lessThanOrEqual").input(5.0, 6.0).outType(BitType.class).apply().get());
-		assertTrue(op("logic.lessThanOrEqual").input(5.0, 5.0).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.lessThanOrEqual").input(5.0, 3.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.lessThanOrEqual").input(5.0, 6.0).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.lessThanOrEqual").input(5.0, 5.0).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testObjectsEqual() {
-		assertFalse(op("logic.equal").input(2, 1).outType(BitType.class).apply().get());
-		assertTrue(op("logic.equal").input(2, 2).outType(BitType.class).apply().get());
-		assertFalse(op("logic.equal").input(2, 3).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.equal").input(2, 1).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.equal").input(2, 2).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.equal").input(2, 3).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testObjectsNotEqual() {
-		assertTrue(op("logic.notEqual").input(2, 1).outType(BitType.class).apply().get());
-		assertFalse(op("logic.notEqual").input(2, 2).outType(BitType.class).apply().get());
-		assertTrue(op("logic.notEqual").input(2, 3).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.notEqual").input(2, 1).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.notEqual").input(2, 2).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.notEqual").input(2, 3).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testNot() {
-		assertFalse(op("logic.not").input(new BitType(true)).outType(BitType.class).apply().get());
-		assertTrue(op("logic.not").input(new BitType(false)).outType(BitType.class).apply().get());
+		assertFalse(ops.op("logic.not").input(new BitType(true)).outType(BitType.class).apply().get());
+		assertTrue(ops.op("logic.not").input(new BitType(false)).outType(BitType.class).apply().get());
 	}
 
 	@Test
 	public void testOr() {
-		assertTrue(op("logic.or").input(new BitType(true), new BitType(true)).outType(BitType.class)
+		assertTrue(ops.op("logic.or").input(new BitType(true), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertTrue(op("logic.or").input(new BitType(true), new BitType(false)).outType(BitType.class)
+		assertTrue(ops.op("logic.or").input(new BitType(true), new BitType(false)).outType(BitType.class)
 				.apply().get());
-		assertTrue(op("logic.or").input(new BitType(false), new BitType(true)).outType(BitType.class)
+		assertTrue(ops.op("logic.or").input(new BitType(false), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertFalse(op("logic.or").input(new BitType(false), new BitType(false)).outType(BitType.class)
+		assertFalse(ops.op("logic.or").input(new BitType(false), new BitType(false)).outType(BitType.class)
 				.apply().get());
 	}
 
 	@Test
 	public void testXor() {
-		assertFalse(op("logic.xor").input(new BitType(true), new BitType(true)).outType(BitType.class)
+		assertFalse(ops.op("logic.xor").input(new BitType(true), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertTrue(op("logic.xor").input(new BitType(true), new BitType(false)).outType(BitType.class)
+		assertTrue(ops.op("logic.xor").input(new BitType(true), new BitType(false)).outType(BitType.class)
 				.apply().get());
-		assertTrue(op("logic.xor").input(new BitType(false), new BitType(true)).outType(BitType.class)
+		assertTrue(ops.op("logic.xor").input(new BitType(false), new BitType(true)).outType(BitType.class)
 				.apply().get());
-		assertFalse(op("logic.xor").input(new BitType(false), new BitType(false)).outType(BitType.class)
+		assertFalse(ops.op("logic.xor").input(new BitType(false), new BitType(false)).outType(BitType.class)
 				.apply().get());
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/logic/ConditionalTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/logic/ConditionalTest.java
@@ -50,9 +50,9 @@ public class ConditionalTest extends AbstractOpTest {
 		final ByteType ifTrueVal = new ByteType((byte) 10);
 		final ByteType ifFalseVal = new ByteType((byte) 100);
 		final ByteType outVal = new ByteType();
-		op("logic.match").input(new BoolType(true), ifTrueVal, ifFalseVal).output(outVal).compute();
+		ops.op("logic.match").input(new BoolType(true), ifTrueVal, ifFalseVal).output(outVal).compute();
 		assertEquals(10, outVal.get());
-		op("logic.match").input(new BoolType(false), ifTrueVal, ifFalseVal).output(outVal).compute();
+		ops.op("logic.match").input(new BoolType(false), ifTrueVal, ifFalseVal).output(outVal).compute();
 		assertEquals(100, outVal.get());
 	}
 
@@ -60,9 +60,9 @@ public class ConditionalTest extends AbstractOpTest {
 	public void testDefault() {
 		final ByteType out = new ByteType((byte) 10);
 		final ByteType defaultVal = new ByteType((byte) 100);
-		op("logic.default").input(new BoolType(true), defaultVal).output(out).compute();
+		ops.op("logic.default").input(new BoolType(true), defaultVal).output(out).compute();
 		assertEquals(10, out.get());
-		op("logic.default").input(new BoolType(false), defaultVal).output(out).compute();
+		ops.op("logic.default").input(new BoolType(false), defaultVal).output(out).compute();
 		assertEquals(100, out.get());
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodTest.java
@@ -68,7 +68,7 @@ public class MapNeighborhoodTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testMapNeighborhoodsAccess() {
-		op("map.neighborhood").input(in, new RectangleShape(1, false), new CountNeighbors()).output(out).compute();
+		ops.op("map.neighborhood").input(in, new RectangleShape(1, false), new CountNeighbors()).output(out).compute();
 
 		for (final ByteType t : out) {
 			assertEquals(9, t.get());

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/math/UnaryRealTypeMathTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/math/UnaryRealTypeMathTest.java
@@ -61,7 +61,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testAbs() {
 		final LongType in = new LongType(-LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.abs").input(in).output(out).compute();
+		ops.op("math.abs").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -69,7 +69,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccos() {
 		final FloatType in = new FloatType(0.5f);
 		final DoubleType out = new DoubleType();
-		op("math.arccos").input(in).output(out).compute();
+		ops.op("math.arccos").input(in).output(out).compute();
 		assertEquals(out.get(), Math.acos(0.5), 0.0);
 	}
 
@@ -77,7 +77,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccosh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arccosh").input(in).output(out).compute();
+		ops.op("math.arccosh").input(in).output(out).compute();
 		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 - 1);
 		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
 	}
@@ -86,7 +86,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arccot").input(in).output(out).compute();
+		ops.op("math.arccot").input(in).output(out).compute();
 		assertEquals(out.get(), Math.atan(1.0 / 1234567890), 0.0);
 	}
 
@@ -94,7 +94,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccoth() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arccoth").input(in).output(out).compute();
+		ops.op("math.arccoth").input(in).output(out).compute();
 		final double result = 0.5 * Math.log(1234567891.0 / 1234567889.0);
 		assertEquals(out.get(), result, 0.0);
 	}
@@ -103,7 +103,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArccsch() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arccsch").input(in).output(out).compute();
+		ops.op("math.arccsch").input(in).output(out).compute();
 		final double delta = Math.sqrt(1 + 1 / (1234567890.0 * 1234567890.0));
 		assertEquals(out.get(), Math.log(1 / 1234567890.0 + delta), 0.0);
 	}
@@ -112,7 +112,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsech() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arcsech").input(in).output(out).compute();
+		ops.op("math.arcsech").input(in).output(out).compute();
 		final double numer = 1 + Math.sqrt(1 - 1234567890.0 * 1234567890.0);
 		assertEquals(out.get(), Math.log(numer / 1234567890.0), 0.0);
 	}
@@ -121,7 +121,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsin() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arcsin").input(in).output(out).compute();
+		ops.op("math.arcsin").input(in).output(out).compute();
 		assertEquals(out.get(), Math.asin(1234567890), 0.0);
 	}
 
@@ -129,7 +129,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArcsinh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arcsinh").input(in).output(out).compute();
+		ops.op("math.arcsinh").input(in).output(out).compute();
 		final double delta = Math.sqrt(1234567890.0 * 1234567890.0 + 1);
 		assertEquals(out.get(), Math.log(1234567890 + delta), 0.0);
 	}
@@ -138,7 +138,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArctan() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arctan").input(in).output(out).compute();
+		ops.op("math.arctan").input(in).output(out).compute();
 		assertEquals(out.get(), Math.atan(1234567890), 0.0);
 	}
 
@@ -146,7 +146,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testArctanh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.arctanh").input(in).output(out).compute();
+		ops.op("math.arctanh").input(in).output(out).compute();
 		assertEquals(out.get(), 0.5 * Math.log(1234567891.0 / -1234567889.0), 0.0);
 	}
 
@@ -154,7 +154,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCeil() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.ceil").input(in).output(out).compute();
+		ops.op("math.ceil").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -162,7 +162,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCos() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.cos").input(in).output(out).compute();
+		ops.op("math.cos").input(in).output(out).compute();
 		assertEquals(out.get(), Math.cos(1234567890), 0.0);
 	}
 
@@ -170,7 +170,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCosh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.cosh").input(in).output(out).compute();
+		ops.op("math.cosh").input(in).output(out).compute();
 		assertEquals(out.get(), Math.cosh(1234567890), 0.0);
 	}
 
@@ -178,7 +178,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.cot").input(in).output(out).compute();
+		ops.op("math.cot").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.tan(1234567890), 0.0);
 	}
 
@@ -186,7 +186,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCoth() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.coth").input(in).output(out).compute();
+		ops.op("math.coth").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.tanh(1234567890), 0.0);
 	}
 
@@ -194,7 +194,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCsc() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.csc").input(in).output(out).compute();
+		ops.op("math.csc").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.sin(1234567890), 0.0);
 	}
 
@@ -202,7 +202,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCsch() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.csch").input(in).output(out).compute();
+		ops.op("math.csch").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.sinh(1234567890), 0.0);
 	}
 
@@ -210,7 +210,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testCubeRoot() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.cubeRoot").input(in).output(out).compute();
+		ops.op("math.cubeRoot").input(in).output(out).compute();
 		assertEquals(out.get(), Math.cbrt(1234567890), 0.0);
 	}
 
@@ -218,7 +218,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testExp() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.exp").input(in).output(out).compute();
+		ops.op("math.exp").input(in).output(out).compute();
 		assertEquals(out.get(), Math.exp(1234567890), 0.0);
 	}
 
@@ -226,7 +226,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testExpMinusOne() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.expMinusOne").input(in).output(out).compute();
+		ops.op("math.expMinusOne").input(in).output(out).compute();
 		assertEquals(out.get(), Math.exp(1234567890) - 1, 0.0);
 	}
 
@@ -234,7 +234,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testFloor() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.floor").input(in).output(out).compute();
+		ops.op("math.floor").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -242,7 +242,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testInvert() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.invert").input(in, 9007199254740992.0, 9007199254740994.0).output(out).compute();
+		ops.op("math.invert").input(in, 9007199254740992.0, 9007199254740994.0).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM + 1);
 	}
 
@@ -250,7 +250,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.log").input(in).output(out).compute();
+		ops.op("math.log").input(in).output(out).compute();
 		assertEquals(out.get(), Math.log(1234567890), 0.0);
 	}
 
@@ -258,7 +258,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog10() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.log10").input(in).output(out).compute();
+		ops.op("math.log10").input(in).output(out).compute();
 		assertEquals(out.get(), Math.log10(1234567890), 0.0);
 	}
 
@@ -266,7 +266,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLog2() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.log2").input(in).output(out).compute();
+		ops.op("math.log2").input(in).output(out).compute();
 		assertEquals(out.get(), Math.log(1234567890) / Math.log(2), 0.0);
 	}
 
@@ -274,7 +274,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testLogOnePlusX() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.logOnePlusX").input(in).output(out).compute();
+		ops.op("math.logOnePlusX").input(in).output(out).compute();
 		assertEquals(out.get(), Math.log1p(1234567890), 0.0);
 	}
 
@@ -282,7 +282,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testMax() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.max").input(in, LARGE_NUM + 1.0).output(out).compute();
+		ops.op("math.max").input(in, LARGE_NUM + 1.0).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -290,7 +290,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testMin() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.min").input(in, LARGE_NUM - 1.0).output(out).compute();
+		ops.op("math.min").input(in, LARGE_NUM - 1.0).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -298,7 +298,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testNearestInt() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.nearestInt").input(in).output(out).compute();
+		ops.op("math.nearestInt").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -306,7 +306,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testNegate() {
 		final LongType in = new LongType(-LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.negate").input(in).output(out).compute();
+		ops.op("math.negate").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -314,7 +314,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testPower() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.power").input(in, 1.5).output(out).compute();
+		ops.op("math.power").input(in, 1.5).output(out).compute();
 		assertEquals(out.get(), Math.pow(1234567890, 1.5), 0.0);
 	}
 
@@ -322,7 +322,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testReciprocal() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.reciprocal").input(in, 0.0).output(out).compute();
+		ops.op("math.reciprocal").input(in, 0.0).output(out).compute();
 		assertEquals(out.get(), 1.0 / 1234567890, 0.0);
 	}
 
@@ -330,7 +330,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testRound() {
 		final LongType in = new LongType(LARGE_NUM);
 		final LongType out = in.createVariable();
-		op("math.round").input(in).output(out).compute();
+		ops.op("math.round").input(in).output(out).compute();
 		assertEquals(out.get(), LARGE_NUM - 1);
 	}
 
@@ -338,7 +338,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSec() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sec").input(in).output(out).compute();
+		ops.op("math.sec").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.cos(1234567890), 0.0);
 	}
 
@@ -346,7 +346,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSech() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sech").input(in).output(out).compute();
+		ops.op("math.sech").input(in).output(out).compute();
 		assertEquals(out.get(), 1 / Math.cosh(1234567890), 0.0);
 	}
 
@@ -354,7 +354,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSignum() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.signum").input(in).output(out).compute();
+		ops.op("math.signum").input(in).output(out).compute();
 		assertEquals(out.get(), 1.0, 0.0);
 	}
 
@@ -362,7 +362,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSin() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sin").input(in).output(out).compute();
+		ops.op("math.sin").input(in).output(out).compute();
 		assertEquals(out.get(), Math.sin(1234567890), 0.0);
 	}
 
@@ -370,7 +370,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSinc() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sinc").input(in).output(out).compute();
+		ops.op("math.sinc").input(in).output(out).compute();
 		assertEquals(out.get(), Math.sin(1234567890) / 1234567890, 0.0);
 	}
 
@@ -378,7 +378,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSincPi() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sincPi").input(in).output(out).compute();
+		ops.op("math.sincPi").input(in).output(out).compute();
 		final double PI = Math.PI;
 		assertEquals(out.get(), Math.sin(PI * 1234567890) / (PI * 1234567890), 0.0);
 	}
@@ -387,7 +387,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSinh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sinh").input(in).output(out).compute();
+		ops.op("math.sinh").input(in).output(out).compute();
 		assertEquals(out.get(), Math.sinh(1234567890), 0.0);
 	}
 
@@ -395,7 +395,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSqr() {
 		final LongType in = new LongType(94906267L);
 		final LongType out = in.createVariable();
-		op("math.sqr").input(in).output(out).compute();
+		ops.op("math.sqr").input(in).output(out).compute();
 		// NB: for any odd number greater than LARGE_NUM - 1, its double
 		// representation is not exact.
 		assertEquals(out.get(), 94906267L * 94906267L - 1);
@@ -405,7 +405,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testSqrt() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.sqrt").input(in).output(out).compute();
+		ops.op("math.sqrt").input(in).output(out).compute();
 		assertEquals(out.get(), Math.sqrt(1234567890), 0.0);
 	}
 
@@ -413,7 +413,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testStep() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.step").input(in).output(out).compute();
+		ops.op("math.step").input(in).output(out).compute();
 		assertEquals(out.get(), 1.0, 0.0);
 	}
 
@@ -421,7 +421,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testTan() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.tan").input(in).output(out).compute();
+		ops.op("math.tan").input(in).output(out).compute();
 		assertEquals(out.get(), Math.tan(1234567890), 0.0);
 	}
 
@@ -429,7 +429,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testTanh() {
 		final LongType in = new LongType(1234567890);
 		final DoubleType out = new DoubleType();
-		op("math.tanh").input(in).output(out).compute();
+		ops.op("math.tanh").input(in).output(out).compute();
 		assertEquals(out.get(), Math.tanh(1234567890), 0.0);
 	}
 
@@ -437,7 +437,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	public void testUlp() {
 		final LongType in = new LongType(LARGE_NUM);
 		final DoubleType out = new DoubleType();
-		op("math.ulp").input(in).output(out).compute();
+		ops.op("math.ulp").input(in).output(out).compute();
 		assertEquals(out.get(), 2.0, 0.0);
 	}
 
@@ -504,21 +504,21 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	private void assertArccsc(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
 		final DoubleType out = in.createVariable();
-		op("math.arccsc").input(in).output(out).compute();
+		ops.op("math.arccsc").input(in).output(out).compute();
 		assertEquals(o, out.get(), 1e-15);
 	}
 
 	private void assertArcsec(final double i, final double o) {
 		final DoubleType in = new DoubleType(i);
 		final DoubleType out = in.createVariable();
-		op("math.arcsec").input(in).output(out).compute();
+		ops.op("math.arcsec").input(in).output(out).compute();
 		assertEquals(o, out.get(), 1e-15);
 	}
 
 	private void assertRandomGaussian(final double i, final double o, final long seed) {
 		final DoubleType in = new DoubleType(i);
 		final DoubleType out = in.createVariable();
-		op("math.randomGaussian").input(in, seed).output(out).compute();
+		ops.op("math.randomGaussian").input(in, seed).output(out).compute();
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -527,7 +527,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 		final DoubleType out = new DoubleType();
 		final long seed = 0xcafebabe12345678L;
 		final Random rng = new Random(seed);
-		final Computers.Arity2<DoubleType, Random, DoubleType> op = Computers.match(ops, "math.randomGaussian",
+		final Computers.Arity2<DoubleType, Random, DoubleType> op = Computers.match(ops.env(), "math.randomGaussian",
 				new Nil<DoubleType>() {}, new Nil<Random>() {}, new Nil<DoubleType>() {});
 		op.compute(in, rng, out);
 		assertEquals(o, out.get(), 0);
@@ -539,7 +539,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 	private void assertRandomUniform(final double i, final double o, final long seed) {
 		final DoubleType in = new DoubleType(i);
 		final DoubleType out = in.createVariable();
-		op("math.randomUniform").input(in, seed).output(out).compute();
+		ops.op("math.randomUniform").input(in, seed).output(out).compute();
 		assertEquals(o, out.get(), 0);
 	}
 
@@ -548,7 +548,7 @@ public class UnaryRealTypeMathTest extends AbstractOpTest {
 		final DoubleType out = new DoubleType();
 		final long seed = 0xcafebabe12345678L;
 		final Random rng = new Random(seed);
-		final Computers.Arity2<DoubleType, Random, DoubleType> op = Computers.match(ops, "math.randomUniform",
+		final Computers.Arity2<DoubleType, Random, DoubleType> op = Computers.match(ops.env(), "math.randomUniform",
 				new Nil<DoubleType>() {}, new Nil<Random>() {}, new Nil<DoubleType>() {});
 		op.compute(in, rng, out);
 		assertEquals(o, out.get(), 0);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/math/add/AddNumericTypeBinaryMathAddTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/math/add/AddNumericTypeBinaryMathAddTest.java
@@ -52,7 +52,7 @@ public class AddNumericTypeBinaryMathAddTest extends AbstractOpTest {
 		final ARGBDoubleType b = new ARGBDoubleType(255, 75, 35, 45);
 		final ARGBDoubleType c = new ARGBDoubleType();
 
-		op("math.add").input(a, b).output(c).compute();
+		ops.op("math.add").input(a, b).output(c).compute();
 		assertEquals(203.0, c.getR(), DELTA);
 		assertEquals(163.0, c.getG(), DELTA);
 		assertEquals(173.0, c.getB(), DELTA);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/MorphologyOpsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/MorphologyOpsTest.java
@@ -69,11 +69,11 @@ public class MorphologyOpsTest extends AbstractOpTest {
 		Cursor<FloatType> inputWithHolesCursor = inputWithHoles.cursor();
 		Cursor<FloatType> invertedInputWithFilledHolesCursor = invertedInputWithFilledHoles.cursor();
 
-		imgWithoutHoles = op("create.img").input(inputWithoutHoles, new BitType()).outType(new Nil<Img<BitType>>() {})
+		imgWithoutHoles = ops.op("create.img").input(inputWithoutHoles, new BitType()).outType(new Nil<Img<BitType>>() {})
 				.apply();
-		imgWithHoles = op("create.img").input(inputWithHoles, new BitType()).outType(new Nil<Img<BitType>>() {})
+		imgWithHoles = ops.op("create.img").input(inputWithHoles, new BitType()).outType(new Nil<Img<BitType>>() {})
 				.apply();
-		invertedImgWithFilledHoles = op("create.img").input(invertedInputWithFilledHoles, new BitType())
+		invertedImgWithFilledHoles = ops.op("create.img").input(invertedInputWithFilledHoles, new BitType())
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		Cursor<BitType> imgWithoutHolesCursor = imgWithoutHoles.cursor();
@@ -98,18 +98,18 @@ public class MorphologyOpsTest extends AbstractOpTest {
 
 	@Test
 	public void testExtractHoles() {
-		assertNotNull(op("morphology.extractHoles").input(imgWithoutHoles,
+		assertNotNull(ops.op("morphology.extractHoles").input(imgWithoutHoles,
 			new DiamondShape(1)).outType(new Nil<Img<BitType>>()
 		{}).apply(), "Img Without Holes");
-		assertNotNull(op("morphology.extractHoles").input(imgWithHoles,
+		assertNotNull(ops.op("morphology.extractHoles").input(imgWithHoles,
 			new DiamondShape(1)).outType(new Nil<Img<BitType>>()
 		{}).apply(), "Img With Holes");
 	}
 
 	@Test
 	public void testFillHoles() {
-		Img<BitType> result = op("create.img").input(imgWithHoles).outType(new Nil<Img<BitType>>() {}).apply();
-		op("morphology.fillHoles").input(imgWithHoles, new DiamondShape(1)).output(result).compute();
+		Img<BitType> result = ops.op("create.img").input(imgWithHoles).outType(new Nil<Img<BitType>>() {}).apply();
+		ops.op("morphology.fillHoles").input(imgWithHoles, new DiamondShape(1)).output(result).compute();
 
 		Cursor<BitType> resultC = result.cursor();
 		final BitType one = new BitType(true);
@@ -120,12 +120,12 @@ public class MorphologyOpsTest extends AbstractOpTest {
 
 	@Test
 	public void testFillHoles1() {
-		Img<BitType> result = op("create.img").input(invertedImgWithFilledHoles).outType(new Nil<Img<BitType>>() {})
+		Img<BitType> result = ops.op("create.img").input(invertedImgWithFilledHoles).outType(new Nil<Img<BitType>>() {})
 				.apply();
-		Img<BitType> inverted = op("create.img").input(invertedImgWithFilledHoles).outType(new Nil<Img<BitType>>() {})
+		Img<BitType> inverted = ops.op("create.img").input(invertedImgWithFilledHoles).outType(new Nil<Img<BitType>>() {})
 				.apply();
-		op("image.invert").input(imgWithHoles).output(inverted).compute();
-		op("morphology.fillHoles").input(inverted, new DiamondShape(1)).output(result).compute();
+		ops.op("image.invert").input(imgWithHoles).output(inverted).compute();
+		ops.op("morphology.fillHoles").input(inverted, new DiamondShape(1)).output(result).compute();
 
 		Cursor<BitType> resultC = result.localizingCursor();
 		RandomAccess<BitType> groundTruthRA = invertedImgWithFilledHoles.randomAccess();
@@ -139,7 +139,7 @@ public class MorphologyOpsTest extends AbstractOpTest {
 
 	@Test
 	public void testFillHoles2() {
-		RandomAccessibleInterval<BitType> result = op("morphology.fillHoles")
+		RandomAccessibleInterval<BitType> result = ops.op("morphology.fillHoles")
 				.input(imgWithoutHoles, new RectangleShape(1, false))
 				.outType(new Nil<RandomAccessibleInterval<BitType>>() {}).apply();
 		Cursor<BitType> groundTruthC = imgWithoutHoles.localizingCursor();

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/blackTopHat/BlackTopHatTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/blackTopHat/BlackTopHatTest.java
@@ -69,7 +69,7 @@ public class BlackTopHatTest extends AbstractOpTest {
 	public void testSingleBlackTopHat() {
 		final Shape shape = new DiamondShape(1);
 		final List<Shape> shapes = Arrays.asList(shape);
-		final Img<ByteType> out1 = op("morphology.BlackTopHat").input(in, shapes, 1)
+		final Img<ByteType> out1 = ops.op("morphology.BlackTopHat").input(in, shapes, 1)
 				.outType(new Nil<Img<ByteType>>() {}).apply();
 		final Img<ByteType> out2 = BlackTopHat.blackTopHat(in, shape, 1);
 		assertTrue(AssertIterations.equal(out2, out1));
@@ -82,7 +82,7 @@ public class BlackTopHatTest extends AbstractOpTest {
 		shapes.add(new DiamondShape(1));
 		shapes.add(new RectangleShape(1, false));
 		shapes.add(new HorizontalLineShape(2, 1, false));
-		final IterableInterval<ByteType> out1 = op("morphology.BlackTopHat").input(in, shapes, 1)
+		final IterableInterval<ByteType> out1 = ops.op("morphology.BlackTopHat").input(in, shapes, 1)
 				.outType(new Nil<IterableInterval<ByteType>>() {}).apply();
 		final Img<ByteType> out2 = BlackTopHat.blackTopHat(in, shapes, 1);
 		assertTrue(AssertIterations.equal(out2, out1));

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/outline/OutlineTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/outline/OutlineTest.java
@@ -63,7 +63,7 @@ public class OutlineTest extends AbstractOpTest {
 		final Img<BitType> img = ArrayImgs.bits(inputDims);
 
 		// EXECUTE
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -80,7 +80,7 @@ public class OutlineTest extends AbstractOpTest {
 		final Img<BitType> img = ArrayImgs.bits(3, 3, 3);
 
 		// EXECUTE
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -96,7 +96,7 @@ public class OutlineTest extends AbstractOpTest {
 		img.forEach(BitType::setOne);
 
 		// EXECUTE
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -112,7 +112,7 @@ public class OutlineTest extends AbstractOpTest {
 		square.cursor().forEachRemaining(BitType::setOne);
 
 		// EXECUTE
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -139,7 +139,7 @@ public class OutlineTest extends AbstractOpTest {
 		access.get().setZero();
 
 		// EXECUTION
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -167,7 +167,7 @@ public class OutlineTest extends AbstractOpTest {
 		square.cursor().forEachRemaining(BitType::setOne);
 
 		// EXECUTION
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY
@@ -196,7 +196,7 @@ public class OutlineTest extends AbstractOpTest {
 		final IntervalView<BitType> square = Views.offsetInterval(img, new long[] { 0, 1 }, new long[] { 3, 3 });
 		square.cursor().forEachRemaining(BitType::setOne);
 
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.FALSE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.FALSE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		assertEquals(8, countForeground(result),
@@ -221,7 +221,7 @@ public class OutlineTest extends AbstractOpTest {
 		hyperCube.cursor().forEachRemaining(BitType::setOne);
 
 		// EXECUTE
-		final Img<BitType> result = op("morphology.outline").input(img, Boolean.TRUE)
+		final Img<BitType> result = ops.op("morphology.outline").input(img, Boolean.TRUE)
 				.outType(new Nil<Img<BitType>>() {}).apply();
 
 		// VERIFY

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/thin/ThinningTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/thin/ThinningTest.java
@@ -55,38 +55,38 @@ public class ThinningTest extends AbstractOpTest {
 	@BeforeEach
 	public void initialize() {
 		Img<FloatType> testImg = openFloatImg(AbstractFeatureTest.class, "3d_geometric_features_testlabel.tif");
-		in = op("create.img").input(testImg, new BitType()).outType(new Nil<Img<BitType>>() {}).apply();
-		target = op("create.img").input(in, new BitType()).outType(new Nil<Img<BitType>>() {}).apply();
-		op("convert.bit").input(testImg).output(in).compute();
+		in = ops.op("create.img").input(testImg, new BitType()).outType(new Nil<Img<BitType>>() {}).apply();
+		target = ops.op("create.img").input(in, new BitType()).outType(new Nil<Img<BitType>>() {}).apply();
+		ops.op("convert.bit").input(testImg).output(in).compute();
 
 	}
 
 	@Test
 	public void testThinGuoHall() {
-		final Img<BitType> out = op("morphology.thinGuoHall").input(in).outType(new Nil<Img<BitType>>() {}).apply();
-		op("convert.bit").input(openFloatImg(AbstractThin.class, "result_guoHall.tif")).output(target).compute();
+		final Img<BitType> out = ops.op("morphology.thinGuoHall").input(in).outType(new Nil<Img<BitType>>() {}).apply();
+		ops.op("convert.bit").input(openFloatImg(AbstractThin.class, "result_guoHall.tif")).output(target).compute();
 		assertTrue(AssertIterations.equal(target, out));
 	}
 
 	@Test
 	public void testThinHilditch() {
-		final Img<BitType> out = op("morphology.thinHilditch").input(in).outType(new Nil<Img<BitType>>() {}).apply();
-		op("convert.bit").input(openFloatImg(AbstractThin.class, "result_hilditch.tif")).output(target).compute();
+		final Img<BitType> out = ops.op("morphology.thinHilditch").input(in).outType(new Nil<Img<BitType>>() {}).apply();
+		ops.op("convert.bit").input(openFloatImg(AbstractThin.class, "result_hilditch.tif")).output(target).compute();
 		assertTrue(AssertIterations.equal(target, out));
 	}
 
 	@Test
 	public void testMorphological() {
-		final Img<BitType> out = op("morphology.thinMorphological").input(in).outType(new Nil<Img<BitType>>() {})
+		final Img<BitType> out = ops.op("morphology.thinMorphological").input(in).outType(new Nil<Img<BitType>>() {})
 				.apply();
-		op("convert.bit").input(openFloatImg(AbstractThin.class, "result_morphological.tif")).output(target).compute();
+		ops.op("convert.bit").input(openFloatImg(AbstractThin.class, "result_morphological.tif")).output(target).compute();
 		assertTrue(AssertIterations.equal(target, out));
 	}
 
 	@Test
 	public void testZhangSuen() {
-		final Img<BitType> out = op("morphology.thinZhangSuen").input(in).outType(new Nil<Img<BitType>>() {}).apply();
-		op("convert.bit").input(openFloatImg(AbstractThin.class, "result_zhangSuen.tif")).output(target).compute();
+		final Img<BitType> out = ops.op("morphology.thinZhangSuen").input(in).outType(new Nil<Img<BitType>>() {}).apply();
+		ops.op("convert.bit").input(openFloatImg(AbstractThin.class, "result_zhangSuen.tif")).output(target).compute();
 		assertTrue(AssertIterations.equal(target, out));
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/project/ProjectTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/project/ProjectTest.java
@@ -70,7 +70,7 @@ public class ProjectTest extends AbstractOpTest {
 		out1 = TestImgGeneration.unsignedByteArray(false, 10, 10);
 		out2 = TestImgGeneration.unsignedByteArray(false, 10, 10);
 
-		op = Computers.match(ops, "stats.sum", new Nil<Iterable<UnsignedByteType>>() {},
+		op = Computers.match(ops.env(), "stats.sum", new Nil<Iterable<UnsignedByteType>>() {},
 				new Nil<UnsignedByteType>() {});
 	}
 
@@ -81,8 +81,8 @@ public class ProjectTest extends AbstractOpTest {
 		// ops.run(DefaultProjectParallel.class, out2, in, op, PROJECTION_DIM);
 		// testEquality(out1, out2);
 
-		op("project").input(in, op, PROJECTION_DIM).output(out1).compute();
-		op("project").input(in, op, PROJECTION_DIM).output(out2).compute();
+		ops.op("project").input(in, op, PROJECTION_DIM).output(out1).compute();
+		ops.op("project").input(in, op, PROJECTION_DIM).output(out2).compute();
 		testEquality(out1, out2);
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectJunctions/DefaultDetectJunctionsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectJunctions/DefaultDetectJunctionsTest.java
@@ -95,9 +95,9 @@ public class DefaultDetectJunctionsTest extends AbstractOpTest {
 		lines.add(new DefaultWritablePolyline(list4));
 
 		List<RealPoint> results;
-		results = op(
-			"segment.detectJunctions").input(lines,
-			threshold).outType(new Nil<List<RealPoint>>() {}).apply();
+		results = ops.env().op("segment.detectJunctions").input(lines, threshold)
+			.outType(new Nil<List<RealPoint>>()
+			{}).apply();
 
 		List<RealPoint> expected = new ArrayList<>();
 		expected.add(new RealPoint(0, 0));

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidgesTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidgesTest.java
@@ -63,7 +63,7 @@ public class DefaultDetectRidgesTest extends AbstractOpTest {
 
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
 			@SuppressWarnings("unused")
-			List<DefaultWritablePolyline> polylines = op("segment.detectRidges")
+			List<DefaultWritablePolyline> polylines = ops.op("segment.detectRidges")
 					.input(input, width, lowerThreshold, higherThreshold, ridgeLengthMin)
 					.outType(new Nil<List<DefaultWritablePolyline>>() {}).apply();
 		});
@@ -79,7 +79,7 @@ public class DefaultDetectRidgesTest extends AbstractOpTest {
 
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
 			@SuppressWarnings("unused")
-			List<DefaultWritablePolyline> polylines = op("segment.detectRidges")
+			List<DefaultWritablePolyline> polylines = ops.op("segment.detectRidges")
 					.input(input, width, lowerThreshold, higherThreshold, ridgeLengthMin)
 					.outType(new Nil<List<DefaultWritablePolyline>>() {}).apply();
 		});
@@ -117,7 +117,7 @@ public class DefaultDetectRidgesTest extends AbstractOpTest {
 		int ridgeLengthMin = 4;
 		double width = 1, lowerThreshold = 2, higherThreshold = 4;
 
-		List<DefaultWritablePolyline> polylines = op("segment.detectRidges")
+		List<DefaultWritablePolyline> polylines = ops.op("segment.detectRidges")
 				.input(input, width, lowerThreshold, higherThreshold, ridgeLengthMin)
 				.outType(new Nil<List<DefaultWritablePolyline>>() {}).apply();
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/slice/SliceTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/slice/SliceTest.java
@@ -97,10 +97,10 @@ public class SliceTest<I extends RealType<I>, O extends RealType<O>> extends Abs
 		final int[] xyAxis = new int[] { 0, 1 };
 
 		Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<ByteType>> wrapped =
-			ops.wrap(test,
+			ops.env().opify(test,
 				new Nil<Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<ByteType>>>()
 				{}.getType());
-		op("slice").input(in, wrapped, xyAxis, true).output(out).compute();
+		ops.op("slice").input(in, wrapped, xyAxis, true).output(out).compute();
 
 		for (final Cursor<ByteType> cur = out.cursor(); cur.hasNext();) {
 			cur.fwd();
@@ -135,10 +135,11 @@ public class SliceTest<I extends RealType<I>, O extends RealType<O>> extends Abs
 		final int[] xyAxis = new int[] { 0, 1, 2 };
 
 		Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<ByteType>> wrapped =
-			ops.wrap(test,
+			ops.env().opify(test,
 				new Nil<Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<ByteType>>>()
 				{}.getType());
-		op("slice").input(inSequence, wrapped, xyAxis, true).output(outSequence).compute();
+		ops.op("slice").input(inSequence, wrapped, xyAxis, true).output(outSequence)
+			.compute();
 
 		for (final Cursor<ByteType> cur = outSequence.cursor(); cur.hasNext();) {
 			cur.fwd();
@@ -206,13 +207,14 @@ public class SliceTest<I extends RealType<I>, O extends RealType<O>> extends Abs
 
 	}
 
-	public Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> test = (input, output) -> {
-		final Iterator<I> itA = Views.iterable(input).iterator();
-		final Iterator<O> itB = Views.iterable(output).iterator();
+	public Computers.Arity1<RandomAccessibleInterval<ByteType>, RandomAccessibleInterval<ByteType>> test =
+		(input, output) -> {
+			final Iterator<ByteType> itA = Views.iterable(input).iterator();
+			final Iterator<ByteType> itB = Views.iterable(output).iterator();
 
-		while (itA.hasNext() && itB.hasNext()) {
-			itB.next().setReal(itA.next().getRealDouble());
-		}
-	};
+			while (itA.hasNext() && itB.hasNext()) {
+				itB.next().setReal(itA.next().getRealDouble());
+			}
+		};
 
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/DefaultMedianTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/DefaultMedianTest.java
@@ -60,7 +60,7 @@ public class DefaultMedianTest extends AbstractOpTest {
 		numbers.add(new DoubleType(1.0));
 
 		final DoubleType result = new DoubleType();
-		op("stats.median").input(numbers).output(result).compute();
+		ops.op("stats.median").input(numbers).output(result).compute();
 
 		assertEquals(numbers.get(0).getRealDouble(), result.getRealDouble(), 1e-12);
 	}
@@ -76,7 +76,7 @@ public class DefaultMedianTest extends AbstractOpTest {
 		shuffle(numbers);
 
 		final DoubleType result = new DoubleType();
-		op("stats.median").input(numbers).output(result).compute();
+		ops.op("stats.median").input(numbers).output(result).compute();
 
 		assertEquals(3.0, result.getRealDouble(), 1e-12);
 	}
@@ -91,7 +91,7 @@ public class DefaultMedianTest extends AbstractOpTest {
 		shuffle(numbers);
 
 		final DoubleType result = new DoubleType();
-		op("stats.median").input(numbers).output(result).compute();
+		ops.op("stats.median").input(numbers).output(result).compute();
 
 		assertEquals(2.5, result.getRealDouble(), 1e-12);
 	}
@@ -102,7 +102,7 @@ public class DefaultMedianTest extends AbstractOpTest {
 			.randomlyFilledUnsignedByteWithSeed(new long[] { 100, 100 }, 1234567890L);
 
 		final DoubleType result = new DoubleType();
-		op("stats.median").input(randomlyFilledImg).output(result).compute();
+		ops.op("stats.median").input(randomlyFilledImg).output(result).compute();
 
 		assertEquals(128d, result.getRealDouble(), 0.00001d);
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
@@ -98,7 +98,7 @@ public class StatisticsTest extends AbstractOpTest {
 				max = array[i];
 		}
 
-		Pair<FloatType, FloatType> minMax = op("stats.minMax").input((Iterable<FloatType>) img)
+		Pair<FloatType, FloatType> minMax = ops.op("stats.minMax").input((Iterable<FloatType>) img)
 				.outType(new Nil<Pair<FloatType, FloatType>>() {}).apply();
 
 		Assertions.assertEquals(min, minMax.getA().get(), 0);
@@ -130,14 +130,14 @@ public class StatisticsTest extends AbstractOpTest {
 
 		// calculate mean using ops
 		final FloatType mean2 = new FloatType();
-		op("stats.mean").input(img).output(mean2).compute();
+		ops.op("stats.mean").input(img).output(mean2).compute();
 
 		// check that the ratio between mean1 and mean2 is 1.0
 		Assertions.assertEquals(1.0, mean1 / mean2.getRealFloat(), delta);
 
 		// calculate standard deviation using ops
 		final DoubleType std2 = new DoubleType();
-		op("stats.stdDev").input(img).output(std2).compute();
+		ops.op("stats.stdDev").input(img).output(std2).compute();
 
 		// check that the ratio between std1 and std2 is 1.0
 		Assertions.assertEquals(1.0, std1 / std2.getRealFloat(), delta);
@@ -146,131 +146,131 @@ public class StatisticsTest extends AbstractOpTest {
 	@Test
 	public void testMax() {
 		final UnsignedByteType max = new UnsignedByteType();
-		op("stats.max").input(randomlyFilledImg).output(max).compute();
+		ops.op("stats.max").input(randomlyFilledImg).output(max).compute();
 		Assertions.assertEquals(254d, max.getRealDouble(), 0.00001d, "Max");
 
 		// NB: should work with negative numbers
 		final ByteType maxByte = new ByteType();
-		op("stats.max").input(ArrayImgs.bytes(new byte[] { -1, -2, -4, -3 }, 2, 2)).output(maxByte).compute();
+		ops.op("stats.max").input(ArrayImgs.bytes(new byte[] { -1, -2, -4, -3 }, 2, 2)).output(maxByte).compute();
 		Assertions.assertEquals(-1.0, maxByte.getRealDouble(), 0.0, "Max");
 	}
 
 	@Test
 	public void testMin() {
 		final UnsignedByteType min = new UnsignedByteType();
-		op("stats.min").input(randomlyFilledImg).output(min).compute();
+		ops.op("stats.min").input(randomlyFilledImg).output(min).compute();
 		Assertions.assertEquals(0, min.getRealDouble(), 0.00001d, "Min");
 	}
 
 	@Test
 	public void testStdDev() {
 		final DoubleType stdDev = new DoubleType();
-		op("stats.stdDev").input(randomlyFilledImg).output(stdDev).compute();
+		ops.op("stats.stdDev").input(randomlyFilledImg).output(stdDev).compute();
 		Assertions.assertEquals(73.7460374274008, stdDev.getRealDouble(), 0.00001d, "StdDev");
 	}
 
 	@Test
 	public void testSum() {
 		final DoubleType sum = new DoubleType();
-		op("stats.sum").input(randomlyFilledImg).output(sum).compute();
+		ops.op("stats.sum").input(randomlyFilledImg).output(sum).compute();
 		Assertions.assertEquals(1277534.0, sum.getRealDouble(), 0.00001d, "Sum");
 	}
 
 	@Test
 	public void testVariance() {
 		final DoubleType variance = new DoubleType();
-		op("stats.variance").input(randomlyFilledImg).output(variance).compute();
+		ops.op("stats.variance").input(randomlyFilledImg).output(variance).compute();
 		Assertions.assertEquals(5438.4780362436, variance.getRealDouble(), 0.00001d, "Variance");
 	}
 
 	@Test
 	public void testGeometricMean() {
 		final DoubleType geoMetricMean = new DoubleType();
-		op("stats.geometricMean").input(randomlyFilledImg).output(geoMetricMean).compute();
+		ops.op("stats.geometricMean").input(randomlyFilledImg).output(geoMetricMean).compute();
 		Assertions.assertEquals(0, geoMetricMean.getRealDouble(), 0.00001d, "Geometric Mean");
 	}
 
 	@Test
 	public void testHarmonicMean() {
 		final DoubleType harmonicMean = new DoubleType();
-		op("stats.harmonicMean").input(randomlyFilledImg).output(harmonicMean).compute();
+		ops.op("stats.harmonicMean").input(randomlyFilledImg).output(harmonicMean).compute();
 		Assertions.assertEquals(0, harmonicMean.getRealDouble(), 0.00001d, "Harmonic Mean");
 	}
 
 	@Test
 	public void testKurtosis() {
 		final DoubleType kurtosis = new DoubleType();
-		op("stats.kurtosis").input(randomlyFilledImg).output(kurtosis).compute();
+		ops.op("stats.kurtosis").input(randomlyFilledImg).output(kurtosis).compute();
 		Assertions.assertEquals(1.794289587623922, kurtosis.getRealDouble(), 0.00001d, "Kurtosis");
 	}
 
 	@Test
 	public void testMoment1AboutMean() {
 		final DoubleType moment1 = new DoubleType();
-		op("stats.moment1AboutMean").input(randomlyFilledImg).output(moment1).compute();
+		ops.op("stats.moment1AboutMean").input(randomlyFilledImg).output(moment1).compute();
 		Assertions.assertEquals(0, moment1.getRealDouble(), 0.00001d, "Moment 1 About Mean");
 	}
 
 	@Test
 	public void testMoment2AboutMean() {
 		final DoubleType moment2 = new DoubleType();
-		op("stats.moment2AboutMean").input(randomlyFilledImg).output(moment2).compute();
+		ops.op("stats.moment2AboutMean").input(randomlyFilledImg).output(moment2).compute();
 		Assertions.assertEquals(5437.93418843998, moment2.getRealDouble(), 0.00001d, "Moment 2 About Mean");
 	}
 
 	@Test
 	public void testMoment3AboutMean() {
 		final DoubleType moment3 = new DoubleType();
-		op("stats.moment3AboutMean").input(randomlyFilledImg).output(moment3).compute();
+		ops.op("stats.moment3AboutMean").input(randomlyFilledImg).output(moment3).compute();
 		Assertions.assertEquals(-507.810691261427, moment3.getRealDouble(), 0.00001d, "Moment 3 About Mean");
 	}
 
 	@Test
 	public void testMoment4AboutMean() {
 		final DoubleType moment4 = new DoubleType();
-		op("stats.moment4AboutMean").input(randomlyFilledImg).output(moment4).compute();
+		ops.op("stats.moment4AboutMean").input(randomlyFilledImg).output(moment4).compute();
 		Assertions.assertEquals(53069780.9168701, moment4.getRealDouble(), 0.00001d, "Moment 4 About Mean");
 	}
 
 	@Test
 	public void testPercentile() {
 		final DoubleType percentile = new DoubleType();
-		op("stats.percentile").input(randomlyFilledImg, 50d).output(percentile).compute();
+		ops.op("stats.percentile").input(randomlyFilledImg, 50d).output(percentile).compute();
 		Assertions.assertEquals(128d, percentile.getRealDouble(), 0.00001d, "50-th Percentile");
 	}
 
 	@Test
 	public void testQuantile() {
 		final DoubleType quantile = new DoubleType();
-		op("stats.quantile").input(randomlyFilledImg, 0.5d).output(quantile).compute();
+		ops.op("stats.quantile").input(randomlyFilledImg, 0.5d).output(quantile).compute();
 		Assertions.assertEquals(128d, quantile.getRealDouble(), 0.00001d, "0.5-th Quantile");
 	}
 
 	@Test
 	public void testSkewness() {
 		final DoubleType skewness = new DoubleType();
-		op("stats.skewness").input(randomlyFilledImg).output(skewness).compute();
+		ops.op("stats.skewness").input(randomlyFilledImg).output(skewness).compute();
 		Assertions.assertEquals(-0.0012661517853476312, skewness.getRealDouble(), 0.00001d, "Skewness");
 	}
 
 	@Test
 	public void testSumOfInverses() {
 		final DoubleType sumOfInverses = new DoubleType();
-		op("stats.sumOfInverses").input(randomlyFilledImg).output(sumOfInverses).compute();
+		ops.op("stats.sumOfInverses").input(randomlyFilledImg).output(sumOfInverses).compute();
 		Assertions.assertEquals(Double.POSITIVE_INFINITY, sumOfInverses.getRealDouble(), 0.00001d, "Sum Of Inverses");
 	}
 
 	@Test
 	public void testSumOfLogs() {
 		final DoubleType sumOfLogs = new DoubleType();
-		op("stats.sumOfLogs").input(randomlyFilledImg).output(sumOfLogs).compute();
+		ops.op("stats.sumOfLogs").input(randomlyFilledImg).output(sumOfLogs).compute();
 		Assertions.assertEquals(Double.NEGATIVE_INFINITY, sumOfLogs.getRealDouble(), 0.00001d, "Sum Of Logs");
 	}
 
 	@Test
 	public void testSumOfSquares() {
 		final DoubleType sumOfSquares = new DoubleType();
-		op("stats.sumOfSquares").input(randomlyFilledImg).output(sumOfSquares).compute();
+		ops.op("stats.sumOfSquares").input(randomlyFilledImg).output(sumOfSquares).compute();
 		Assertions.assertEquals(217588654, sumOfSquares.getRealDouble(), 0.00001d, "Sum Of Squares");
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/regression/leastSquares/QuadricTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/regression/leastSquares/QuadricTest.java
@@ -61,7 +61,7 @@ public class QuadricTest extends AbstractOpTest {
 
 	@Test
 	public void testEquation() {
-		final Matrix4dc solution = op("stats.leastSquares").input(unitSpherePoints).outType(Matrix4dc.class).apply();
+		final Matrix4dc solution = ops.op("stats.leastSquares").input(unitSpherePoints).outType(Matrix4dc.class).apply();
 		final double a = solution.m00();
 		final double b = solution.m11();
 		final double c = solution.m22();
@@ -86,13 +86,13 @@ public class QuadricTest extends AbstractOpTest {
 		final List<Vector3d> points = Stream.generate(Vector3d::new).limit(nPoints).collect(toList());
 
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			op("stats.leastSquares").input(points).outType(Matrix4d.class).apply();
+			ops.op("stats.leastSquares").input(points).outType(Matrix4d.class).apply();
 		});
 	}
 
 	@Test
 	public void testMatrixElements() {
-		final Matrix4dc solution = op("stats.leastSquares").input(unitSpherePoints).outType(Matrix4d.class).apply();
+		final Matrix4dc solution = ops.op("stats.leastSquares").input(unitSpherePoints).outType(Matrix4d.class).apply();
 
 		assertEquals(1.0, solution.m00(), 1e-12, "The matrix element is incorrect");
 		assertEquals(1.0, solution.m11(), 1e-12, "The matrix element is incorrect");

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/AbstractThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/AbstractThresholdTest.java
@@ -84,7 +84,7 @@ public class AbstractThresholdTest extends AbstractOpTest {
 			}
 		}
 		
-		createFunc = Functions.match(ops, "image.histogram", new Nil<Img<UnsignedShortType>>() {}, new Nil<Integer>() {}, new Nil<Histogram1d<UnsignedShortType>>() {});
+		createFunc = Functions.match(ops.env(), "image.histogram", new Nil<Img<UnsignedShortType>>() {}, new Nil<Integer>() {}, new Nil<Histogram1d<UnsignedShortType>>() {});
 	}
 
 	protected Histogram1d<UnsignedShortType> histogram() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/ComputeThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/ComputeThresholdTest.java
@@ -182,7 +182,7 @@ public class ComputeThresholdTest extends AbstractThresholdTest {
 	private Computers.Arity1<Histogram1d<UnsignedShortType>, UnsignedShortType>
 		getComputeThresholdOp(final String name)
 	{
-		return Computers.match(ops, name,
+		return Computers.match(ops.env(), name,
 			new Nil<Histogram1d<UnsignedShortType>>()
 			{}, new Nil<UnsignedShortType>() {});
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/ApplyManualThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/ApplyManualThresholdTest.java
@@ -51,12 +51,12 @@ public class ApplyManualThresholdTest extends AbstractThresholdTest {
 
 	@Test
 	public void testApplyThreshold() throws IncompatibleTypeException {
-		Computers.Arity3<Img<UnsignedShortType>, UnsignedShortType, Comparator<UnsignedShortType>,Iterable<BitType>> createFunc = Computers.match(ops,
-				"threshold.apply", new Nil<Img<UnsignedShortType>>() {
-				}, new Nil<UnsignedShortType>() {
-				}, new Nil<Comparator<UnsignedShortType>>() {
-				}, new Nil<Iterable<BitType>>() {
-				});
+		Computers.Arity3<Img<UnsignedShortType>, UnsignedShortType, Comparator<UnsignedShortType>, Iterable<BitType>> createFunc =
+			Computers.match(ops.env(), "threshold.apply",
+				new Nil<Img<UnsignedShortType>>()
+				{}, new Nil<UnsignedShortType>() {},
+				new Nil<Comparator<UnsignedShortType>>()
+				{}, new Nil<Iterable<BitType>>() {});
 
 		final Img<BitType> out = bitmap();
 		final UnsignedShortType threshold = new UnsignedShortType(30000);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
@@ -102,10 +102,10 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@BeforeEach
 	public void before() throws Exception {
 		in = TestImgGeneration.byteArray(true, new long[] { 10, 10 });
-		Pair<ByteType, ByteType> minMax = op("stats.minMax").input(in).outType(new Nil<Pair<ByteType, ByteType>>() {})
+		Pair<ByteType, ByteType> minMax = ops.op("stats.minMax").input(in).outType(new Nil<Pair<ByteType, ByteType>>() {})
 				.apply();
-		normalizedIn = op("create.img").input(in, new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
-		op("image.normalize").input(in, minMax.getA(), minMax.getB(), new DoubleType(0.0), new DoubleType(1.0))
+		normalizedIn = ops.op("create.img").input(in, new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
+		ops.op("image.normalize").input(in, minMax.getA(), minMax.getB(), new DoubleType(0.0), new DoubleType(1.0))
 				.output(normalizedIn).compute();
 
 		out = in.factory().imgFactory(new BitType()).create(in, new BitType());
@@ -265,7 +265,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalBernsenThreshold() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localBernsen", //
+						.match(ops.env(), "threshold.localBernsen", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -286,7 +286,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalContrastThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localContrast", //
+						.match(ops.env(), "threshold.localContrast", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -305,7 +305,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalHuangThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.huang", //
+						.match(ops.env(), "threshold.huang", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -324,7 +324,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalIJ1Threshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.ij1", //
+						.match(ops.env(), "threshold.ij1", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -343,7 +343,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalIntermodesThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.intermodes", //
+						.match(ops.env(), "threshold.intermodes", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -363,7 +363,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		// NB: Test fails for RectangleShapes of span 1
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.isoData", //
+						.match(ops.env(), "threshold.isoData", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -382,7 +382,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalLiThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.li", //
+						.match(ops.env(), "threshold.li", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -401,7 +401,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMaxEntropyThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.maxEntropy", //
+						.match(ops.env(), "threshold.maxEntropy", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -421,7 +421,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 		// NB: Test fails for RectangleShapes of up to span==2
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.maxLikelihood", //
+						.match(ops.env(), "threshold.maxLikelihood", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -440,7 +440,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalThresholdMean() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localMean", //
+						.match(ops.env(), "threshold.localMean", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -502,7 +502,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMedianThreshold() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localMedian", //
+						.match(ops.env(), "threshold.localMedian", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -522,7 +522,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMidGreyThreshold() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localMidGrey", //
+						.match(ops.env(), "threshold.localMidGrey", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -542,7 +542,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMinErrorThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.minError", //
+						.match(ops.env(), "threshold.minError", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -561,7 +561,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMinimumThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.minimum", //
+						.match(ops.env(), "threshold.minimum", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -580,7 +580,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMomentsThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.moments", //
+						.match(ops.env(), "threshold.moments", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -599,7 +599,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalNiblackThreshold() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localNiblack", //
+						.match(ops.env(), "threshold.localNiblack", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -662,7 +662,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalOtsuThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.otsu", //
+						.match(ops.env(), "threshold.otsu", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -681,7 +681,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalPercentileThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.percentile", //
+						.match(ops.env(), "threshold.percentile", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -700,7 +700,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalPhansalkar() {
 		final Computers.Arity5<RandomAccessibleInterval<DoubleType>, Shape, Double, Double, //
 				OutOfBoundsFactory<DoubleType, RandomAccessibleInterval<DoubleType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localPhansalkar", //
+						.match(ops.env(), "threshold.localPhansalkar", //
 								new Nil<RandomAccessibleInterval<DoubleType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -765,7 +765,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalRenyiEntropyThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.renyiEntropy", //
+						.match(ops.env(), "threshold.renyiEntropy", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -784,7 +784,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalSauvola() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.localSauvola", //
+						.match(ops.env(), "threshold.localSauvola", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
@@ -847,7 +847,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalShanbhagThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.shanbhag", //
+						.match(ops.env(), "threshold.shanbhag", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -866,7 +866,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalTriangleThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.triangle", //
+						.match(ops.env(), "threshold.triangle", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -885,7 +885,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalYenThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.yen", //
+						.match(ops.env(), "threshold.yen", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
@@ -904,7 +904,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalRosinThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
 				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
-						.match(ops, "threshold.rosin", //
+						.match(ops.env(), "threshold.rosin", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/BoxCountTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/BoxCountTest.java
@@ -73,7 +73,7 @@ public class BoxCountTest extends AbstractOpTest {
 		final Img<BitType> img = ArrayImgs.bits(TEST_DIMS);
 
 		// EXECUTE
-		final List<ValuePair<DoubleType, DoubleType>> points = op("topology.boxCount")
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.op("topology.boxCount")
 				.input(img, MAX_SIZE, MIN_SIZE, SCALING, 0l)
 				.outType(new Nil<List<ValuePair<DoubleType, DoubleType>>>() {}).apply();
 
@@ -97,7 +97,7 @@ public class BoxCountTest extends AbstractOpTest {
 		img.forEach(BitType::setOne);
 
 		// EXECUTE
-		final List<ValuePair<DoubleType, DoubleType>> points = op("topology.boxCount")
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.op("topology.boxCount")
 				.input(img, MAX_SIZE, MIN_SIZE, SCALING, 0l)
 				.outType(new Nil<List<ValuePair<DoubleType, DoubleType>>>() {}).apply();
 
@@ -119,7 +119,7 @@ public class BoxCountTest extends AbstractOpTest {
 		hyperView.forEach(BitType::setOne);
 
 		// EXECUTE
-		final List<ValuePair<DoubleType, DoubleType>> points = op("topology.boxCount").input(img, 4L, 1L, 2.0, 0L)
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.op("topology.boxCount").input(img, 4L, 1L, 2.0, 0L)
 				.outType(new Nil<List<ValuePair<DoubleType, DoubleType>>>() {}).apply();
 
 		// VERIFY
@@ -143,7 +143,7 @@ public class BoxCountTest extends AbstractOpTest {
 		hyperView.forEach(BitType::setOne);
 
 		// EXECUTE
-		final List<ValuePair<DoubleType, DoubleType>> points = op("topology.boxCount").input(img, 4L, 1L, 2.0, 1L)
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.op("topology.boxCount").input(img, 4L, 1L, 2.0, 1L)
 				.outType(new Nil<List<ValuePair<DoubleType, DoubleType>>>() {}).apply();
 
 		// VERIFY
@@ -164,7 +164,7 @@ public class BoxCountTest extends AbstractOpTest {
 		access.get().setOne();
 
 		// EXECUTE
-		final List<ValuePair<DoubleType, DoubleType>> points = op("topology.boxCount").input(img, 9L, 3L, 3.0, 0l)
+		final List<ValuePair<DoubleType, DoubleType>> points = ops.op("topology.boxCount").input(img, 9L, 3L, 3.0, 0l)
 				.outType(new Nil<List<ValuePair<DoubleType, DoubleType>>>() {}).apply();
 
 		// VERIFY
@@ -179,7 +179,7 @@ public class BoxCountTest extends AbstractOpTest {
 		final Img<BitType> img = ArrayImgs.bits(9, 9, 9);
 
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			op("topology.boxCount").input(img, 8L, 2L, 1.0, 0L).outType(
+			ops.op("topology.boxCount").input(img, 8L, 2L, 1.0, 0L).outType(
 				new Nil<List<ValuePair<DoubleType, DoubleType>>>()
 				{}).apply();
 		});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NFloatingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NFloatingTest.java
@@ -52,7 +52,7 @@ public class EulerCharacteristic26NFloatingTest extends AbstractOpTest {
         final Img<BitType> img = ArrayImgs.bits(3, 3);
 
 				Assertions.assertThrows(IllegalArgumentException.class, () -> {
-					op("topology.eulerCharacteristic26NFloating").input(img).outType(
+					ops.op("topology.eulerCharacteristic26NFloating").input(img).outType(
 						Double.class).apply();
 				});
 	    }
@@ -69,7 +69,7 @@ public class EulerCharacteristic26NFloatingTest extends AbstractOpTest {
         final Img<BitType> img = drawCube(1, 1, 1, 1);
 
         final DoubleType result = new DoubleType();
-        op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
+        ops.op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
 
         assertEquals(1.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
     }
@@ -85,7 +85,7 @@ public class EulerCharacteristic26NFloatingTest extends AbstractOpTest {
         final Img<BitType> img = drawCube(1, 1, 1, 0);
 
         final DoubleType result = new DoubleType();
-        op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
+        ops.op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
 
         assertEquals(1.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
     }
@@ -106,7 +106,7 @@ public class EulerCharacteristic26NFloatingTest extends AbstractOpTest {
         access.get().setZero();
 
         final DoubleType result = new DoubleType();
-        op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
+        ops.op("topology.eulerCharacteristic26NFloating").input(img).output(result).compute();
 
         assertEquals(2.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
     }
@@ -137,7 +137,7 @@ public class EulerCharacteristic26NFloatingTest extends AbstractOpTest {
         access.get().setOne();
 
         final DoubleType result = new DoubleType();
-        op("topology.eulerCharacteristic26NFloating").input(cube).output(result).compute();
+        ops.op("topology.eulerCharacteristic26NFloating").input(cube).output(result).compute();
 
         assertEquals(0.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
     }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NTest.java
@@ -52,7 +52,7 @@ public class EulerCharacteristic26NTest extends AbstractOpTest {
 		final Img<BitType> img = ArrayImgs.bits(3, 3);
 
 		Assertions.assertThrows(IllegalArgumentException.class, () -> {
-			op("topology.eulerCharacteristic26N").input(img).apply();
+			ops.op("topology.eulerCharacteristic26N").input(img).apply();
 		});
 	}
 
@@ -92,7 +92,7 @@ public class EulerCharacteristic26NTest extends AbstractOpTest {
 		final Img<BitType> img = drawCube(1, 1, 1, 1);
 
 		final DoubleType result = new DoubleType();
-		op("topology.eulerCharacteristic26N").input(img).output(result).compute();
+		ops.op("topology.eulerCharacteristic26N").input(img).output(result).compute();
 
 		assertEquals(1.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
 	}
@@ -109,7 +109,7 @@ public class EulerCharacteristic26NTest extends AbstractOpTest {
 		final Img<BitType> img = drawCube(1, 1, 1, 0);
 
 		final DoubleType result = new DoubleType();
-		op("topology.eulerCharacteristic26N").input(img).output(result).compute();
+		ops.op("topology.eulerCharacteristic26N").input(img).output(result).compute();
 
 		assertEquals(0.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
 	}
@@ -130,7 +130,7 @@ public class EulerCharacteristic26NTest extends AbstractOpTest {
 		access.get().setZero();
 
 		final DoubleType result = new DoubleType();
-		op("topology.eulerCharacteristic26N").input(img).output(result).compute();
+		ops.op("topology.eulerCharacteristic26N").input(img).output(result).compute();
 
 		assertEquals(2.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
 	}
@@ -161,7 +161,7 @@ public class EulerCharacteristic26NTest extends AbstractOpTest {
 		access.get().setOne();
 
 		final DoubleType result = new DoubleType();
-		op("topology.eulerCharacteristic26N").input(cube).output(result).compute();
+		ops.op("topology.eulerCharacteristic26N").input(cube).output(result).compute();
 
 		assertEquals(0.0, result.get(), 1e-12, "Euler characteristic (χ) is incorrect");
 	}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCorrectionTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCorrectionTest.java
@@ -52,7 +52,7 @@ public class EulerCorrectionTest extends AbstractOpTest {
         final Img<BitType> img = ArrayImgs.bits(3, 3);
 
 				Assertions.assertThrows(IllegalArgumentException.class, () -> {
-					op("topology.eulerCorrection").input(img).apply();
+					ops.op("topology.eulerCorrection").input(img).apply();
 				});
 	    }
 
@@ -80,7 +80,7 @@ public class EulerCorrectionTest extends AbstractOpTest {
         assertEquals(0, voxelEdgeFaceIntersections, "Number intersections is incorrect");
 
         DoubleType result = new DoubleType();
-        op("topology.eulerCorrection").input(cube).output(result).compute();
+        ops.op("topology.eulerCorrection").input(cube).output(result).compute();
 
         assertEquals(0, result.get(), 1e-12, "Euler correction is incorrect");
     }
@@ -118,7 +118,7 @@ public class EulerCorrectionTest extends AbstractOpTest {
         assertEquals(108, voxelEdgeFaceIntersections, "Number intersections is incorrect");
 
         DoubleType result = new DoubleType();
-        op("topology.eulerCorrection").input(cube).output(result).compute();
+        ops.op("topology.eulerCorrection").input(cube).output(result).compute();
         assertEquals(1, result.get(), 1e-12, "Euler contribution is incorrect");
     }
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/addDimensionView/AddDimensionViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/addDimensionView/AddDimensionViewTest.java
@@ -64,12 +64,12 @@ public class AddDimensionViewTest extends AbstractOpTest {
 
 		MixedTransformView<DoubleType> il2 = Views.addDimension((RandomAccessible<DoubleType>) img);
 
-		Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>> addDimFunc = ops.op(
-				"transform.addDimensionView",
-				new Nil<Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>>>() {
-				}, new Nil[] { new Nil<RandomAccessible<DoubleType>>() {
-				} }, new Nil<MixedTransformView<DoubleType>>() {
-				});
+		Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>> addDimFunc =
+			ops.env().op("transform.addDimensionView",
+				new Nil<Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>>>()
+				{}, new Nil[] { new Nil<RandomAccessible<DoubleType>>() {} },
+				new Nil<MixedTransformView<DoubleType>>()
+				{});
 		MixedTransformView<DoubleType> opr = addDimFunc.apply(img);
 
 		assertEquals(il2.numDimensions(), opr.numDimensions());
@@ -90,15 +90,12 @@ public class AddDimensionViewTest extends AbstractOpTest {
 
 		IntervalView<DoubleType> il2 = Views.addDimension(img, min, max);
 
-		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>> addDimFunc = ops
-				.op(
-				"transform.addDimensionView",
-						new Nil<Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>>>() {
-						}, new Nil[] { new Nil<RandomAccessibleInterval<DoubleType>>() {
-				}, new Nil<Long>() {
-				}, new Nil<Long>() {
-				} }, new Nil<IntervalView<DoubleType>>() {
-				});
+		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>> addDimFunc =
+			ops.env().op("transform.addDimensionView",
+				new Nil<Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>>>()
+				{}, new Nil[] { new Nil<RandomAccessibleInterval<DoubleType>>() {},
+					new Nil<Long>()
+					{}, new Nil<Long>() {} }, new Nil<IntervalView<DoubleType>>() {});
 		IntervalView<DoubleType> opr = addDimFunc.apply(img, min, max);
 
 		assertEquals(il2.numDimensions(), opr.numDimensions(), 0.0);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/addDimensionView/AddDimensionViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/addDimensionView/AddDimensionViewTest.java
@@ -64,7 +64,7 @@ public class AddDimensionViewTest extends AbstractOpTest {
 
 		MixedTransformView<DoubleType> il2 = Views.addDimension((RandomAccessible<DoubleType>) img);
 
-		Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>> addDimFunc = ops.findOp(
+		Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>> addDimFunc = ops.op(
 				"transform.addDimensionView",
 				new Nil<Function<RandomAccessible<DoubleType>, MixedTransformView<DoubleType>>>() {
 				}, new Nil[] { new Nil<RandomAccessible<DoubleType>>() {
@@ -91,7 +91,7 @@ public class AddDimensionViewTest extends AbstractOpTest {
 		IntervalView<DoubleType> il2 = Views.addDimension(img, min, max);
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>> addDimFunc = ops
-				.findOp(
+				.op(
 				"transform.addDimensionView",
 						new Nil<Functions.Arity3<RandomAccessibleInterval<DoubleType>, Long, Long, IntervalView<DoubleType>>>() {
 						}, new Nil[] { new Nil<RandomAccessibleInterval<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseNumericView/CollapseNumericViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseNumericView/CollapseNumericViewTest.java
@@ -70,7 +70,7 @@ public class CollapseNumericViewTest extends AbstractOpTest {
 		Img<NativeARGBDoubleType> img = new ArrayImgFactory<>(new NativeARGBDoubleType()).create(new int[] { 10, 10 });
 		
 		Function<Img<NativeARGBDoubleType>, CompositeIntervalView<NativeARGBDoubleType, NumericComposite<NativeARGBDoubleType>>> collapseFunc = 
-				op("transform.collapseNumericView").input(img).outType(new Nil<CompositeIntervalView<NativeARGBDoubleType, NumericComposite<NativeARGBDoubleType>>>() {}).function();
+				ops.op("transform.collapseNumericView").input(img).outType(new Nil<CompositeIntervalView<NativeARGBDoubleType, NumericComposite<NativeARGBDoubleType>>>() {}).function();
 
 		CompositeIntervalView<NativeARGBDoubleType, NumericComposite<NativeARGBDoubleType>> il2 = Views
 				.collapseNumeric((RandomAccessibleInterval<NativeARGBDoubleType>) img);
@@ -80,7 +80,7 @@ public class CollapseNumericViewTest extends AbstractOpTest {
 		assertEquals(il2.numDimensions(), opr.numDimensions());
 
 		BiFunction<RandomAccessible<NativeARGBDoubleType>, Integer, CompositeView<NativeARGBDoubleType, NumericComposite<NativeARGBDoubleType>>> collapseFuncRA = Functions
-				.match(ops, "transform.collapseNumericView",
+				.match(ops.env(), "transform.collapseNumericView",
 						new Nil<RandomAccessible<NativeARGBDoubleType>>() {
 				}, new Nil<Integer>() {
 				},

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseRealView/CollapseRealViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseRealView/CollapseRealViewTest.java
@@ -66,7 +66,7 @@ public class CollapseRealViewTest extends AbstractOpTest {
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });
 
 		Function<RandomAccessibleInterval<DoubleType>, CompositeIntervalView<DoubleType, RealComposite<DoubleType>>> collapseFunc = Functions
-				.match(ops, "transform.collapseRealView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.collapseRealView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<CompositeIntervalView<DoubleType, RealComposite<DoubleType>>>() {
 				});
 
@@ -77,7 +77,7 @@ public class CollapseRealViewTest extends AbstractOpTest {
 		assertEquals(il2.numDimensions(), opr.numDimensions());
 
 		BiFunction<RandomAccessible<DoubleType>, Integer, CompositeView<DoubleType, RealComposite<DoubleType>>> collapseFuncRA = Functions
-				.match(ops, "transform.collapseRealView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.collapseRealView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<CompositeView<DoubleType, RealComposite<DoubleType>>>() {
 				});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseView/CollapseViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/collapseView/CollapseViewTest.java
@@ -64,7 +64,7 @@ public class CollapseViewTest extends AbstractOpTest {
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });
 
 		Function<RandomAccessibleInterval<DoubleType>, CompositeIntervalView<DoubleType, ? extends GenericComposite<DoubleType>>> collapseFunc = Functions
-				.match(ops, "transform.collapseView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.collapseView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<CompositeIntervalView<DoubleType, ? extends GenericComposite<DoubleType>>>() {
 				});
 
@@ -80,7 +80,7 @@ public class CollapseViewTest extends AbstractOpTest {
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10, 10 });
 
 		Function<RandomAccessible<DoubleType>, CompositeView<DoubleType, ? extends GenericComposite<DoubleType>>> collapseFunc = Functions
-				.match(ops, "transform.collapseView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.collapseView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<CompositeView<DoubleType, ? extends GenericComposite<DoubleType>>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/concatenateView/ConcatenateViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/concatenateView/ConcatenateViewTest.java
@@ -108,7 +108,7 @@ public class ConcatenateViewTest extends AbstractOpTest {
 	@Test
 	public void defaultConcatenateTest() {
 		BiFunction<Integer, List<RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<ByteType>> concatFunc = Functions
-				.match(ops, "transform.concatenateView", new Nil<Integer>() {
+				.match(ops.env(), "transform.concatenateView", new Nil<Integer>() {
 				}, new Nil<List<RandomAccessibleInterval<ByteType>>>() {
 				}, new Nil<RandomAccessibleInterval<ByteType>>() {
 				});
@@ -123,7 +123,7 @@ public class ConcatenateViewTest extends AbstractOpTest {
 	@Test
 	public void concatenateWithAccessModeTest() {
 		Functions.Arity3<Integer, StackAccessMode, List<RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<ByteType>> concatFunc = Functions
-				.match(ops, "transform.concatenateView", new Nil<Integer>() {
+				.match(ops.env(), "transform.concatenateView", new Nil<Integer>() {
 				}, new Nil<StackAccessMode>() {
 				}, new Nil<List<RandomAccessibleInterval<ByteType>>>() {
 				}, new Nil<RandomAccessibleInterval<ByteType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/dropSingleDimensionsView/DropSingletonDimensionsViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/dropSingleDimensionsView/DropSingletonDimensionsViewTest.java
@@ -59,7 +59,7 @@ public class DropSingletonDimensionsViewTest extends AbstractOpTest {
 	public void dropSingletonDimensionsTest() {
 
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessibleInterval<DoubleType>> dropFunc = Functions
-				.match(ops, "transform.dropSingletonDimensionsView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.dropSingletonDimensionsView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendBorderView/ExtendBorderViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendBorderView/ExtendBorderViewTest.java
@@ -63,7 +63,7 @@ public class ExtendBorderViewTest extends AbstractOpTest {
 	@Test
 	public void extendBorderTest() {
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendBorderView", raiNil,
+				.match(ops.env(), "transform.extendBorderView", raiNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendMirrorDoubleView/ExtendMirrorDoubleViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendMirrorDoubleView/ExtendMirrorDoubleViewTest.java
@@ -63,7 +63,7 @@ public class ExtendMirrorDoubleViewTest extends AbstractOpTest {
 	@Test
 	public void extendMirrorDoubleTest() {
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendMirrorDoubleView", raiNil,
+				.match(ops.env(), "transform.extendMirrorDoubleView", raiNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendMirrorSingleView/ExtendMirrorSingleViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendMirrorSingleView/ExtendMirrorSingleViewTest.java
@@ -63,7 +63,7 @@ public class ExtendMirrorSingleViewTest extends AbstractOpTest {
 	@Test
 	public void extendMirrorSingleTest() {
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendMirrorSingleView", raiNil,
+				.match(ops.env(), "transform.extendMirrorSingleView", raiNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendPeriodicView/ExtendPeriodicViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendPeriodicView/ExtendPeriodicViewTest.java
@@ -63,7 +63,7 @@ public class ExtendPeriodicViewTest extends AbstractOpTest {
 	@Test
 	public void extendPeriodicTest() {
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendPeriodicView", raiNil,
+				.match(ops.env(), "transform.extendPeriodicView", raiNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendRandomView/ExtendRandomViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendRandomView/ExtendRandomViewTest.java
@@ -64,7 +64,7 @@ public class ExtendRandomViewTest extends AbstractOpTest {
 	@Test
 	public void extendRandomTest() {
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Double, Double, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendRandomView", raiNil, doubleNil, doubleNil,
+				.match(ops.env(), "transform.extendRandomView", raiNil, doubleNil, doubleNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendValueView/ExtendValueViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendValueView/ExtendValueViewTest.java
@@ -63,7 +63,7 @@ public class ExtendValueViewTest extends AbstractOpTest {
 	@Test
 	public void extendValueTest() {
 		BiFunction<RandomAccessibleInterval<DoubleType>, DoubleType, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendValueView", raiNil, new Nil<DoubleType>() {
+				.match(ops.env(), "transform.extendValueView", raiNil, new Nil<DoubleType>() {
 				}, new Nil<RandomAccessible<DoubleType>>() {
 				});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendView/ExtendViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendView/ExtendViewTest.java
@@ -65,7 +65,7 @@ public class ExtendViewTest extends AbstractOpTest {
 	@Test
 	public void defaultExtendTest() {
 		BiFunction<RandomAccessibleInterval<DoubleType>, OutOfBoundsFactory<DoubleType, ? super RandomAccessibleInterval<DoubleType>>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendView", raiNil,
+				.match(ops.env(), "transform.extendView", raiNil,
 						new Nil<OutOfBoundsFactory<DoubleType, ? super RandomAccessibleInterval<DoubleType>>>() {
 				},
 						new Nil<RandomAccessible<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendZeroView/ExtendZeroViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/extendZeroView/ExtendZeroViewTest.java
@@ -63,7 +63,7 @@ public class ExtendZeroViewTest extends AbstractOpTest {
 	@Test
 	public void extendZeroTest() {
 		Function<RandomAccessibleInterval<DoubleType>, RandomAccessible<DoubleType>> extendFunc = Functions
-				.match(ops, "transform.extendZeroView", raiNil,
+				.match(ops.env(), "transform.extendZeroView", raiNil,
 						new Nil<RandomAccessible<DoubleType>>() {
 				});
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/flatIterableView/FlatIterableViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/flatIterableView/FlatIterableViewTest.java
@@ -64,7 +64,7 @@ public class FlatIterableViewTest extends AbstractOpTest {
 	@Test
 	public void defaultFlatIterableTest() {
 		Function<RandomAccessibleInterval<DoubleType>, IterableInterval<DoubleType>> flatIterableFunc = Functions
-				.match(ops, "transform.flatIterableView", raiNil, iiNil);
+				.match(ops.env(), "transform.flatIterableView", raiNil, iiNil);
 
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/hyperSliceView/HyperSliceViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/hyperSliceView/HyperSliceViewTest.java
@@ -74,7 +74,7 @@ public class HyperSliceViewTest extends AbstractOpTest {
 	@Test
 	public void defaultHyperSliceTest() {
 		Functions.Arity3<RandomAccessible<DoubleType>, Integer, Long, MixedTransformView<DoubleType>> hyperSliceFunc = Functions
-				.match(ops, "transform.hyperSliceView", raNil, integerNil, longNil,
+				.match(ops.env(), "transform.hyperSliceView", raNil, integerNil, longNil,
 						new Nil<MixedTransformView<DoubleType>>() {
 				});
 
@@ -95,7 +95,7 @@ public class HyperSliceViewTest extends AbstractOpTest {
 	public void IntervalHyperSliceTest() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Integer, Long, IntervalView<DoubleType>> hyperSliceFunc = Functions
-				.match(ops, "transform.hyperSliceView", raiNil, integerNil, longNil,
+				.match(ops.env(), "transform.hyperSliceView", raiNil, integerNil, longNil,
 						new Nil<IntervalView<DoubleType>>() {
 						});
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/interpolateView/InterpolateViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/interpolateView/InterpolateViewTest.java
@@ -65,7 +65,7 @@ public class InterpolateViewTest extends AbstractOpTest {
 	public void defaultInterpolateTest() {
 
 		BiFunction<RandomAccessible<DoubleType>, FloorInterpolatorFactory<DoubleType>, RealRandomAccessible<DoubleType>> interpolateFunc = Functions
-				.match(ops, "transform.interpolateView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.interpolateView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<FloorInterpolatorFactory<DoubleType>>() {
 				}, new Nil<RealRandomAccessible<DoubleType>>() {
 				});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/intervalView/IntervalViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/intervalView/IntervalViewTest.java
@@ -67,7 +67,7 @@ public class IntervalViewTest extends AbstractOpTest {
 	public void defaultIntervalTest() {
 
 		BiFunction<RandomAccessible<DoubleType>, Interval, IntervalView<DoubleType>> intervalFunc = Functions
-				.match(ops, "transform.intervalView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.intervalView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Interval>() {
 				}, new Nil<IntervalView<DoubleType>>() {
 				});
@@ -94,7 +94,7 @@ public class IntervalViewTest extends AbstractOpTest {
 	public void intervalMinMaxTest() {
 
 		Functions.Arity3<RandomAccessible<DoubleType>, long[], long[], IntervalView<DoubleType>> intervalFunc = Functions
-				.match(ops, "transform.intervalView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.intervalView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<long[]>() {
 				}, new Nil<long[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/invertAxisView/InvertAxisViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/invertAxisView/InvertAxisViewTest.java
@@ -67,7 +67,7 @@ public class InvertAxisViewTest extends AbstractOpTest {
 	public void defaultInvertAxisTest() {
 
 		BiFunction<RandomAccessible<DoubleType>, Integer, MixedTransformView<DoubleType>> invertFunc = Functions
-				.match(ops, "transform.invertAxisView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.invertAxisView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<MixedTransformView<DoubleType>>() {
 				});
@@ -89,7 +89,7 @@ public class InvertAxisViewTest extends AbstractOpTest {
 	public void intervalInvertAxisTest() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, Integer, IntervalView<DoubleType>> invertFunc = Functions
-				.match(ops, "transform.invertAxisView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.invertAxisView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<IntervalView<DoubleType>>() {
 				});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/offsetView/OffsetViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/offsetView/OffsetViewTest.java
@@ -65,7 +65,7 @@ public class OffsetViewTest extends AbstractOpTest {
 	public void defaultOffsetTest() {
 
 		BiFunction<RandomAccessible<DoubleType>, long[], MixedTransformView<DoubleType>> offsetFunc = Functions
-				.match(ops, "transform.offsetView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.offsetView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<long[]>() {
 				}, new Nil<MixedTransformView<DoubleType>>() {
 				});
@@ -87,7 +87,7 @@ public class OffsetViewTest extends AbstractOpTest {
 	public void defaultOffsetIntervalTest() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, Interval, IntervalView<DoubleType>> offsetFunc = Functions
-				.match(ops, "transform.offsetView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.offsetView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<Interval>() {
 				}, new Nil<IntervalView<DoubleType>>() {
 				});
@@ -109,7 +109,7 @@ public class OffsetViewTest extends AbstractOpTest {
 	public void defaultOffsetStartEndTest() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, long[], long[], IntervalView<DoubleType>> offsetFunc = Functions
-				.match(ops, "transform.offsetView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.offsetView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<long[]>() {
 				}, new Nil<long[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/permuteView/PermuteViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/permuteView/PermuteViewTest.java
@@ -76,7 +76,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void defaultPermuteTest() {
 
 		Functions.Arity3<RandomAccessible<DoubleType>, Integer, Integer, MixedTransformView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.permuteView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<MixedTransformView<DoubleType>>() {
@@ -99,7 +99,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void defaultPermuteCoordinatesTest() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, int[], IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {
 				});
@@ -125,7 +125,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void permuteCoordinatesOfDimensionTest() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, int[], Integer, IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<Integer>() {
 				}, new Nil<IntervalView<DoubleType>>() {
@@ -153,7 +153,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void defaultPermuteCoordinatesInverseTest() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, int[], IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesInverseView",
+				.match(ops.env(), "transform.permuteCoordinatesInverseView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {
@@ -180,7 +180,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void permuteCoordinatesInverseOfDimensionTest() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, int[], Integer, IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesInverseView",
+				.match(ops.env(), "transform.permuteCoordinatesInverseView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<Integer>() {
@@ -211,7 +211,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void testIntervalPermute() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Integer, Integer, IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteView",
+				.match(ops.env(), "transform.permuteView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
@@ -240,7 +240,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void testIntervalPermuteCoordinates() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, int[], IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.permuteCoordinatesView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {
 				});
@@ -270,7 +270,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void testIntervalPermuteDimensionCoordinates() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, int[], Integer, IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesInverseView",
+				.match(ops.env(), "transform.permuteCoordinatesInverseView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<Integer>() {
@@ -303,7 +303,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void testIntervalPermuteInverseCoordinates() {
 
 		BiFunction<RandomAccessibleInterval<DoubleType>, int[], IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesInverseView",
+				.match(ops.env(), "transform.permuteCoordinatesInverseView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {
@@ -335,7 +335,7 @@ public class PermuteViewTest extends AbstractOpTest {
 	public void testIntervalPermuteInverseDimensionCoordinates() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, int[], Integer, IntervalView<DoubleType>> permuteFunc = Functions
-				.match(ops, "transform.permuteCoordinatesInverseView",
+				.match(ops.env(), "transform.permuteCoordinatesInverseView",
 						new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<int[]>() {
 				}, new Nil<Integer>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/rasterView/RasterViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/rasterView/RasterViewTest.java
@@ -66,7 +66,7 @@ public class RasterViewTest extends AbstractOpTest {
 	public void defaultRasterTest() {
 
 		Function<RealRandomAccessible<DoubleType>, RandomAccessibleOnRealRandomAccessible<DoubleType>> rasterFunc = Functions
-				.match(ops, "transform.rasterView", new Nil<RealRandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.rasterView", new Nil<RealRandomAccessible<DoubleType>>() {
 				}, new Nil<RandomAccessibleOnRealRandomAccessible<DoubleType>>() {
 				});
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/rotateView/RotateViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/rotateView/RotateViewTest.java
@@ -67,7 +67,7 @@ public class RotateViewTest extends AbstractOpTest {
 	public void testDefaultRotate() {
 
 		Functions.Arity3<RandomAccessible<DoubleType>, Integer, Integer, MixedTransformView<DoubleType>> rotateFunc = Functions
-				.match(ops, "transform.rotateView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.rotateView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<MixedTransformView<DoubleType>>() {
@@ -90,7 +90,7 @@ public class RotateViewTest extends AbstractOpTest {
 	public void testIntervalRotate() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Integer, Integer, IntervalView<DoubleType>> rotateFunc = Functions
-				.match(ops, "transform.rotateView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.rotateView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<IntervalView<DoubleType>>() {
@@ -117,7 +117,7 @@ public class RotateViewTest extends AbstractOpTest {
 	public void testIntervalRotateInterval() {
 
 		Functions.Arity3<RandomAccessibleInterval<DoubleType>, Integer, Integer, IntervalView<DoubleType>> rotateFunc = Functions
-				.match(ops, "transform.rotateView", new Nil<RandomAccessibleInterval<DoubleType>>() {
+				.match(ops.env(), "transform.rotateView", new Nil<RandomAccessibleInterval<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<IntervalView<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/shearView/ShearViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/shearView/ShearViewTest.java
@@ -66,7 +66,7 @@ public class ShearViewTest extends AbstractOpTest {
 	public void defaultShearTest() {
 
 		Functions.Arity3<RandomAccessible<DoubleType>, Integer, Integer, TransformView<DoubleType>> shearFunc = Functions
-				.match(ops, "transform.shearView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.shearView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<TransformView<DoubleType>>() {
@@ -97,7 +97,7 @@ public class ShearViewTest extends AbstractOpTest {
 	public void ShearIntervalTest() {
 
 		Functions.Arity4<RandomAccessible<DoubleType>, Interval, Integer, Integer, IntervalView<DoubleType>> shearFunc = Functions
-				.match(ops, "transform.shearView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.shearView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Interval>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/stackView/StackViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/stackView/StackViewTest.java
@@ -61,10 +61,10 @@ public class StackViewTest extends AbstractOpTest {
 
 	@Test
 	public void defaultStackTest() {
-		Function<List<Img<DoubleType>>, RandomAccessibleInterval<DoubleType>> stackFunc = Functions.match(ops,
-				"transform.stackView", new Nil<List<Img<DoubleType>>>() {
-		}, new Nil<RandomAccessibleInterval<DoubleType>>() {
-		});
+		Function<List<Img<DoubleType>>, RandomAccessibleInterval<DoubleType>> stackFunc =
+			Functions.match(ops.env(), "transform.stackView",
+				new Nil<List<Img<DoubleType>>>()
+				{}, new Nil<RandomAccessibleInterval<DoubleType>>() {});
 
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });
 
@@ -82,7 +82,7 @@ public class StackViewTest extends AbstractOpTest {
 	public void stackWithAccessModeTest() {
 
 		BiFunction<StackAccessMode, List<Img<DoubleType>>, RandomAccessibleInterval<DoubleType>> stackFunc = Functions
-				.match(ops, "transform.stackView", new Nil<StackAccessMode>() {
+				.match(ops.env(), "transform.stackView", new Nil<StackAccessMode>() {
 				}, new Nil<List<Img<DoubleType>>>() {
 				}, new Nil<RandomAccessibleInterval<DoubleType>>() {
 				});

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/subsampleView/SubsampleViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/subsampleView/SubsampleViewTest.java
@@ -69,7 +69,7 @@ public class SubsampleViewTest extends AbstractOpTest {
 	@Test
 	public void defaultSubsampleTest() {
 
-		BiFunction<Img<DoubleType>, Long, SubsampleView<DoubleType>> subsampleFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, Long, SubsampleView<DoubleType>> subsampleFunc = Functions.match(ops.env(),
 				"transform.subsampleView", new Nil<Img<DoubleType>>() {
 		}, new Nil<Long>() {
 		}, new Nil<SubsampleView<DoubleType>>() {
@@ -97,7 +97,7 @@ public class SubsampleViewTest extends AbstractOpTest {
 	@Test
 	public void defaultSubsampleStepsTest() {
 
-		BiFunction<Img<DoubleType>, long[], SubsampleView<DoubleType>> subsampleFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, long[], SubsampleView<DoubleType>> subsampleFunc = Functions.match(ops.env(),
 				"transform.subsampleView", new Nil<Img<DoubleType>>() {
 		}, new Nil<long[]>() {
 		}, new Nil<SubsampleView<DoubleType>>() {
@@ -125,7 +125,7 @@ public class SubsampleViewTest extends AbstractOpTest {
 	@Test
 	public void testIntervalSubsample() {
 
-		BiFunction<Img<DoubleType>, Long, SubsampleIntervalView<DoubleType>> subsampleFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, Long, SubsampleIntervalView<DoubleType>> subsampleFunc = Functions.match(ops.env(),
 				"transform.subsampleView", new Nil<Img<DoubleType>>() {
 		}, new Nil<Long>() {
 		}, new Nil<SubsampleIntervalView<DoubleType>>() {
@@ -155,7 +155,7 @@ public class SubsampleViewTest extends AbstractOpTest {
 	@Test
 	public void testIntervalSubsampleSteps() {
 
-		BiFunction<Img<DoubleType>, long[], SubsampleIntervalView<DoubleType>> subsampleFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, long[], SubsampleIntervalView<DoubleType>> subsampleFunc = Functions.match(ops.env(),
 				"transform.subsampleView", new Nil<Img<DoubleType>>() {
 				}, new Nil<long[]>() {
 				}, new Nil<SubsampleIntervalView<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/translateView/TranslateViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/translateView/TranslateViewTest.java
@@ -70,7 +70,7 @@ public class TranslateViewTest extends AbstractOpTest {
 	@Test
 	public void defaultTranslateTest() {
 
-		BiFunction<Img<DoubleType>, long[], MixedTransformView<DoubleType>> translateFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, long[], MixedTransformView<DoubleType>> translateFunc = Functions.match(ops.env(),
 				"transform.translateView", new Nil<Img<DoubleType>>() {
 		}, new Nil<long[]>() {
 		}, new Nil<MixedTransformView<DoubleType>>() {
@@ -92,7 +92,7 @@ public class TranslateViewTest extends AbstractOpTest {
 	@Test
 	public void testIntervalTranslate() {
 
-		BiFunction<Img<DoubleType>, long[], IntervalView<DoubleType>> translateFunc = Functions.match(ops,
+		BiFunction<Img<DoubleType>, long[], IntervalView<DoubleType>> translateFunc = Functions.match(ops.env(),
 				"transform.translateView", new Nil<Img<DoubleType>>() {
 				}, new Nil<long[]>() {
 				}, new Nil<IntervalView<DoubleType>>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/unshearView/UnshearViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/unshearView/UnshearViewTest.java
@@ -64,7 +64,7 @@ public class UnshearViewTest extends AbstractOpTest {
 	public void defaultUnshearTest() {
 
 		Functions.Arity3<RandomAccessible<DoubleType>, Integer, Integer, TransformView<DoubleType>> unshearFunc = Functions
-				.match(ops, "transform.unshearView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.unshearView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {
 				}, new Nil<TransformView<DoubleType>>() {
@@ -94,7 +94,7 @@ public class UnshearViewTest extends AbstractOpTest {
 	public void UnshearIntervalTest() {
 
 		Functions.Arity4<RandomAccessible<DoubleType>, Interval, Integer, Integer, IntervalView<DoubleType>> unshearFunc = Functions
-				.match(ops, "transform.unshearView", new Nil<RandomAccessible<DoubleType>>() {
+				.match(ops.env(), "transform.unshearView", new Nil<RandomAccessible<DoubleType>>() {
 				}, new Nil<Interval>() {
 				}, new Nil<Integer>() {
 				}, new Nil<Integer>() {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/zeroMinView/ZeroMinViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/transform/zeroMinView/ZeroMinViewTest.java
@@ -59,11 +59,10 @@ public class ZeroMinViewTest extends AbstractOpTest {
 	@Test
 	public void defaultZeroMinTest() {
 
-		Function<IntervalView<DoubleType>, IntervalView<DoubleType>> zeroMinFunc = Functions.match(ops,
-				"transform.zeroMinView",
-				new Nil<IntervalView<DoubleType>>() {
-		}, new Nil<IntervalView<DoubleType>>() {
-		});
+		Function<IntervalView<DoubleType>, IntervalView<DoubleType>> zeroMinFunc =
+			Functions.match(ops.env(), "transform.zeroMinView",
+				new Nil<IntervalView<DoubleType>>()
+				{}, new Nil<IntervalView<DoubleType>>() {});
 		Img<DoubleType> img = new ArrayImgFactory<>(new DoubleType()).create(new int[] { 10, 10 });
 
 		IntervalView<DoubleType> imgTranslated = Views.interval(

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/LiftingTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/LiftingTest.java
@@ -22,10 +22,10 @@ public class LiftingTest<I extends RealType<I>, O extends RealType<O>> extends A
 
 	@Test
 	public void testLiftToImg() {
-		Img<DoubleType> input = op("create.img").input(new FinalDimensions(10, 10), new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
-		Img<DoubleType> output = op("create.img").input(new FinalDimensions(10, 10), new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
+		Img<DoubleType> input = ops.op("create.img").input(new FinalDimensions(10, 10), new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
+		Img<DoubleType> output = ops.op("create.img").input(new FinalDimensions(10, 10), new DoubleType()).outType(new Nil<Img<DoubleType>>() {}).apply();
 		
-		op("test.liftImg").input(input).output(output).compute();
+		ops.op("test.liftImg").input(input).output(output).compute();
 
 		Cursor<DoubleType> cursor = output.cursor();
 		while(cursor.hasNext()) {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/TypeExtractorTests.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/TypeExtractorTests.java
@@ -36,7 +36,7 @@ public class TypeExtractorTests extends AbstractOpTest {
 		OutOfBoundsFactory<UnsignedByteType, RandomAccessibleInterval<UnsignedByteType>> oobf = new OutOfBoundsConstantValueFactory<>(
 				new UnsignedByteType(5));
 
-		String output = (String) op("test.oobcvfTypeExtractor").input(oobf).apply();
+		String output = (String) ops.op("test.oobcvfTypeExtractor").input(oobf).apply();
 		// make sure that output matches the return from the Op above, specific to the
 		// type of OOBF we passed through.
 		assert output.equals("oobcvf");
@@ -50,6 +50,6 @@ public class TypeExtractorTests extends AbstractOpTest {
 		OutOfBoundsFactory<UnsignedByteType, RandomAccessibleInterval<UnsignedByteType>> oobf = new OutOfBoundsRandomValueFactory<>( 
 				new UnsignedByteType(7), 7, 7);
 		Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(new long[] { 10, 10 }); 
-		String output = (String) op("test.oobrvfTypeExtractor").input(oobf, img).apply(); // make sure that output matches the return from the Op above, specific to the // type of OOBF we passed through. 
+		String output = (String) ops.op("test.oobrvfTypeExtractor").input(oobf, img).apply(); // make sure that output matches the return from the Op above, specific to the // type of OOBF we passed through. 
 		assert output.equals("oobrvf"); } 
 	}

--- a/scijava/scijava-ops/src/main/java/module-info.java
+++ b/scijava/scijava-ops/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.scijava.ops {
 
 	// -- Open plugins to scijava-common
 	opens org.scijava.ops to org.scijava;
+	opens org.scijava.ops.impl to org.scijava;
 
   // FIXME: This is a file name and is thus unstable
   requires geantyref;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
@@ -29,7 +29,6 @@
 
 package org.scijava.ops;
 
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.ops.matcher.OpRef;
 
 /**

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
@@ -29,7 +29,11 @@
 
 package org.scijava.ops;
 
+import java.lang.reflect.Type;
+
+import org.scijava.ops.core.builder.OpBuilder;
 import org.scijava.ops.matcher.OpRef;
+import org.scijava.types.Nil;
 
 /**
  * An op environment is the top-level entry point into op execution. It provides
@@ -49,15 +53,8 @@ import org.scijava.ops.matcher.OpRef;
  * <li>Configuration of environment "hints" to improve performance in time or
  * space.</li>
  * </ul>
- * <p>
- * The default&mdash;but not necessarily <em>only</em>&mdash;op environment is
- * the {@link OpService} of the application. The environment can be modified by
- * using a {@link CustomOpEnvironment}, or by implementing this interface
- * directly.
- * </p>
  * 
  * @author Curtis Rueden
- * @see OpService
  */
 public interface OpEnvironment {
 
@@ -65,4 +62,15 @@ public interface OpEnvironment {
 	Iterable<OpInfo> infos();
 	
 	Iterable<OpInfo> infos(String name);
+
+	// TODO: Add interface method: OpInfo info(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType);
+
+	<T> T op(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType);
+
+	default OpBuilder op(final String opName) {
+		return new OpBuilder(this, opName);
+	}
+
+	/** Discerns the generic type of an object instance. */
+	Type genericType(Object obj);
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpEnvironment.java
@@ -73,4 +73,40 @@ public interface OpEnvironment {
 
 	/** Discerns the generic type of an object instance. */
 	Type genericType(Object obj);
+
+	/**
+	 * Used to enrich a lambda expression with its generic type. Its usage is
+	 * necessary in order to find Ops that could take this lamdba expression as an
+	 * argument.
+	 * <p>
+	 * Suppose, for example, that a user has written a lambda
+	 * {@code Computers.Arity1<Double, Double> computer}, but a user wishes to
+	 * have a {@code Computers.Arity1<Iterable<Double>, Iterable<Double>>}. They
+	 * know of an Op in the {@code OpEnvironment} that is able to adapt
+	 * {@code computer} so that it is run in a parallel fashion. They cannot
+	 * simply call
+	 * <p>
+	 *
+	 * <pre>
+	 * <code>
+	 * op("adapt").input(computer).outType(new Nil&lt;Computers.Arity1&lt;Iterable&lt;Double&gt;, Iterable&lt;Double&gt;&gt;&gt;() {}).apply()
+	 * </code>
+	 * </pre>
+	 *
+	 * since the type parameters of {@code computer} are not retained at runtime.
+	 * <p>
+	 * {@code opify} should be used as a method of retaining that fully reified
+	 * lambda type so that it can be used by the {@link OpMatcher}.
+	 * <p>
+	 * Note: {@code opify} <b>does not</b> need to be used with anonymous
+	 * subclasses; these retain their type parameters at runtime. It is only
+	 * lambda expressions that need to be passed to this method.
+	 * 
+	 * @param <T> The type of the op instance to enrich.
+	 * @param op The op instance to enrich.
+	 * @param type The intended generic type of the object to be known at runtime.
+	 * @return An enriched version of the object with full knowledge of its
+	 *         generic type.
+	 */
+	<T> T opify(T op, Type type);
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpInfo.java
@@ -1,12 +1,10 @@
 
-package org.scijava.ops.matcher;
+package org.scijava.ops;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import org.scijava.ops.OpDependencyMember;
-import org.scijava.ops.OpUtils;
 import org.scijava.param.ValidityException;
 import org.scijava.struct.Member;
 import org.scijava.struct.Struct;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
@@ -56,7 +56,6 @@ import org.scijava.ops.matcher.OpAdaptationInfo;
 import org.scijava.ops.matcher.OpCandidate;
 import org.scijava.ops.matcher.OpClassInfo;
 import org.scijava.ops.matcher.OpFieldInfo;
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.ops.matcher.OpMatcher;
 import org.scijava.ops.matcher.OpMatchingException;
 import org.scijava.ops.matcher.OpRef;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
@@ -401,7 +401,7 @@ public class OpService extends AbstractService implements SciJavaService, OpEnvi
 		return wrapper.wrap((T) op, reifiedType);
 	}
 
-	public <T> T findOp(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType) {
+	public <T> T op(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType) {
 		return findOpInstance(opName, specialType, inTypes, outType);
 	}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpService.java
@@ -28,52 +28,12 @@
  */
 package org.scijava.ops;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import org.scijava.InstantiableException;
-import org.scijava.log.LogService;
-import org.scijava.ops.adapt.AdaptedOp;
-import org.scijava.ops.core.Op;
-import org.scijava.ops.core.OpCollection;
-import org.scijava.ops.matcher.DefaultOpMatcher;
-import org.scijava.ops.matcher.MatchingUtils;
-import org.scijava.ops.matcher.OpAdaptationInfo;
-import org.scijava.ops.matcher.OpCandidate;
-import org.scijava.ops.matcher.OpClassInfo;
-import org.scijava.ops.matcher.OpFieldInfo;
-import org.scijava.ops.matcher.OpMatcher;
-import org.scijava.ops.matcher.OpMatchingException;
-import org.scijava.ops.matcher.OpRef;
-import org.scijava.ops.util.OpWrapper;
-import org.scijava.param.FunctionalMethodType;
-import org.scijava.param.ParameterStructs;
-import org.scijava.plugin.Parameter;
+import org.scijava.ops.core.builder.OpBuilder;
+import org.scijava.ops.impl.DefaultOpEnvironment;
 import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginInfo;
-import org.scijava.plugin.PluginService;
 import org.scijava.service.AbstractService;
 import org.scijava.service.SciJavaService;
 import org.scijava.service.Service;
-import org.scijava.struct.ItemIO;
-import org.scijava.types.Nil;
-import org.scijava.types.TypeService;
-import org.scijava.types.Types;
-import org.scijava.util.ClassUtils;
 
 /**
  * Service to provide a list of available ops structured in a prefix tree and to
@@ -82,389 +42,34 @@ import org.scijava.util.ClassUtils;
  * @author David Kolb
  */
 @Plugin(type = Service.class)
-public class OpService extends AbstractService implements SciJavaService, OpEnvironment {
+public class OpService extends AbstractService implements SciJavaService {
 
-	@Parameter
-	private PluginService pluginService;
-
-	private OpMatcher opMatcher;
-
-	@Parameter
-	private LogService log;
-
-	@Parameter
-	private TypeService typeService;
+	private OpEnvironment env;
 
 	/**
-	 * Map to collect all aliases for a specific op. All aliases will map to one
-	 * canonical name of the op which is defined as the first one.
+	 * Begins declaration of an op matching request for locating an op with a
+	 * particular name. Additional criteria are specified as chained method calls
+	 * on the returned {@link OpBuilder} object. See {@link OpBuilder} for
+	 * examples.
+	 * 
+	 * @param opName The name of the op to be matched.
+	 * @return An {@link OpBuilder} for refining the search criteria for an op.
+	 * @see OpBuilder
 	 */
-	private Map<String, Set<OpInfo>> opCache;
-
-	private Map<Class<?>, OpWrapper<?>> wrappers;
-
-	private void initOpCache() {
-		opCache = new HashMap<>();
-
-		// Add regular Ops
-		for (final PluginInfo<Op> pluginInfo : pluginService.getPluginsOfType(Op.class)) {
-			try {
-				final Class<?> opClass = pluginInfo.loadClass();
-				OpInfo opInfo = new OpClassInfo(opClass);
-				addToOpIndex(opInfo, pluginInfo.getName());
-			} catch (InstantiableException exc) {
-				log.error("Can't load class from plugin info: " + pluginInfo.toString(), exc);
-			}
-		}
-		// Add Ops contained in an OpCollection
-		for (final PluginInfo<OpCollection> pluginInfo : pluginService.getPluginsOfType(OpCollection.class)) {
-			try {
-				Class<? extends OpCollection> c = pluginInfo.loadClass();
-				final List<Field> fields = ClassUtils.getAnnotatedFields(c, OpField.class);
-				Object instance = null;
-				for (Field field : fields) {
-					final boolean isStatic = Modifier.isStatic(field.getModifiers());
-					if (!isStatic && instance == null) {
-						instance = field.getDeclaringClass().newInstance();
-					}
-					OpInfo opInfo = new OpFieldInfo(isStatic ? null : instance, field);
-					addToOpIndex(opInfo, field.getAnnotation(OpField.class).names());
-				}
-			} catch (InstantiableException | InstantiationException | IllegalAccessException exc) {
-				log.error("Can't load class from plugin info: " + pluginInfo.toString(), exc);
-			}
-		}
+	public OpBuilder op(final String opName) {
+		return env().op(opName);
 	}
 
-	private void initWrappers() {
-		wrappers = new HashMap<>();
-		for (OpWrapper<?> wrapper : pluginService.createInstancesOfType(OpWrapper.class)) {
-			wrappers.put(wrapper.type(), wrapper);
-		}
+	/** Retrieves the motherlode of available ops. */
+	public OpEnvironment env() {
+		if (env == null) initEnv();
+		return env;
 	}
 
-	private void addToOpIndex(final OpInfo opInfo, final String opNames) {
-		String[] parsedOpNames = OpUtils.parseOpNames(opNames);
-		if (parsedOpNames == null || parsedOpNames.length == 0) {
-			log.error("Skipping Op " + opInfo.implementationName() + ":\n" + "Op implementation must provide name.");
-			return;
-		}
-		if (!opInfo.isValid()) {
-			log.error("Skipping invalid Op " + opInfo.implementationName() + ":\n"
-					+ opInfo.getValidityException().getMessage());
-			return;
-		}
-		for (String opName : parsedOpNames) {
-			if (!opCache.containsKey(opName))
-				opCache.put(opName, new TreeSet<>());
-			opCache.get(opName).add(opInfo);
-		}
-	}
+	// -- Helper methods - lazy initialization --
 
-	@Override
-	public Iterable<OpInfo> infos() {
-		if (opCache == null) {
-			initOpCache();
-		}
-		return opCache.values().stream().flatMap(list -> list.stream()).collect(Collectors.toList());
-	}
-
-	@Override
-	public Iterable<OpInfo> infos(String name) {
-		if (opCache == null) {
-			initOpCache();
-		}
-		if (name == null || name.isEmpty()) {
-			return infos();
-		}
-		return opsOfName(name);
-	}
-
-	private OpMatcher getOpMatcher() {
-		if (opMatcher == null) {
-			opMatcher = new DefaultOpMatcher(log);
-		}
-		return opMatcher;
-	}
-
-	/**
-	 * Attempts to inject {@link OpDependency} annotated fields of the specified
-	 * object by looking for Ops matching the field type and the name specified in
-	 * the annotation. The field type is assumed to be functional.
-	 *
-	 * @param op
-	 * @throws OpMatchingException
-	 *             if the type of the specified object is not functional, if the Op
-	 *             matching the functional type and the name could not be found, if
-	 *             an exception occurs during injection
-	 */
-	private List<Object> resolveOpDependencies(OpCandidate op) throws OpMatchingException {
-		final List<OpDependencyMember<?>> dependencies = op.opInfo().dependencies();
-		final List<Object> resolvedDependencies = new ArrayList<>(dependencies.size());
-		for (final OpDependencyMember<?> dependency : dependencies) {
-			final String dependencyName = dependency.getDependencyName();
-			final Type mappedDependencyType = Types.mapVarToTypes(new Type[] { dependency.getType() },
-					op.typeVarAssigns())[0];
-			final OpRef inferredRef = inferOpRef(mappedDependencyType, dependencyName, op.typeVarAssigns());
-			if (inferredRef == null) {
-				throw new OpMatchingException("Could not infer functional "
-						+ "method inputs and outputs of Op dependency field: " + dependency.getKey());
-			}
-			try {
-				resolvedDependencies.add(findOpInstance(dependencyName, inferredRef, dependency.isAdaptable()));
-			} catch (final Exception e) {
-				throw new OpMatchingException("Could not find Op that matches requested Op dependency:" + "\nOp class: "
-						+ op.opInfo().implementationName() + //
-						"\nDependency identifier: " + dependency.getKey() + //
-						"\n\n Attempted request:\n" + inferredRef, e);
-			}
-		}
-		return resolvedDependencies;
-	}
-
-	@SuppressWarnings("unchecked")
-	public <T> T findOpInstance(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes,
-			final Nil<?> outType) {
-		final OpRef ref = OpRef.fromTypes(opName, toTypes(specialType), outType != null ? outType.getType() : null,
-				toTypes(inTypes));
-		return (T) findOpInstance(opName, ref, true);
-	}
-
-	public Object findOpInstance(final String opName, final OpRef ref, boolean adaptable) {
-		Object op = null;
-		OpCandidate match = null;
-		AdaptedOp adaptation = null;
-		try {
-			// Find single match which matches the specified types
-			match = getOpMatcher().findSingleMatch(this, ref);
-			final List<Object> dependencies = resolveOpDependencies(match);
-			op = match.createOp(dependencies);
-		} catch (OpMatchingException e) {
-			log.debug("No matching Op for request: " + ref + "\n");
-			if (!adaptable) {
-				throw new IllegalArgumentException(opName + " cannot be adapted (adaptation is disabled)");
-			}
-			log.debug("Attempting Op adaptation...");
-			try {
-				adaptation = adaptOp(ref);
-				op = adaptation.op();
-			} catch (OpMatchingException e1) {
-				log.debug("No suitable Op adaptation found");
-				throw new IllegalArgumentException(e1);
-			}
-
-		}
-		try {
-			// Try to resolve annotated OpDependency fields
-			// N.B. Adapted Op dependency fields are already matched.
-			if (match != null)
-				resolveOpDependencies(match);
-		} catch (OpMatchingException e) {
-			throw new IllegalArgumentException(e);
-		}
-		OpAdaptationInfo adaptedInfo = adaptation == null ? null : adaptation.opInfo();
-		Object wrappedOp = wrapOp(op, match, adaptedInfo);
-		return wrappedOp;
-	}
-
-	/**
-	 * Adapts an Op with the name of ref into a type that can be SAFELY cast to ref.
-	 * 
-	 * @param ref
-	 *            - the type of Op that we are looking to adapt to.
-	 * @return {@link AdaptedOp} - an Op that has been adapted to conform the the
-	 *         ref type.
-	 * @throws OpMatchingException
-	 */
-	private AdaptedOp adaptOp(OpRef ref) throws OpMatchingException {
-		// FIXME: Need to validate against all types, not just the first.
-		final Type opType = ref.getTypes()[0];
-
-		for (final OpInfo adaptor : opsOfName("adapt")) {
-			Type adaptTo = adaptor.output().getType();
-			Map<TypeVariable<?>, Type> map = new HashMap<>();
-			// make sure that the adaptor outputs the correct type
-			if (opType instanceof ParameterizedType) {
-				if (!MatchingUtils.checkGenericAssignability(adaptTo,
-					(ParameterizedType) opType, map, true))
-				{
-					continue;
-				}
-			}
-			else if (!Types.isAssignable(opType, adaptTo, map)) {
-				continue;
-			}
-			// make sure that the adaptor is a Function (so we can cast it later)
-			if (Types.isInstance(adaptor.opType(), Function.class)) {
-				log.debug(adaptor + " is an illegal adaptor Op: must be a Function");
-				continue;
-			}
-			// build the type of fromOp (we know there must be one input because the adaptor
-			// is a Function)
-			Type adaptFrom = adaptor.inputs().get(0).getType();
-			Type refAdaptTo = Types.substituteTypeVariables(adaptTo, map);
-			Type refAdaptFrom = Types.substituteTypeVariables(adaptFrom, map);
-
-			// build the OpRef of the adaptor.
-			Type refType = Types.parameterize(Function.class, new Type[] { refAdaptFrom, refAdaptTo });
-			OpRef adaptorRef = new OpRef("adapt", new Type[] { refType }, refAdaptTo, new Type[] { refAdaptFrom });
-
-			// make an OpCandidate
-			OpCandidate candidate = new OpCandidate(this, log, adaptorRef, adaptor, map);
-
-			try {
-				// resolve adaptor dependencies and get the adaptor (as a function)
-				final List<Object> dependencies = resolveOpDependencies(candidate);
-				Object adaptorOp = adaptor.createOpInstance(dependencies).object();
-
-				// grab the first type parameter (from the OpCandidate?) and search for an Op
-				// that will then be adapted (this will be the first (only) type in the args of
-				// the adaptor)
-				Type srcOpType = Types.substituteTypeVariables(adaptor.inputs().get(0).getType(), map);
-				final OpRef srcOpRef;
-					srcOpRef = inferOpRef(srcOpType, ref.getName(), map);
-				// TODO: export this to another function (also done in findOpInstance).
-				// We need this here because we need to grab the OpInfo. 
-				// TODO: is there a better way to do this?
-				final OpCandidate srcCandidate = getOpMatcher().findSingleMatch(this, srcOpRef);
-				final List<Object> srcDependencies = resolveOpDependencies(srcCandidate);
-				final Object fromOp = srcCandidate.opInfo().createOpInstance(srcDependencies).object();
-
-				// get adapted Op by applying adaptor on unadapted Op, then return
-				// TODO: can we make this safer?
-				@SuppressWarnings("unchecked")
-				Object toOp = ((Function<Object, Object>) adaptorOp).apply(fromOp);
-				// construct type of adapted op
-				Type adapterOpType = Types.substituteTypeVariables(adaptor.output().getType(),
-						map);
-				return new AdaptedOp(toOp, adapterOpType, srcCandidate.opInfo(), adaptor);
-			} catch (OpMatchingException e1) {
-				log.trace(e1);
-			}
-		}
-
-		// no adaptors available.
-		throw new OpMatchingException("Op adaptation failed: no adaptable Ops of type " + ref.getName());
-	}
-
-	/**
-	 * Wraps the matched op into an {@link Op} that knows its generic typing and
-	 * {@link OpInfo}.
-	 * 
-	 * @param op
-	 *            - the matched op to wrap.
-	 * @param match
-	 *            - where to retrieve the {@link OpInfo} if no transformation is
-	 *            needed.
-	 * @param adaptationInfo
-	 *            - where to retrieve the {@link OpInfo} if a transformation is
-	 *            needed.
-	 * @return an {@link Op} wrapping of op.
-	 */
-	private Object wrapOp(Object op, OpCandidate match, OpAdaptationInfo adaptationInfo) {
-		if (wrappers == null)
-			initWrappers();
-
-		OpInfo opInfo = match == null ? adaptationInfo : match.opInfo();
-		// FIXME: this type is not necessarily Computer, Function, etc. but often
-		// something more specific (like the class of an Op).
-		// TODO: Is this correct?
-		Type type = match == null ? adaptationInfo.opType() : match.getRef().getTypes()[0];
-		try {
-			// determine the Op wrappers that could wrap the matched Op
-			Class<?>[] suitableWrappers = wrappers.keySet().stream().filter(wrapper -> wrapper.isInstance(op))
-					.toArray(Class[]::new);
-			if (suitableWrappers.length == 0)
-				throw new IllegalArgumentException(opInfo.implementationName() + ": matched op Type " + type.getClass()
-						+ " does not match a wrappable Op type.");
-			if (suitableWrappers.length > 1)
-				throw new IllegalArgumentException(
-						"Matched op Type " + type.getClass() + " matches multiple Op types: " + wrappers.toString());
-			// get the wrapper and wrap up the Op
-			if (!Types.isAssignable(Types.raw(type), suitableWrappers[0]))
-				throw new IllegalArgumentException(Types.raw(type) + "cannot be wrapped as a " + suitableWrappers[0].getClass());
-			return wrap(op, type);
-		} catch (IllegalArgumentException | SecurityException exc) {
-			log.error(exc.getMessage() != null ? exc.getMessage() : "Cannot wrap " + op.getClass());
-			return op;
-		} catch (NullPointerException e) {
-			log.error("No wrapper exists for " + Types.raw(type).toString() + ".");
-			return op;
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	public <T> T wrap(Object op, Type reifiedType) {
-		if (wrappers == null)
-			initWrappers();
-		OpWrapper<T> wrapper = (OpWrapper<T>) wrappers.get(Types.raw(reifiedType));
-		return wrapper.wrap((T) op, reifiedType);
-	}
-
-	public <T> T op(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType) {
-		return findOpInstance(opName, specialType, inTypes, outType);
-	}
-
-	private Type[] toTypes(Nil<?>... nils) {
-		return Arrays.stream(nils).filter(n -> n != null).map(n -> n.getType()).toArray(Type[]::new);
-	}
-
-	/**
-	 * Tries to infer a {@link OpRef} from a functional Op type. E.g. the type:
-	 * 
-	 * <pre>
-	 * Computer&lt;Double[], Double[]&gt
-	 * </pre>
-	 * 
-	 * Will result in the following {@link OpRef}:
-	 * 
-	 * <pre>
-	 * Name: 'specified name'
-	 * Types:       [Computer&lt;Double, Double&gt]
-	 * InputTypes:  [Double[], Double[]]
-	 * OutputTypes: [Double[]]
-	 * </pre>
-	 * 
-	 * Input and output types will be inferred by looking at the signature of the
-	 * functional method of the specified type. Also see
-	 * {@link ParameterStructs#findFunctionalMethodTypes(Type)}.
-	 *
-	 * @param type
-	 * @param name
-	 * @return null if the specified type has no functional method
-	 */
-	private OpRef inferOpRef(Type type, String name, Map<TypeVariable<?>, Type> typeVarAssigns)
-			throws OpMatchingException {
-		List<FunctionalMethodType> fmts = ParameterStructs.findFunctionalMethodTypes(type);
-		if (fmts == null)
-			return null;
-
-		EnumSet<ItemIO> inIos = EnumSet.of(ItemIO.BOTH, ItemIO.INPUT);
-		EnumSet<ItemIO> outIos = EnumSet.of(ItemIO.BOTH, ItemIO.OUTPUT);
-
-		Type[] inputs = fmts.stream().filter(fmt -> inIos.contains(fmt.itemIO())).map(fmt -> fmt.type())
-				.toArray(Type[]::new);
-
-		Type[] outputs = fmts.stream().filter(fmt -> outIos.contains(fmt.itemIO())).map(fmt -> fmt.type())
-				.toArray(Type[]::new);
-
-		Type[] mappedInputs = Types.mapVarToTypes(inputs, typeVarAssigns);
-		Type[] mappedOutputs = Types.mapVarToTypes(outputs, typeVarAssigns);
-
-		final int numOutputs = mappedOutputs.length;
-		if (numOutputs != 1) {
-			String error = "Op '" + name + "' of type " + type + " specifies ";
-			error += numOutputs == 0 //
-					? "no outputs" //
-					: "multiple outputs: " + Arrays.toString(outputs);
-			error += ". This is not supported.";
-			throw new OpMatchingException(error);
-		}
-		return new OpRef(name, new Type[] { type }, mappedOutputs[0], mappedInputs);
-	}
-
-	private Set<OpInfo> opsOfName(final String name) {
-		final Set<OpInfo> ops = opCache.getOrDefault(name, Collections.emptySet());
-		return Collections.unmodifiableSet(ops);
+	private synchronized void initEnv() {
+		if (env != null) return;
+		env = new DefaultOpEnvironment(context());
 	}
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpUtils.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 import org.scijava.ops.matcher.MatchingResult;
 import org.scijava.ops.matcher.OpCandidate;
 import org.scijava.ops.matcher.OpCandidate.StatusCode;
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.ops.matcher.OpMatcher;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.param.ParameterMember;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/adapt/AdaptedOp.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/adapt/AdaptedOp.java
@@ -3,8 +3,8 @@ package org.scijava.ops.adapt;
 
 import java.lang.reflect.Type;
 
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.matcher.OpAdaptationInfo;
-import org.scijava.ops.matcher.OpInfo;
 
 /**
  * Wrapper class combining an adapted Op with its adapted type and associated

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/adapt/lift/FunctionToIterables.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/adapt/lift/FunctionToIterables.java
@@ -220,11 +220,11 @@ public class FunctionToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 	static <E> Iterable<E> lazyIterable(final Function<Iterator<?>[], E> nexter,
 		final Iterable<?>... iterables)
 	{
-		return new Iterable<E>() {
+		return new Iterable<>() {
 
 			@Override
 			public Iterator<E> iterator() {
-				return new Iterator<E>() {
+				return new Iterator<>() {
 
 					private Iterator<?>[] iterators;
 					{

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
@@ -38,7 +38,7 @@ import java.lang.reflect.Type;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Inplaces;
@@ -59,11 +59,11 @@ import org.scijava.types.Types;
  */
 public class OpBuilder {
 
-	private final OpService ops;
+	private final OpEnvironment env;
 	private final String opName;
 
-	public OpBuilder(final OpService ops, final String opName) {
-		this.ops = ops;
+	public OpBuilder(final OpEnvironment env, final String opName) {
+		this.env = env;
 		this.opName = opName;
 	}
 
@@ -364,7 +364,8 @@ public class OpBuilder {
 
 	@SuppressWarnings({ "unchecked" })
 	private <T> Nil<T> type(Object obj) {
-		return (Nil<T>) Nil.of(ops.context().service(TypeService.class).reify(obj));
+		// FIXME: This vacuous T and unsafe cast is wrong.
+		return (Nil<T>) Nil.of(env.genericType(obj));
 	}
 
 	private void checkComputerRefs(Object... objects) {
@@ -439,7 +440,7 @@ public class OpBuilder {
 						Object.class });
 				}
 			};
-			return ops.op(opName, specialType, new Nil<?>[0], Nil.of(
+			return env.op(opName, specialType, new Nil<?>[0], Nil.of(
 				Object.class));
 		}
 
@@ -471,11 +472,11 @@ public class OpBuilder {
 						.getType() });
 				}
 			};
-			return ops.op(opName, specialType, new Nil<?>[0], outType);
+			return env.op(opName, specialType, new Nil<?>[0], outType);
 		}
 
 		public Computers.Arity0<O> computer() {
-			return Computers.match(ops, opName, outType);
+			return Computers.match(env, opName, outType);
 		}
 
 		public O create() {
@@ -499,7 +500,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity0<O> computer() {
-			return Computers.match(ops, opName, type(out));
+			return Computers.match(env, opName, type(out));
 		}
 
 		public void compute() {
@@ -527,15 +528,15 @@ public class OpBuilder {
 		}
 
 		public Function<I1, O> function() {
-			return Functions.match(ops, opName, in1Type, outType);
+			return Functions.match(env, opName, in1Type, outType);
 		}
 
 		public Computers.Arity1<I1, O> computer() {
-			return Computers.match(ops, opName, in1Type, outType);
+			return Computers.match(env, opName, in1Type, outType);
 		}
 
 		public Inplaces.Arity1<I1> inplace() {
-			return Inplaces.match(ops, opName, in1Type);
+			return Inplaces.match(env, opName, in1Type);
 		}
 
 	}
@@ -564,11 +565,11 @@ public class OpBuilder {
 		}
 
 		public Function<I1, ?> function() {
-			return Functions.match(ops, opName, in1Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity1<I1> inplace() {
-			return Inplaces.match(ops, opName, in1Type);
+			return Inplaces.match(env, opName, in1Type);
 		}
 
 	}
@@ -592,11 +593,11 @@ public class OpBuilder {
 		}
 
 		public Function<I1, O> function() {
-			return Functions.match(ops, opName, type(in1), outType);
+			return Functions.match(env, opName, type(in1), outType);
 		}
 	
 		public Computers.Arity1<I1, O> computer() {
-			return Computers.match(ops, opName, type(in1), outType);
+			return Computers.match(env, opName, type(in1), outType);
 		}
 	
 		public O apply() {
@@ -633,12 +634,12 @@ public class OpBuilder {
 		}
 
 		public Function<I1, ?> function() {
-			return Functions.match(ops, opName, type(in1), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity1<I1> inplace() {
 			checkInplaceRefs(1, in1);
-			return Inplaces.match(ops, opName, type(in1));
+			return Inplaces.match(env, opName, type(in1));
 		}
 
 		public Object apply() {
@@ -669,7 +670,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity1<I1, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(out));
+			return Computers.match(env, opName, type(in1), type(out));
 		}
 
 		public void compute() {
@@ -700,19 +701,19 @@ public class OpBuilder {
 		}
 
 		public BiFunction<I1, I2, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, outType);
 		}
 
 		public Computers.Arity2<I1, I2, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, outType);
 		}
 
 		public Inplaces.Arity2_1<I1, I2> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type);
 		}
 
 		public Inplaces.Arity2_2<I1, I2> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type);
 		}
 
 	}
@@ -744,15 +745,15 @@ public class OpBuilder {
 		}
 
 		public BiFunction<I1, I2, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity2_1<I1, I2> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type);
 		}
 
 		public Inplaces.Arity2_2<I1, I2> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type);
 		}
 
 	}
@@ -779,11 +780,11 @@ public class OpBuilder {
 		}
 
 		public BiFunction<I1, I2, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), outType);
+			return Functions.match(env, opName, type(in1), type(in2), outType);
 		}
 	
 		public Computers.Arity2<I1, I2, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), outType);
+			return Computers.match(env, opName, type(in1), type(in2), outType);
 		}
 	
 		public O apply() {
@@ -823,17 +824,17 @@ public class OpBuilder {
 		}
 
 		public BiFunction<I1, I2, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity2_1<I1, I2> inplace1() {
 			checkInplaceRefs(1, in1, in2);
-			return Inplaces.match1(ops, opName, type(in1), type(in2));
+			return Inplaces.match1(env, opName, type(in1), type(in2));
 		}
 
 		public Inplaces.Arity2_2<I1, I2> inplace2() {
 			checkInplaceRefs(2, in1, in2);
-			return Inplaces.match2(ops, opName, type(in1), type(in2));
+			return Inplaces.match2(env, opName, type(in1), type(in2));
 		}
 
 		public Object apply() {
@@ -871,7 +872,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity2<I1, I2, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(out));
 		}
 
 		public void compute() {
@@ -905,23 +906,23 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity3<I1, I2, I3, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, outType);
 		}
 
 		public Computers.Arity3<I1, I2, I3, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, outType);
 		}
 
 		public Inplaces.Arity3_1<I1, I2, I3> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type);
 		}
 
 		public Inplaces.Arity3_2<I1, I2, I3> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type);
 		}
 
 		public Inplaces.Arity3_3<I1, I2, I3> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type);
 		}
 
 	}
@@ -956,19 +957,19 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity3<I1, I2, I3, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity3_1<I1, I2, I3> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type);
 		}
 
 		public Inplaces.Arity3_2<I1, I2, I3> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type);
 		}
 
 		public Inplaces.Arity3_3<I1, I2, I3> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type);
 		}
 
 	}
@@ -998,11 +999,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity3<I1, I2, I3, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), outType);
 		}
 	
 		public Computers.Arity3<I1, I2, I3, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), outType);
 		}
 	
 		public O apply() {
@@ -1045,22 +1046,22 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity3<I1, I2, I3, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity3_1<I1, I2, I3> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3));
 		}
 
 		public Inplaces.Arity3_2<I1, I2, I3> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3));
 		}
 
 		public Inplaces.Arity3_3<I1, I2, I3> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3));
 		}
 
 		public Object apply() {
@@ -1105,7 +1106,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity3<I1, I2, I3, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(out));
 		}
 
 		public void compute() {
@@ -1142,27 +1143,27 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity4<I1, I2, I3, I4, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, outType);
 		}
 
 		public Computers.Arity4<I1, I2, I3, I4, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, outType);
 		}
 
 		public Inplaces.Arity4_1<I1, I2, I3, I4> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_2<I1, I2, I3, I4> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_3<I1, I2, I3, I4> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_4<I1, I2, I3, I4> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 	}
@@ -1200,23 +1201,23 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity4<I1, I2, I3, I4, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity4_1<I1, I2, I3, I4> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_2<I1, I2, I3, I4> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_3<I1, I2, I3, I4> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 		public Inplaces.Arity4_4<I1, I2, I3, I4> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type);
 		}
 
 	}
@@ -1249,11 +1250,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity4<I1, I2, I3, I4, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), outType);
 		}
 	
 		public Computers.Arity4<I1, I2, I3, I4, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), outType);
 		}
 	
 		public O apply() {
@@ -1299,27 +1300,27 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity4<I1, I2, I3, I4, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity4_1<I1, I2, I3, I4> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4));
 		}
 
 		public Inplaces.Arity4_2<I1, I2, I3, I4> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4));
 		}
 
 		public Inplaces.Arity4_3<I1, I2, I3, I4> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4));
 		}
 
 		public Inplaces.Arity4_4<I1, I2, I3, I4> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4));
 		}
 
 		public Object apply() {
@@ -1371,7 +1372,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity4<I1, I2, I3, I4, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(out));
 		}
 
 		public void compute() {
@@ -1411,31 +1412,31 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity5<I1, I2, I3, I4, I5, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, outType);
 		}
 
 		public Computers.Arity5<I1, I2, I3, I4, I5, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, outType);
 		}
 
 		public Inplaces.Arity5_1<I1, I2, I3, I4, I5> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_2<I1, I2, I3, I4, I5> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_3<I1, I2, I3, I4, I5> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_4<I1, I2, I3, I4, I5> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_5<I1, I2, I3, I4, I5> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 	}
@@ -1476,27 +1477,27 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity5<I1, I2, I3, I4, I5, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity5_1<I1, I2, I3, I4, I5> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_2<I1, I2, I3, I4, I5> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_3<I1, I2, I3, I4, I5> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_4<I1, I2, I3, I4, I5> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 		public Inplaces.Arity5_5<I1, I2, I3, I4, I5> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type);
 		}
 
 	}
@@ -1532,11 +1533,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity5<I1, I2, I3, I4, I5, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), outType);
 		}
 	
 		public Computers.Arity5<I1, I2, I3, I4, I5, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), outType);
 		}
 	
 		public O apply() {
@@ -1585,32 +1586,32 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity5<I1, I2, I3, I4, I5, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity5_1<I1, I2, I3, I4, I5> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
 		}
 
 		public Inplaces.Arity5_2<I1, I2, I3, I4, I5> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
 		}
 
 		public Inplaces.Arity5_3<I1, I2, I3, I4, I5> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
 		}
 
 		public Inplaces.Arity5_4<I1, I2, I3, I4, I5> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
 		}
 
 		public Inplaces.Arity5_5<I1, I2, I3, I4, I5> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5));
 		}
 
 		public Object apply() {
@@ -1669,7 +1670,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity5<I1, I2, I3, I4, I5, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(out));
 		}
 
 		public void compute() {
@@ -1712,35 +1713,35 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity6<I1, I2, I3, I4, I5, I6, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, outType);
 		}
 
 		public Computers.Arity6<I1, I2, I3, I4, I5, I6, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, outType);
 		}
 
 		public Inplaces.Arity6_1<I1, I2, I3, I4, I5, I6> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_2<I1, I2, I3, I4, I5, I6> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_3<I1, I2, I3, I4, I5, I6> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_4<I1, I2, I3, I4, I5, I6> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_5<I1, I2, I3, I4, I5, I6> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_6<I1, I2, I3, I4, I5, I6> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 	}
@@ -1784,31 +1785,31 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity6<I1, I2, I3, I4, I5, I6, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity6_1<I1, I2, I3, I4, I5, I6> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_2<I1, I2, I3, I4, I5, I6> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_3<I1, I2, I3, I4, I5, I6> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_4<I1, I2, I3, I4, I5, I6> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_5<I1, I2, I3, I4, I5, I6> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 		public Inplaces.Arity6_6<I1, I2, I3, I4, I5, I6> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 		}
 
 	}
@@ -1847,11 +1848,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity6<I1, I2, I3, I4, I5, I6, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), outType);
 		}
 	
 		public Computers.Arity6<I1, I2, I3, I4, I5, I6, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), outType);
 		}
 	
 		public O apply() {
@@ -1903,37 +1904,37 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity6<I1, I2, I3, I4, I5, I6, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity6_1<I1, I2, I3, I4, I5, I6> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Inplaces.Arity6_2<I1, I2, I3, I4, I5, I6> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Inplaces.Arity6_3<I1, I2, I3, I4, I5, I6> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Inplaces.Arity6_4<I1, I2, I3, I4, I5, I6> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Inplaces.Arity6_5<I1, I2, I3, I4, I5, I6> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Inplaces.Arity6_6<I1, I2, I3, I4, I5, I6> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6));
 		}
 
 		public Object apply() {
@@ -1999,7 +2000,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity6<I1, I2, I3, I4, I5, I6, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(out));
 		}
 
 		public void compute() {
@@ -2045,39 +2046,39 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, outType);
 		}
 
 		public Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, outType);
 		}
 
 		public Inplaces.Arity7_1<I1, I2, I3, I4, I5, I6, I7> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_2<I1, I2, I3, I4, I5, I6, I7> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_3<I1, I2, I3, I4, I5, I6, I7> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_4<I1, I2, I3, I4, I5, I6, I7> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_5<I1, I2, I3, I4, I5, I6, I7> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_6<I1, I2, I3, I4, I5, I6, I7> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, I7> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 	}
@@ -2124,35 +2125,35 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity7_1<I1, I2, I3, I4, I5, I6, I7> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_2<I1, I2, I3, I4, I5, I6, I7> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_3<I1, I2, I3, I4, I5, I6, I7> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_4<I1, I2, I3, I4, I5, I6, I7> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_5<I1, I2, I3, I4, I5, I6, I7> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_6<I1, I2, I3, I4, I5, I6, I7> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 		public Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, I7> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 		}
 
 	}
@@ -2194,11 +2195,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), outType);
 		}
 	
 		public Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), outType);
 		}
 	
 		public O apply() {
@@ -2253,42 +2254,42 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity7_1<I1, I2, I3, I4, I5, I6, I7> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_2<I1, I2, I3, I4, I5, I6, I7> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_3<I1, I2, I3, I4, I5, I6, I7> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_4<I1, I2, I3, I4, I5, I6, I7> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_5<I1, I2, I3, I4, I5, I6, I7> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_6<I1, I2, I3, I4, I5, I6, I7> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, I7> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7));
 		}
 
 		public Object apply() {
@@ -2361,7 +2362,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(out));
 		}
 
 		public void compute() {
@@ -2410,43 +2411,43 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, outType);
 		}
 
 		public Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, outType);
 		}
 
 		public Inplaces.Arity8_1<I1, I2, I3, I4, I5, I6, I7, I8> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_2<I1, I2, I3, I4, I5, I6, I7, I8> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_3<I1, I2, I3, I4, I5, I6, I7, I8> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_4<I1, I2, I3, I4, I5, I6, I7, I8> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_5<I1, I2, I3, I4, I5, I6, I7, I8> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_6<I1, I2, I3, I4, I5, I6, I7, I8> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, I7, I8> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, I8> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 	}
@@ -2496,39 +2497,39 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity8_1<I1, I2, I3, I4, I5, I6, I7, I8> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_2<I1, I2, I3, I4, I5, I6, I7, I8> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_3<I1, I2, I3, I4, I5, I6, I7, I8> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_4<I1, I2, I3, I4, I5, I6, I7, I8> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_5<I1, I2, I3, I4, I5, I6, I7, I8> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_6<I1, I2, I3, I4, I5, I6, I7, I8> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, I7, I8> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 		public Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, I8> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 		}
 
 	}
@@ -2573,11 +2574,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), outType);
 		}
 	
 		public Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), outType);
 		}
 	
 		public O apply() {
@@ -2635,47 +2636,47 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity8_1<I1, I2, I3, I4, I5, I6, I7, I8> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_2<I1, I2, I3, I4, I5, I6, I7, I8> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_3<I1, I2, I3, I4, I5, I6, I7, I8> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_4<I1, I2, I3, I4, I5, I6, I7, I8> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_5<I1, I2, I3, I4, I5, I6, I7, I8> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_6<I1, I2, I3, I4, I5, I6, I7, I8> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, I7, I8> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, I8> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8));
 		}
 
 		public Object apply() {
@@ -2755,7 +2756,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(out));
 		}
 
 		public void compute() {
@@ -2807,47 +2808,47 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, outType);
 		}
 
 		public Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, outType);
 		}
 
 		public Inplaces.Arity9_1<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_2<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_3<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_4<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_5<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_6<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 	}
@@ -2900,43 +2901,43 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity9_1<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_2<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_3<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_4<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_5<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_6<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 		public Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 		}
 
 	}
@@ -2984,11 +2985,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), outType);
 		}
 	
 		public Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), outType);
 		}
 	
 		public O apply() {
@@ -3049,52 +3050,52 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity9_1<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_2<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_3<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_4<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_5<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_6<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, I9> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9));
 		}
 
 		public Object apply() {
@@ -3181,7 +3182,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(out));
 		}
 
 		public void compute() {
@@ -3236,51 +3237,51 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, outType);
 		}
 
 		public Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, outType);
 		}
 
 		public Inplaces.Arity10_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 	}
@@ -3336,47 +3337,47 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity10_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 		public Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 		}
 
 	}
@@ -3427,11 +3428,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), outType);
 		}
 	
 		public Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), outType);
 		}
 	
 		public O apply() {
@@ -3495,57 +3496,57 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity10_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10));
 		}
 
 		public Object apply() {
@@ -3639,7 +3640,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(out));
 		}
 
 		public void compute() {
@@ -3697,55 +3698,55 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, outType);
 		}
 
 		public Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, outType);
 		}
 
 		public Inplaces.Arity11_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 	}
@@ -3804,51 +3805,51 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity11_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 		public Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 		}
 
 	}
@@ -3902,11 +3903,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), outType);
 		}
 	
 		public Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), outType);
 		}
 	
 		public O apply() {
@@ -3973,62 +3974,62 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity11_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11));
 		}
 
 		public Object apply() {
@@ -4129,7 +4130,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(out));
 		}
 
 		public void compute() {
@@ -4190,59 +4191,59 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, outType);
 		}
 
 		public Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, outType);
 		}
 
 		public Inplaces.Arity12_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 	}
@@ -4304,55 +4305,55 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity12_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 		public Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 		}
 
 	}
@@ -4409,11 +4410,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), outType);
 		}
 	
 		public Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), outType);
 		}
 	
 		public O apply() {
@@ -4483,67 +4484,67 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity12_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> inplace12() {
 			checkInplaceRefs(12, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
-			return Inplaces.match12(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
+			return Inplaces.match12(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12));
 		}
 
 		public Object apply() {
@@ -4651,7 +4652,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(out));
 		}
 
 		public void compute() {
@@ -4715,63 +4716,63 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, outType);
 		}
 
 		public Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, outType);
 		}
 
 		public Inplaces.Arity13_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 	}
@@ -4836,59 +4837,59 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity13_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 		public Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 		}
 
 	}
@@ -4948,11 +4949,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), outType);
 		}
 	
 		public Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), outType);
 		}
 	
 		public O apply() {
@@ -5025,72 +5026,72 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity13_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace12() {
 			checkInplaceRefs(12, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match12(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match12(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> inplace13() {
 			checkInplaceRefs(13, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
-			return Inplaces.match13(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
+			return Inplaces.match13(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13));
 		}
 
 		public Object apply() {
@@ -5205,7 +5206,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(out));
 		}
 
 		public void compute() {
@@ -5272,67 +5273,67 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, outType);
 		}
 
 		public Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, outType);
 		}
 
 		public Inplaces.Arity14_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 	}
@@ -5400,63 +5401,63 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity14_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 		public Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 		}
 
 	}
@@ -5519,11 +5520,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), outType);
 		}
 	
 		public Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), outType);
 		}
 	
 		public O apply() {
@@ -5599,77 +5600,77 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity14_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace12() {
 			checkInplaceRefs(12, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match12(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match12(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace13() {
 			checkInplaceRefs(13, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match13(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match13(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> inplace14() {
 			checkInplaceRefs(14, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
-			return Inplaces.match14(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
+			return Inplaces.match14(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14));
 		}
 
 		public Object apply() {
@@ -5791,7 +5792,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(out));
 		}
 
 		public void compute() {
@@ -5861,71 +5862,71 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, outType);
 		}
 
 		public Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, outType);
 		}
 
 		public Inplaces.Arity15_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace15() {
-			return Inplaces.match15(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match15(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 	}
@@ -5996,67 +5997,67 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity15_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 		public Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace15() {
-			return Inplaces.match15(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+			return Inplaces.match15(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 		}
 
 	}
@@ -6122,11 +6123,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), outType);
 		}
 	
 		public Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), outType);
 		}
 	
 		public O apply() {
@@ -6205,82 +6206,82 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity15_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace12() {
 			checkInplaceRefs(12, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match12(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match12(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace13() {
 			checkInplaceRefs(13, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match13(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match13(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace14() {
 			checkInplaceRefs(14, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match14(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match14(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> inplace15() {
 			checkInplaceRefs(15, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
-			return Inplaces.match15(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
+			return Inplaces.match15(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15));
 		}
 
 		public Object apply() {
@@ -6409,7 +6410,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(out));
 		}
 
 		public void compute() {
@@ -6482,75 +6483,75 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, outType);
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, outType);
 		}
 
 		public Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> computer() {
-			return Computers.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, outType);
+			return Computers.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, outType);
 		}
 
 		public Inplaces.Arity16_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace15() {
-			return Inplaces.match15(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match15(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace16() {
-			return Inplaces.match16(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match16(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 	}
@@ -6624,71 +6625,71 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, ?> function() {
-			return Functions.match(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, Nil.of(Object.class));
+			return Functions.match(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type, Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity16_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace1() {
-			return Inplaces.match1(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match1(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace2() {
-			return Inplaces.match2(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match2(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace3() {
-			return Inplaces.match3(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match3(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace4() {
-			return Inplaces.match4(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match4(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace5() {
-			return Inplaces.match5(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match5(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace6() {
-			return Inplaces.match6(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match6(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace7() {
-			return Inplaces.match7(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match7(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace8() {
-			return Inplaces.match8(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match8(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace9() {
-			return Inplaces.match9(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match9(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace10() {
-			return Inplaces.match10(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match10(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace11() {
-			return Inplaces.match11(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match11(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace12() {
-			return Inplaces.match12(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match12(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace13() {
-			return Inplaces.match13(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match13(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace14() {
-			return Inplaces.match14(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match14(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace15() {
-			return Inplaces.match15(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match15(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 		public Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace16() {
-			return Inplaces.match16(ops, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+			return Inplaces.match16(env, opName, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 		}
 
 	}
@@ -6757,11 +6758,11 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), outType);
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), outType);
 		}
 	
 		public Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), outType);
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), outType);
 		}
 	
 		public O apply() {
@@ -6843,87 +6844,87 @@ public class OpBuilder {
 		}
 
 		public Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, ?> function() {
-			return Functions.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), Nil.of(Object.class));
+			return Functions.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), Nil.of(Object.class));
 		}
 
 		public Inplaces.Arity16_1<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace1() {
 			checkInplaceRefs(1, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match1(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match1(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_2<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace2() {
 			checkInplaceRefs(2, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match2(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match2(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_3<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace3() {
 			checkInplaceRefs(3, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match3(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match3(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_4<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace4() {
 			checkInplaceRefs(4, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match4(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match4(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_5<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace5() {
 			checkInplaceRefs(5, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match5(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match5(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_6<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace6() {
 			checkInplaceRefs(6, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match6(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match6(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace7() {
 			checkInplaceRefs(7, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match7(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match7(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace8() {
 			checkInplaceRefs(8, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match8(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match8(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace9() {
 			checkInplaceRefs(9, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match9(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match9(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace10() {
 			checkInplaceRefs(10, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match10(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match10(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace11() {
 			checkInplaceRefs(11, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match11(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match11(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace12() {
 			checkInplaceRefs(12, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match12(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match12(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace13() {
 			checkInplaceRefs(13, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match13(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match13(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace14() {
 			checkInplaceRefs(14, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match14(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match14(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace15() {
 			checkInplaceRefs(15, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match15(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match15(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> inplace16() {
 			checkInplaceRefs(16, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);
-			return Inplaces.match16(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
+			return Inplaces.match16(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16));
 		}
 
 		public Object apply() {
@@ -7059,7 +7060,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> computer() {
-			return Computers.match(ops, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), type(out));
+			return Computers.match(env, opName, type(in1), type(in2), type(in3), type(in4), type(in5), type(in6), type(in7), type(in8), type(in9), type(in10), type(in11), type(in12), type(in13), type(in14), type(in15), type(in16), type(out));
 		}
 
 		public void compute() {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
@@ -431,7 +431,7 @@ public class OpBuilder {
 		}
 
 		public Producer<?> producer() {
-			final Nil<Producer<Object>> specialType = new Nil<Producer<Object>>() {
+			final Nil<Producer<Object>> specialType = new Nil<>() {
 
 				@Override
 				public Type getType() {
@@ -463,7 +463,7 @@ public class OpBuilder {
 		}
 
 		public Producer<O> producer() {
-			final Nil<Producer<O>> specialType = new Nil<Producer<O>>() {
+			final Nil<Producer<O>> specialType = new Nil<>() {
 
 				@Override
 				public Type getType() {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/core/builder/OpBuilder.java
@@ -439,7 +439,7 @@ public class OpBuilder {
 						Object.class });
 				}
 			};
-			return ops.findOp(opName, specialType, new Nil<?>[0], Nil.of(
+			return ops.op(opName, specialType, new Nil<?>[0], Nil.of(
 				Object.class));
 		}
 
@@ -471,7 +471,7 @@ public class OpBuilder {
 						.getType() });
 				}
 			};
-			return ops.findOp(opName, specialType, new Nil<?>[0], outType);
+			return ops.op(opName, specialType, new Nil<?>[0], outType);
 		}
 
 		public Computers.Arity0<O> computer() {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
@@ -197,7 +197,7 @@ public final class Computers {
 		final Nil<?>[] nils = new Nil[inTypes.length + 1];
 		System.arraycopy(inTypes, 0, nils, 0, inTypes.length);
 		nils[nils.length - 1] = outType;
-		return (T) ops.findOp(opName, Nil.of(specialType), nils, outType);
+		return (T) ops.op(opName, Nil.of(specialType), nils, outType);
 	}
 
 	// -- END TEMP --

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.param.Mutable;
 import org.scijava.types.Types;
@@ -85,109 +85,109 @@ public final class Computers {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <O> Computers.Arity0<O> match(final OpService ops, final String opName, final Nil<O> outType)
+	public static <O> Computers.Arity0<O> match(final OpEnvironment env, final String opName, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity0.class, outType);
+		return matchHelper(env, opName, Computers.Arity0.class, outType);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I, O> Computers.Arity1<I, O> match(final OpService ops, final String opName, final Nil<I> inType, final Nil<O> outType)
+	public static <I, O> Computers.Arity1<I, O> match(final OpEnvironment env, final String opName, final Nil<I> inType, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity1.class, outType, inType);
+		return matchHelper(env, opName, Computers.Arity1.class, outType, inType);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, O> Computers.Arity2<I1, I2, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<O> outType)
+	public static <I1, I2, O> Computers.Arity2<I1, I2, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity2.class, outType, in1Type, in2Type);
+		return matchHelper(env, opName, Computers.Arity2.class, outType, in1Type, in2Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, O> Computers.Arity3<I1, I2, I3, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<O> outType)
+	public static <I1, I2, I3, O> Computers.Arity3<I1, I2, I3, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity3.class, outType, in1Type, in2Type, in3Type);
+		return matchHelper(env, opName, Computers.Arity3.class, outType, in1Type, in2Type, in3Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, O> Computers.Arity4<I1, I2, I3, I4, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, O> Computers.Arity4<I1, I2, I3, I4, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity4.class, outType, in1Type, in2Type, in3Type, in4Type);
+		return matchHelper(env, opName, Computers.Arity4.class, outType, in1Type, in2Type, in3Type, in4Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, O> Computers.Arity5<I1, I2, I3, I4, I5, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, O> Computers.Arity5<I1, I2, I3, I4, I5, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity5.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type);
+		return matchHelper(env, opName, Computers.Arity5.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, O> Computers.Arity6<I1, I2, I3, I4, I5, I6, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, O> Computers.Arity6<I1, I2, I3, I4, I5, I6, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity6.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+		return matchHelper(env, opName, Computers.Arity6.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, O> Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, O> Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity7.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+		return matchHelper(env, opName, Computers.Arity7.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, O> Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, O> Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity8.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+		return matchHelper(env, opName, Computers.Arity8.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, O> Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, O> Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity9.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+		return matchHelper(env, opName, Computers.Arity9.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity10.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+		return matchHelper(env, opName, Computers.Arity10.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity11.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+		return matchHelper(env, opName, Computers.Arity11.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity12.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+		return matchHelper(env, opName, Computers.Arity12.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity13.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+		return matchHelper(env, opName, Computers.Arity13.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity14.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+		return matchHelper(env, opName, Computers.Arity14.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity15.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+		return matchHelper(env, opName, Computers.Arity15.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Computers.Arity16.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+		return matchHelper(env, opName, Computers.Arity16.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName, final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
+	private static <T> T matchHelper(final OpEnvironment env, final String opName, final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length + 1];
 		for (int i = 0; i < inTypes.length; i++)
@@ -197,7 +197,7 @@ public final class Computers {
 		final Nil<?>[] nils = new Nil[inTypes.length + 1];
 		System.arraycopy(inTypes, 0, nils, 0, inTypes.length);
 		nils[nils.length - 1] = outType;
-		return (T) ops.op(opName, Nil.of(specialType), nils, outType);
+		return (T) env.op(opName, Nil.of(specialType), nils, outType);
 	}
 
 	// -- END TEMP --

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Functions.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Functions.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 
@@ -82,113 +82,113 @@ public final class Functions {
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <O> Producer<O> match(final OpService ops, final String opName, final Nil<O> outType)
+	public static <O> Producer<O> match(final OpEnvironment env, final String opName, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Producer.class, outType);
+		return matchHelper(env, opName, Producer.class, outType);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I, O> Function<I, O> match(final OpService ops, final String opName, final Nil<I> inType, final Nil<O> outType)
+	public static <I, O> Function<I, O> match(final OpEnvironment env, final String opName, final Nil<I> inType, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Function.class, outType, inType);
+		return matchHelper(env, opName, Function.class, outType, inType);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, O> BiFunction<I1, I2, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<O> outType)
+	public static <I1, I2, O> BiFunction<I1, I2, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, BiFunction.class, outType, in1Type, in2Type);
+		return matchHelper(env, opName, BiFunction.class, outType, in1Type, in2Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, O> Functions.Arity3<I1, I2, I3, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<O> outType)
+	public static <I1, I2, I3, O> Functions.Arity3<I1, I2, I3, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity3.class, outType, in1Type, in2Type, in3Type);
+		return matchHelper(env, opName, Functions.Arity3.class, outType, in1Type, in2Type, in3Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, O> Functions.Arity4<I1, I2, I3, I4, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, O> Functions.Arity4<I1, I2, I3, I4, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity4.class, outType, in1Type, in2Type, in3Type, in4Type);
+		return matchHelper(env, opName, Functions.Arity4.class, outType, in1Type, in2Type, in3Type, in4Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, O> Functions.Arity5<I1, I2, I3, I4, I5, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, O> Functions.Arity5<I1, I2, I3, I4, I5, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity5.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type);
+		return matchHelper(env, opName, Functions.Arity5.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, O> Functions.Arity6<I1, I2, I3, I4, I5, I6, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, O> Functions.Arity6<I1, I2, I3, I4, I5, I6, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity6.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
+		return matchHelper(env, opName, Functions.Arity6.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, O> Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, O> Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity7.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
+		return matchHelper(env, opName, Functions.Arity7.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, O> Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, O> Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity8.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
+		return matchHelper(env, opName, Functions.Arity8.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, O> Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, O> Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity9.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
+		return matchHelper(env, opName, Functions.Arity9.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity10.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
+		return matchHelper(env, opName, Functions.Arity10.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity11.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
+		return matchHelper(env, opName, Functions.Arity11.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity12.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
+		return matchHelper(env, opName, Functions.Arity12.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity13.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
+		return matchHelper(env, opName, Functions.Arity13.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity14.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
+		return matchHelper(env, opName, Functions.Arity14.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity15.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
+		return matchHelper(env, opName, Functions.Arity15.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type);
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> match(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type, final Nil<O> outType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> match(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type, final Nil<O> outType)
 	{
-		return matchHelper(ops, opName, Functions.Arity16.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
+		return matchHelper(env, opName, Functions.Arity16.class, outType, in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type);
 	}
 
 
 	@SuppressWarnings({ "unchecked" })
-	public static <O, T> Functions.ArityN<O> matchN(final OpService ops,
+	public static <O, T> Functions.ArityN<O> matchN(final OpEnvironment env,
 		final String opName, final Nil<O> outType, final Nil<?>... inTypes)
 	{
-		Object op = matchHelper(ops, opName, ALL_FUNCTIONS.get(inTypes.length),
+		Object op = matchHelper(env, opName, ALL_FUNCTIONS.get(inTypes.length),
 			outType, inTypes);
 		if (op instanceof Producer) {
 			return new Arity0AsN<>((Producer<O>) op);
@@ -242,7 +242,7 @@ public final class Functions {
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName,
+	private static <T> T matchHelper(final OpEnvironment env, final String opName,
 		final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length + 1];
@@ -250,7 +250,7 @@ public final class Functions {
 			types[i] = inTypes[i].getType();
 		types[types.length - 1] = outType.getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
+		return (T) env.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	/**

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Functions.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Functions.java
@@ -250,7 +250,7 @@ public final class Functions {
 			types[i] = inTypes[i].getType();
 		types[types.length - 1] = outType.getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.findOp(opName, Nil.of(specialType), inTypes, outType);
+		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	/**

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Inplaces.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Inplaces.java
@@ -15,7 +15,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.param.Mutable;
 import org.scijava.types.Types;
@@ -223,830 +223,830 @@ public final class Inplaces {
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO> Arity1<IO> match(final OpService ops, final String opName, final Nil<IO> ioType)
+	public static <IO> Arity1<IO> match(final OpEnvironment env, final String opName, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity1.class, ioType, new Nil[] {ioType});
+		return matchHelper(env, opName, Arity1.class, ioType, new Nil[] {ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2> Arity2_1<IO, I2> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type)
+	public static <IO, I2> Arity2_1<IO, I2> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type)
 	{
-		return matchHelper(ops, opName, Arity2_1.class, ioType, new Nil[] {ioType, in2Type});
+		return matchHelper(env, opName, Arity2_1.class, ioType, new Nil[] {ioType, in2Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO> Arity2_2<I1, IO> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType)
+	public static <I1, IO> Arity2_2<I1, IO> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity2_2.class, ioType, new Nil[] {in1Type, ioType});
+		return matchHelper(env, opName, Arity2_2.class, ioType, new Nil[] {in1Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3> Arity3_1<IO, I2, I3> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type)
+	public static <IO, I2, I3> Arity3_1<IO, I2, I3> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type)
 	{
-		return matchHelper(ops, opName, Arity3_1.class, ioType, new Nil[] {ioType, in2Type, in3Type});
+		return matchHelper(env, opName, Arity3_1.class, ioType, new Nil[] {ioType, in2Type, in3Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3> Arity3_2<I1, IO, I3> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type)
+	public static <I1, IO, I3> Arity3_2<I1, IO, I3> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type)
 	{
-		return matchHelper(ops, opName, Arity3_2.class, ioType, new Nil[] {in1Type, ioType, in3Type});
+		return matchHelper(env, opName, Arity3_2.class, ioType, new Nil[] {in1Type, ioType, in3Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO> Arity3_3<I1, I2, IO> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType)
+	public static <I1, I2, IO> Arity3_3<I1, I2, IO> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity3_3.class, ioType, new Nil[] {in1Type, in2Type, ioType});
+		return matchHelper(env, opName, Arity3_3.class, ioType, new Nil[] {in1Type, in2Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4> Arity4_1<IO, I2, I3, I4> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type)
+	public static <IO, I2, I3, I4> Arity4_1<IO, I2, I3, I4> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type)
 	{
-		return matchHelper(ops, opName, Arity4_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type});
+		return matchHelper(env, opName, Arity4_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4> Arity4_2<I1, IO, I3, I4> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type)
+	public static <I1, IO, I3, I4> Arity4_2<I1, IO, I3, I4> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type)
 	{
-		return matchHelper(ops, opName, Arity4_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type});
+		return matchHelper(env, opName, Arity4_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4> Arity4_3<I1, I2, IO, I4> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type)
+	public static <I1, I2, IO, I4> Arity4_3<I1, I2, IO, I4> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type)
 	{
-		return matchHelper(ops, opName, Arity4_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type});
+		return matchHelper(env, opName, Arity4_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO> Arity4_4<I1, I2, I3, IO> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, IO> Arity4_4<I1, I2, I3, IO> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity4_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType});
+		return matchHelper(env, opName, Arity4_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5> Arity5_1<IO, I2, I3, I4, I5> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type)
+	public static <IO, I2, I3, I4, I5> Arity5_1<IO, I2, I3, I4, I5> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type)
 	{
-		return matchHelper(ops, opName, Arity5_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type});
+		return matchHelper(env, opName, Arity5_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5> Arity5_2<I1, IO, I3, I4, I5> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type)
+	public static <I1, IO, I3, I4, I5> Arity5_2<I1, IO, I3, I4, I5> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type)
 	{
-		return matchHelper(ops, opName, Arity5_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type});
+		return matchHelper(env, opName, Arity5_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5> Arity5_3<I1, I2, IO, I4, I5> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type)
+	public static <I1, I2, IO, I4, I5> Arity5_3<I1, I2, IO, I4, I5> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type)
 	{
-		return matchHelper(ops, opName, Arity5_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type});
+		return matchHelper(env, opName, Arity5_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5> Arity5_4<I1, I2, I3, IO, I5> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type)
+	public static <I1, I2, I3, IO, I5> Arity5_4<I1, I2, I3, IO, I5> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type)
 	{
-		return matchHelper(ops, opName, Arity5_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type});
+		return matchHelper(env, opName, Arity5_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO> Arity5_5<I1, I2, I3, I4, IO> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, IO> Arity5_5<I1, I2, I3, I4, IO> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity5_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType});
+		return matchHelper(env, opName, Arity5_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6> Arity6_1<IO, I2, I3, I4, I5, I6> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
+	public static <IO, I2, I3, I4, I5, I6> Arity6_1<IO, I2, I3, I4, I5, I6> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
 	{
-		return matchHelper(ops, opName, Arity6_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type});
+		return matchHelper(env, opName, Arity6_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6> Arity6_2<I1, IO, I3, I4, I5, I6> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
+	public static <I1, IO, I3, I4, I5, I6> Arity6_2<I1, IO, I3, I4, I5, I6> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
 	{
-		return matchHelper(ops, opName, Arity6_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type});
+		return matchHelper(env, opName, Arity6_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6> Arity6_3<I1, I2, IO, I4, I5, I6> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
+	public static <I1, I2, IO, I4, I5, I6> Arity6_3<I1, I2, IO, I4, I5, I6> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type)
 	{
-		return matchHelper(ops, opName, Arity6_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type});
+		return matchHelper(env, opName, Arity6_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6> Arity6_4<I1, I2, I3, IO, I5, I6> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type)
+	public static <I1, I2, I3, IO, I5, I6> Arity6_4<I1, I2, I3, IO, I5, I6> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type)
 	{
-		return matchHelper(ops, opName, Arity6_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type});
+		return matchHelper(env, opName, Arity6_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6> Arity6_5<I1, I2, I3, I4, IO, I6> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type)
+	public static <I1, I2, I3, I4, IO, I6> Arity6_5<I1, I2, I3, I4, IO, I6> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type)
 	{
-		return matchHelper(ops, opName, Arity6_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type});
+		return matchHelper(env, opName, Arity6_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO> Arity6_6<I1, I2, I3, I4, I5, IO> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, IO> Arity6_6<I1, I2, I3, I4, I5, IO> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity6_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType});
+		return matchHelper(env, opName, Arity6_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7> Arity7_1<IO, I2, I3, I4, I5, I6, I7> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
+	public static <IO, I2, I3, I4, I5, I6, I7> Arity7_1<IO, I2, I3, I4, I5, I6, I7> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type});
+		return matchHelper(env, opName, Arity7_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7> Arity7_2<I1, IO, I3, I4, I5, I6, I7> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
+	public static <I1, IO, I3, I4, I5, I6, I7> Arity7_2<I1, IO, I3, I4, I5, I6, I7> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type});
+		return matchHelper(env, opName, Arity7_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7> Arity7_3<I1, I2, IO, I4, I5, I6, I7> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
+	public static <I1, I2, IO, I4, I5, I6, I7> Arity7_3<I1, I2, IO, I4, I5, I6, I7> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type});
+		return matchHelper(env, opName, Arity7_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7> Arity7_4<I1, I2, I3, IO, I5, I6, I7> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
+	public static <I1, I2, I3, IO, I5, I6, I7> Arity7_4<I1, I2, I3, IO, I5, I6, I7> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type});
+		return matchHelper(env, opName, Arity7_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7> Arity7_5<I1, I2, I3, I4, IO, I6, I7> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type)
+	public static <I1, I2, I3, I4, IO, I6, I7> Arity7_5<I1, I2, I3, I4, IO, I6, I7> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type});
+		return matchHelper(env, opName, Arity7_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7> Arity7_6<I1, I2, I3, I4, I5, IO, I7> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type)
+	public static <I1, I2, I3, I4, I5, IO, I7> Arity7_6<I1, I2, I3, I4, I5, IO, I7> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type)
 	{
-		return matchHelper(ops, opName, Arity7_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type});
+		return matchHelper(env, opName, Arity7_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO> Arity7_7<I1, I2, I3, I4, I5, I6, IO> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, IO> Arity7_7<I1, I2, I3, I4, I5, I6, IO> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity7_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType});
+		return matchHelper(env, opName, Arity7_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8> Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8> Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8> Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8> Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8> Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8> Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8> Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8> Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8> Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8> Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8> Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8> Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type});
+		return matchHelper(env, opName, Arity8_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8> Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8> Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type)
 	{
-		return matchHelper(ops, opName, Arity8_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type});
+		return matchHelper(env, opName, Arity8_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO> Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO> Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity8_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType});
+		return matchHelper(env, opName, Arity8_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9> Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9> Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9> Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9> Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9> Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9> Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9> Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9> Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9> Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9> Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9> Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9> Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9> Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9> Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type});
+		return matchHelper(env, opName, Arity9_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9> Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9> Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type)
 	{
-		return matchHelper(ops, opName, Arity9_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type});
+		return matchHelper(env, opName, Arity9_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO> Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO> Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity9_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType});
+		return matchHelper(env, opName, Arity9_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10> Arity10_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10> Arity10_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10> Arity10_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10> Arity10_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10> Arity10_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10> Arity10_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10> Arity10_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10> Arity10_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10> Arity10_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10> Arity10_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10> Arity10_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10> Arity10_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10> Arity10_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10> Arity10_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10> Arity10_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10> Arity10_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type});
+		return matchHelper(env, opName, Arity10_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10> Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10> Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type)
 	{
-		return matchHelper(ops, opName, Arity10_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type});
+		return matchHelper(env, opName, Arity10_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO> Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO> Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity10_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType});
+		return matchHelper(env, opName, Arity10_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11> Arity11_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11> Arity11_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11> Arity11_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11> Arity11_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11> Arity11_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11> Arity11_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11> Arity11_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11> Arity11_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11> Arity11_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11> Arity11_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11> Arity11_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11> Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11> Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type});
+		return matchHelper(env, opName, Arity11_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11> Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11> Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type)
 	{
-		return matchHelper(ops, opName, Arity11_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type});
+		return matchHelper(env, opName, Arity11_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO> Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO> Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity11_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType});
+		return matchHelper(env, opName, Arity11_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12> Arity12_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12> Arity12_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12> Arity12_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12> Arity12_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12> Arity12_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12> Arity12_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12> Arity12_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12> Arity12_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12> Arity12_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12> Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12> Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12> Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12> Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type});
+		return matchHelper(env, opName, Arity12_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12> Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12> Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type)
 	{
-		return matchHelper(ops, opName, Arity12_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type});
+		return matchHelper(env, opName, Arity12_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO> Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO> match12(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO> Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO> match12(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity12_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType});
+		return matchHelper(env, opName, Arity12_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13> Arity13_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13> Arity13_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13> Arity13_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13> Arity13_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13> Arity13_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13> Arity13_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13> Arity13_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13> Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13> Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13> Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13> Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13> Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13> Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type});
+		return matchHelper(env, opName, Arity13_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13> Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13> match12(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13> Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13> match12(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type)
 	{
-		return matchHelper(ops, opName, Arity13_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type});
+		return matchHelper(env, opName, Arity13_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO> Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO> match13(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO> Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO> match13(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity13_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType});
+		return matchHelper(env, opName, Arity13_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14> Arity14_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14> Arity14_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14> Arity14_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14> Arity14_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14> Arity14_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14> Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14> Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14> Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14> Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14> Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14> Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14> Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14> match12(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14> Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14> match12(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type});
+		return matchHelper(env, opName, Arity14_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14> Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14> match13(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14> Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14> match13(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type)
 	{
-		return matchHelper(ops, opName, Arity14_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type});
+		return matchHelper(env, opName, Arity14_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO> Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO> match14(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO> Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO> match14(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity14_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType});
+		return matchHelper(env, opName, Arity14_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15> Arity15_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15> Arity15_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15> Arity15_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15> Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15> Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15> Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15> Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15> Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15> Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15> Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15> match12(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15> Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15> match12(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15> Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15> match13(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15> Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15> match13(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type, in15Type});
+		return matchHelper(env, opName, Arity15_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15> Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15> match14(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType, final Nil<I15> in15Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15> Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15> match14(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType, final Nil<I15> in15Type)
 	{
-		return matchHelper(ops, opName, Arity15_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType, in15Type});
+		return matchHelper(env, opName, Arity15_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType, in15Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO> Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO> match15(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO> Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO> match15(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity15_15.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, ioType});
+		return matchHelper(env, opName, Arity15_15.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match1(final OpService ops, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match1(final OpEnvironment env, final String opName, final Nil<IO> ioType, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_1.class, ioType, new Nil[] {ioType, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match2(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match2(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<IO> ioType, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_2.class, ioType, new Nil[] {in1Type, ioType, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match3(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match3(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<IO> ioType, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_3.class, ioType, new Nil[] {in1Type, in2Type, ioType, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match4(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match4(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<IO> ioType, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_4.class, ioType, new Nil[] {in1Type, in2Type, in3Type, ioType, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match5(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match5(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<IO> ioType, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_5.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, ioType, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match6(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> match6(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<IO> ioType, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_6.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, ioType, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16> match7(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16> match7(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<IO> ioType, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_7.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, ioType, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16> match8(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16> Arity16_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16> match8(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<IO> ioType, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_8.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, ioType, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16> Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16> match9(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16> Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16> match9(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<IO> ioType, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_9.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, ioType, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16> Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16> match10(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16> Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16> match10(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<IO> ioType, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_10.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, ioType, in11Type, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16> Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16> match11(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16> Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16> match11(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<IO> ioType, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_11.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, ioType, in12Type, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16> Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16> match12(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16> Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16> match12(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<IO> ioType, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_12.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, ioType, in13Type, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16> Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16> match13(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16> Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16> match13(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<IO> ioType, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_13.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, ioType, in14Type, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16> Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16> match14(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType, final Nil<I15> in15Type, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16> Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16> match14(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<IO> ioType, final Nil<I15> in15Type, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType, in15Type, in16Type});
+		return matchHelper(env, opName, Arity16_14.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, ioType, in15Type, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16> Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16> match15(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<IO> ioType, final Nil<I16> in16Type)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16> Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16> match15(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<IO> ioType, final Nil<I16> in16Type)
 	{
-		return matchHelper(ops, opName, Arity16_15.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, ioType, in16Type});
+		return matchHelper(env, opName, Arity16_15.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, ioType, in16Type});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO> Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO> match16(final OpService ops, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<IO> ioType)
+	public static <I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO> Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO> match16(final OpEnvironment env, final String opName, final Nil<I1> in1Type, final Nil<I2> in2Type, final Nil<I3> in3Type, final Nil<I4> in4Type, final Nil<I5> in5Type, final Nil<I6> in6Type, final Nil<I7> in7Type, final Nil<I8> in8Type, final Nil<I9> in9Type, final Nil<I10> in10Type, final Nil<I11> in11Type, final Nil<I12> in12Type, final Nil<I13> in13Type, final Nil<I14> in14Type, final Nil<I15> in15Type, final Nil<IO> ioType)
 	{
-		return matchHelper(ops, opName, Arity16_16.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, ioType});
+		return matchHelper(env, opName, Arity16_16.class, ioType, new Nil[] {in1Type, in2Type, in3Type, in4Type, in5Type, in6Type, in7Type, in8Type, in9Type, in10Type, in11Type, in12Type, in13Type, in14Type, in15Type, ioType});
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName,
+	private static <T> T matchHelper(final OpEnvironment env, final String opName,
 		final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length];
 		for (int i = 0; i < inTypes.length; i++)
 			types[i] = inTypes[i].getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
+		return (T) env.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	public static class InplaceInfo {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Inplaces.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Inplaces.java
@@ -1046,7 +1046,7 @@ public final class Inplaces {
 		for (int i = 0; i < inTypes.length; i++)
 			types[i] = inTypes[i].getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.findOp(opName, Nil.of(specialType), inTypes, outType);
+		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	public static class InplaceInfo {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
@@ -9,11 +9,10 @@ import java.lang.reflect.Type;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.types.GenericTyped;
-import org.scijava.ops.OpInfo;
 import org.scijava.ops.util.OpWrapper;
 import org.scijava.param.Mutable;
 import org.scijava.plugin.Plugin;
+import org.scijava.types.GenericTyped;
 
 public class OpWrappers {
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
@@ -9,8 +9,8 @@ import java.lang.reflect.Type;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.types.GenericTyped;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.util.OpWrapper;
 import org.scijava.param.Mutable;
 import org.scijava.plugin.Plugin;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -1,0 +1,473 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2018 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops.impl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.scijava.AbstractContextual;
+import org.scijava.Context;
+import org.scijava.InstantiableException;
+import org.scijava.log.LogService;
+import org.scijava.ops.OpDependency;
+import org.scijava.ops.OpDependencyMember;
+import org.scijava.ops.OpEnvironment;
+import org.scijava.ops.OpField;
+import org.scijava.ops.OpInfo;
+import org.scijava.ops.OpUtils;
+import org.scijava.ops.adapt.AdaptedOp;
+import org.scijava.ops.core.Op;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.matcher.DefaultOpMatcher;
+import org.scijava.ops.matcher.MatchingUtils;
+import org.scijava.ops.matcher.OpAdaptationInfo;
+import org.scijava.ops.matcher.OpCandidate;
+import org.scijava.ops.matcher.OpClassInfo;
+import org.scijava.ops.matcher.OpFieldInfo;
+import org.scijava.ops.matcher.OpMatcher;
+import org.scijava.ops.matcher.OpMatchingException;
+import org.scijava.ops.matcher.OpRef;
+import org.scijava.ops.util.OpWrapper;
+import org.scijava.param.FunctionalMethodType;
+import org.scijava.param.ParameterStructs;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+import org.scijava.struct.ItemIO;
+import org.scijava.types.Nil;
+import org.scijava.types.TypeService;
+import org.scijava.types.Types;
+import org.scijava.util.ClassUtils;
+
+/**
+ * Default implementation of {@link OpEnvironment}, whose ops and related state
+ * are discovered from a SciJava application context.
+ * 
+ * @author Curtis Rueden
+ */
+public class DefaultOpEnvironment extends AbstractContextual implements OpEnvironment {
+
+	@Parameter
+	private PluginService pluginService;
+
+	private OpMatcher matcher;
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private TypeService typeService;
+
+	/**
+	 * Map to collect all aliases for a specific op. All aliases will map to one
+	 * canonical name of the op which is defined as the first one.
+	 */
+	private Map<String, Set<OpInfo>> opCache;
+
+	private Map<Class<?>, OpWrapper<?>> wrappers;
+
+	public DefaultOpEnvironment(final Context context) {
+		context.inject(this);
+		matcher = new DefaultOpMatcher(log);
+	}
+
+	@Override
+	public Iterable<OpInfo> infos() {
+		if (opCache == null) initOpCache();
+		return opCache.values().stream().flatMap(list -> list.stream()).collect(Collectors.toList());
+	}
+
+	@Override
+	public Iterable<OpInfo> infos(String name) {
+		if (opCache == null) initOpCache();
+		if (name == null || name.isEmpty()) return infos();
+		return opsOfName(name);
+	}
+
+	@Override
+	public <T> T op(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes, final Nil<?> outType) {
+		return findOpInstance(opName, specialType, inTypes, outType);
+	}
+
+	@Override
+	public Type genericType(Object obj) {
+		return typeService.reify(obj);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T findOpInstance(final String opName, final Nil<T> specialType, final Nil<?>[] inTypes,
+			final Nil<?> outType) {
+		final OpRef ref = OpRef.fromTypes(opName, toTypes(specialType), outType != null ? outType.getType() : null,
+				toTypes(inTypes));
+		return (T) findOpInstance(opName, ref, true);
+	}
+
+	private Object findOpInstance(final String opName, final OpRef ref, boolean adaptable) {
+		Object op = null;
+		OpCandidate match = null;
+		AdaptedOp adaptation = null;
+		try {
+			// Find single match which matches the specified types
+			match = matcher.findSingleMatch(this, ref);
+			final List<Object> dependencies = resolveOpDependencies(match);
+			op = match.createOp(dependencies);
+		} catch (OpMatchingException e) {
+			log.debug("No matching Op for request: " + ref + "\n");
+			if (!adaptable) {
+				throw new IllegalArgumentException(opName + " cannot be adapted (adaptation is disabled)");
+			}
+			log.debug("Attempting Op adaptation...");
+			try {
+				adaptation = adaptOp(ref);
+				op = adaptation.op();
+			} catch (OpMatchingException e1) {
+				log.debug("No suitable Op adaptation found");
+				throw new IllegalArgumentException(e1);
+			}
+
+		}
+		try {
+			// Try to resolve annotated OpDependency fields
+			// N.B. Adapted Op dependency fields are already matched.
+			if (match != null)
+				resolveOpDependencies(match);
+		} catch (OpMatchingException e) {
+			throw new IllegalArgumentException(e);
+		}
+		OpAdaptationInfo adaptedInfo = adaptation == null ? null : adaptation.opInfo();
+		Object wrappedOp = wrapOp(op, match, adaptedInfo);
+		return wrappedOp;
+	}
+
+	private Type[] toTypes(Nil<?>... nils) {
+		return Arrays.stream(nils).filter(n -> n != null).map(n -> n.getType()).toArray(Type[]::new);
+	}
+
+	/**
+	 * Attempts to inject {@link OpDependency} annotated fields of the specified
+	 * object by looking for Ops matching the field type and the name specified in
+	 * the annotation. The field type is assumed to be functional.
+	 *
+	 * @param op
+	 * @throws OpMatchingException
+	 *             if the type of the specified object is not functional, if the Op
+	 *             matching the functional type and the name could not be found, if
+	 *             an exception occurs during injection
+	 */
+	private List<Object> resolveOpDependencies(OpCandidate op) throws OpMatchingException {
+		final List<OpDependencyMember<?>> dependencies = op.opInfo().dependencies();
+		final List<Object> resolvedDependencies = new ArrayList<>(dependencies.size());
+		for (final OpDependencyMember<?> dependency : dependencies) {
+			final String dependencyName = dependency.getDependencyName();
+			final Type mappedDependencyType = Types.mapVarToTypes(new Type[] { dependency.getType() },
+					op.typeVarAssigns())[0];
+			final OpRef inferredRef = inferOpRef(mappedDependencyType, dependencyName, op.typeVarAssigns());
+			if (inferredRef == null) {
+				throw new OpMatchingException("Could not infer functional "
+						+ "method inputs and outputs of Op dependency field: " + dependency.getKey());
+			}
+			try {
+				resolvedDependencies.add(findOpInstance(dependencyName, inferredRef, dependency.isAdaptable()));
+			} catch (final Exception e) {
+				throw new OpMatchingException("Could not find Op that matches requested Op dependency:" + "\nOp class: "
+						+ op.opInfo().implementationName() + //
+						"\nDependency identifier: " + dependency.getKey() + //
+						"\n\n Attempted request:\n" + inferredRef, e);
+			}
+		}
+		return resolvedDependencies;
+	}
+
+	/**
+	 * Adapts an Op with the name of ref into a type that can be SAFELY cast to ref.
+	 * 
+	 * @param ref
+	 *            - the type of Op that we are looking to adapt to.
+	 * @return {@link AdaptedOp} - an Op that has been adapted to conform the the
+	 *         ref type.
+	 * @throws OpMatchingException
+	 */
+	private AdaptedOp adaptOp(OpRef ref) throws OpMatchingException {
+		// FIXME: Need to validate against all types, not just the first.
+		final Type opType = ref.getTypes()[0];
+
+		for (final OpInfo adaptor : infos("adapt")) {
+			Type adaptTo = adaptor.output().getType();
+			Map<TypeVariable<?>, Type> map = new HashMap<>();
+			// make sure that the adaptor outputs the correct type
+			if (opType instanceof ParameterizedType) {
+				if (!MatchingUtils.checkGenericAssignability(adaptTo,
+					(ParameterizedType) opType, map, true))
+				{
+					continue;
+				}
+			}
+			else if (!Types.isAssignable(opType, adaptTo, map)) {
+				continue;
+			}
+			// make sure that the adaptor is a Function (so we can cast it later)
+			if (Types.isInstance(adaptor.opType(), Function.class)) {
+				log.debug(adaptor + " is an illegal adaptor Op: must be a Function");
+				continue;
+			}
+			// build the type of fromOp (we know there must be one input because the adaptor
+			// is a Function)
+			Type adaptFrom = adaptor.inputs().get(0).getType();
+			Type refAdaptTo = Types.substituteTypeVariables(adaptTo, map);
+			Type refAdaptFrom = Types.substituteTypeVariables(adaptFrom, map);
+
+			// build the OpRef of the adaptor.
+			Type refType = Types.parameterize(Function.class, new Type[] { refAdaptFrom, refAdaptTo });
+			OpRef adaptorRef = new OpRef("adapt", new Type[] { refType }, refAdaptTo, new Type[] { refAdaptFrom });
+
+			// make an OpCandidate
+			OpCandidate candidate = new OpCandidate(this, log, adaptorRef, adaptor, map);
+
+			try {
+				// resolve adaptor dependencies and get the adaptor (as a function)
+				final List<Object> dependencies = resolveOpDependencies(candidate);
+				Object adaptorOp = adaptor.createOpInstance(dependencies).object();
+
+				// grab the first type parameter (from the OpCandidate?) and search for an Op
+				// that will then be adapted (this will be the first (only) type in the args of
+				// the adaptor)
+				Type srcOpType = Types.substituteTypeVariables(adaptor.inputs().get(0).getType(), map);
+				final OpRef srcOpRef;
+					srcOpRef = inferOpRef(srcOpType, ref.getName(), map);
+				// TODO: export this to another function (also done in findOpInstance).
+				// We need this here because we need to grab the OpInfo. 
+				// TODO: is there a better way to do this?
+				final OpCandidate srcCandidate = matcher.findSingleMatch(this, srcOpRef);
+				final List<Object> srcDependencies = resolveOpDependencies(srcCandidate);
+				final Object fromOp = srcCandidate.opInfo().createOpInstance(srcDependencies).object();
+
+				// get adapted Op by applying adaptor on unadapted Op, then return
+				// TODO: can we make this safer?
+				@SuppressWarnings("unchecked")
+				Object toOp = ((Function<Object, Object>) adaptorOp).apply(fromOp);
+				// construct type of adapted op
+				Type adapterOpType = Types.substituteTypeVariables(adaptor.output().getType(),
+						map);
+				return new AdaptedOp(toOp, adapterOpType, srcCandidate.opInfo(), adaptor);
+			} catch (OpMatchingException e1) {
+				log.trace(e1);
+			}
+		}
+
+		// no adaptors available.
+		throw new OpMatchingException("Op adaptation failed: no adaptable Ops of type " + ref.getName());
+	}
+
+	/**
+	 * Wraps the matched op into an {@link Op} that knows its generic typing and
+	 * {@link OpInfo}.
+	 * 
+	 * @param op
+	 *            - the matched op to wrap.
+	 * @param match
+	 *            - where to retrieve the {@link OpInfo} if no transformation is
+	 *            needed.
+	 * @param adaptationInfo
+	 *            - where to retrieve the {@link OpInfo} if a transformation is
+	 *            needed.
+	 * @return an {@link Op} wrapping of op.
+	 */
+	private Object wrapOp(Object op, OpCandidate match, OpAdaptationInfo adaptationInfo) {
+		if (wrappers == null)
+			initWrappers();
+
+		OpInfo opInfo = match == null ? adaptationInfo : match.opInfo();
+		// FIXME: this type is not necessarily Computer, Function, etc. but often
+		// something more specific (like the class of an Op).
+		// TODO: Is this correct?
+		Type type = match == null ? adaptationInfo.opType() : match.getRef().getTypes()[0];
+		try {
+			// determine the Op wrappers that could wrap the matched Op
+			Class<?>[] suitableWrappers = wrappers.keySet().stream().filter(wrapper -> wrapper.isInstance(op))
+					.toArray(Class[]::new);
+			if (suitableWrappers.length == 0)
+				throw new IllegalArgumentException(opInfo.implementationName() + ": matched op Type " + type.getClass()
+						+ " does not match a wrappable Op type.");
+			if (suitableWrappers.length > 1)
+				throw new IllegalArgumentException(
+						"Matched op Type " + type.getClass() + " matches multiple Op types: " + wrappers.toString());
+			// get the wrapper and wrap up the Op
+			if (!Types.isAssignable(Types.raw(type), suitableWrappers[0]))
+				throw new IllegalArgumentException(Types.raw(type) + "cannot be wrapped as a " + suitableWrappers[0].getClass());
+			return wrap(op, type);
+		} catch (IllegalArgumentException | SecurityException exc) {
+			log.error(exc.getMessage() != null ? exc.getMessage() : "Cannot wrap " + op.getClass());
+			return op;
+		} catch (NullPointerException e) {
+			log.error("No wrapper exists for " + Types.raw(type).toString() + ".");
+			return op;
+		}
+	}
+
+	/**
+	 * Tries to infer a {@link OpRef} from a functional Op type. E.g. the type:
+	 * 
+	 * <pre>
+	 * Computer&lt;Double[], Double[]&gt
+	 * </pre>
+	 * 
+	 * Will result in the following {@link OpRef}:
+	 * 
+	 * <pre>
+	 * Name: 'specified name'
+	 * Types:       [Computer&lt;Double, Double&gt]
+	 * InputTypes:  [Double[], Double[]]
+	 * OutputTypes: [Double[]]
+	 * </pre>
+	 * 
+	 * Input and output types will be inferred by looking at the signature of the
+	 * functional method of the specified type. Also see
+	 * {@link ParameterStructs#findFunctionalMethodTypes(Type)}.
+	 *
+	 * @param type
+	 * @param name
+	 * @return null if the specified type has no functional method
+	 */
+	private OpRef inferOpRef(Type type, String name, Map<TypeVariable<?>, Type> typeVarAssigns)
+			throws OpMatchingException {
+		List<FunctionalMethodType> fmts = ParameterStructs.findFunctionalMethodTypes(type);
+		if (fmts == null)
+			return null;
+
+		EnumSet<ItemIO> inIos = EnumSet.of(ItemIO.BOTH, ItemIO.INPUT);
+		EnumSet<ItemIO> outIos = EnumSet.of(ItemIO.BOTH, ItemIO.OUTPUT);
+
+		Type[] inputs = fmts.stream().filter(fmt -> inIos.contains(fmt.itemIO())).map(fmt -> fmt.type())
+				.toArray(Type[]::new);
+
+		Type[] outputs = fmts.stream().filter(fmt -> outIos.contains(fmt.itemIO())).map(fmt -> fmt.type())
+				.toArray(Type[]::new);
+
+		Type[] mappedInputs = Types.mapVarToTypes(inputs, typeVarAssigns);
+		Type[] mappedOutputs = Types.mapVarToTypes(outputs, typeVarAssigns);
+
+		final int numOutputs = mappedOutputs.length;
+		if (numOutputs != 1) {
+			String error = "Op '" + name + "' of type " + type + " specifies ";
+			error += numOutputs == 0 //
+					? "no outputs" //
+					: "multiple outputs: " + Arrays.toString(outputs);
+			error += ". This is not supported.";
+			throw new OpMatchingException(error);
+		}
+		return new OpRef(name, new Type[] { type }, mappedOutputs[0], mappedInputs);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T wrap(Object op, Type reifiedType) {
+		if (wrappers == null)
+			initWrappers();
+		OpWrapper<T> wrapper = (OpWrapper<T>) wrappers.get(Types.raw(reifiedType));
+		return wrapper.wrap((T) op, reifiedType);
+	}
+
+	private void initOpCache() {
+		opCache = new HashMap<>();
+
+		// Add regular Ops
+		for (final PluginInfo<Op> pluginInfo : pluginService.getPluginsOfType(Op.class)) {
+			try {
+				final Class<?> opClass = pluginInfo.loadClass();
+				OpInfo opInfo = new OpClassInfo(opClass);
+				addToOpIndex(opInfo, pluginInfo.getName());
+			} catch (InstantiableException exc) {
+				log.error("Can't load class from plugin info: " + pluginInfo.toString(), exc);
+			}
+		}
+		// Add Ops contained in an OpCollection
+		for (final PluginInfo<OpCollection> pluginInfo : pluginService.getPluginsOfType(OpCollection.class)) {
+			try {
+				Class<? extends OpCollection> c = pluginInfo.loadClass();
+				final List<Field> fields = ClassUtils.getAnnotatedFields(c, OpField.class);
+				Object instance = null;
+				for (Field field : fields) {
+					final boolean isStatic = Modifier.isStatic(field.getModifiers());
+					if (!isStatic && instance == null) {
+						instance = field.getDeclaringClass().newInstance();
+					}
+					OpInfo opInfo = new OpFieldInfo(isStatic ? null : instance, field);
+					addToOpIndex(opInfo, field.getAnnotation(OpField.class).names());
+				}
+			} catch (InstantiableException | InstantiationException | IllegalAccessException exc) {
+				log.error("Can't load class from plugin info: " + pluginInfo.toString(), exc);
+			}
+		}
+	}
+
+	private void initWrappers() {
+		wrappers = new HashMap<>();
+		for (OpWrapper<?> wrapper : pluginService.createInstancesOfType(OpWrapper.class)) {
+			wrappers.put(wrapper.type(), wrapper);
+		}
+	}
+
+	private void addToOpIndex(final OpInfo opInfo, final String opNames) {
+		String[] parsedOpNames = OpUtils.parseOpNames(opNames);
+		if (parsedOpNames == null || parsedOpNames.length == 0) {
+			log.error("Skipping Op " + opInfo.implementationName() + ":\n" + "Op implementation must provide name.");
+			return;
+		}
+		if (!opInfo.isValid()) {
+			log.error("Skipping invalid Op " + opInfo.implementationName() + ":\n"
+					+ opInfo.getValidityException().getMessage());
+			return;
+		}
+		for (String opName : parsedOpNames) {
+			if (!opCache.containsKey(opName))
+				opCache.put(opName, new TreeSet<>());
+			opCache.get(opName).add(opInfo);
+		}
+	}
+
+	private Set<OpInfo> opsOfName(final String name) {
+		final Set<OpInfo> ops = opCache.getOrDefault(name, Collections.emptySet());
+		return Collections.unmodifiableSet(ops);
+	}
+
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
@@ -46,9 +46,7 @@ import org.scijava.ops.OpEnvironment;
 import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.ops.matcher.OpCandidate.StatusCode;
-import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
-import org.scijava.service.Service;
 import org.scijava.struct.Member;
 import org.scijava.types.Types;
 import org.scijava.types.Types.TypeVarInfo;
@@ -68,19 +66,19 @@ public class DefaultOpMatcher extends AbstractService implements OpMatcher {
 	}
 
 	@Override
-	public OpCandidate findSingleMatch(final OpEnvironment ops, final OpRef ref) throws OpMatchingException {
-		return findMatch(ops, ref).singleMatch();
+	public OpCandidate findSingleMatch(final OpEnvironment env, final OpRef ref) throws OpMatchingException {
+		return findMatch(env, ref).singleMatch();
 	}
 
 	@Override
-	public MatchingResult findMatch(final OpEnvironment ops, final OpRef ref) {
-		return findMatch(ops, Collections.singletonList(ref));
+	public MatchingResult findMatch(final OpEnvironment env, final OpRef ref) {
+		return findMatch(env, Collections.singletonList(ref));
 	}
 
 	@Override
-	public MatchingResult findMatch(final OpEnvironment ops, final List<OpRef> refs) {
+	public MatchingResult findMatch(final OpEnvironment env, final List<OpRef> refs) {
 		// find candidates with matching name & type
-		final List<OpCandidate> candidates = findCandidates(ops, refs);
+		final List<OpCandidate> candidates = findCandidates(env, refs);
 		if (candidates.isEmpty()) {
 			return MatchingResult.empty(refs);
 		}
@@ -90,18 +88,18 @@ public class DefaultOpMatcher extends AbstractService implements OpMatcher {
 	}
 
 	@Override
-	public List<OpCandidate> findCandidates(final OpEnvironment ops, final OpRef ref) {
-		return findCandidates(ops, Collections.singletonList(ref));
+	public List<OpCandidate> findCandidates(final OpEnvironment env, final OpRef ref) {
+		return findCandidates(env, Collections.singletonList(ref));
 	}
 
 	@Override
-	public List<OpCandidate> findCandidates(final OpEnvironment ops, final List<OpRef> refs) {
+	public List<OpCandidate> findCandidates(final OpEnvironment env, final List<OpRef> refs) {
 		final ArrayList<OpCandidate> candidates = new ArrayList<>();
 		for (final OpRef ref : refs) {
-			for (final OpInfo info : ops.infos(ref.getName())) {
+			for (final OpInfo info : env.infos(ref.getName())) {
 				Map<TypeVariable<?>, Type> typeVarAssigns = new HashMap<>();
 				if (ref.typesMatch(info.opType(), typeVarAssigns)) {
-					candidates.add(new OpCandidate(ops, log, ref, info, typeVarAssigns));
+					candidates.add(new OpCandidate(env, log, ref, info, typeVarAssigns));
 				}
 			}
 		}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
@@ -43,6 +43,7 @@ import java.util.function.Predicate;
 
 import org.scijava.log.Logger;
 import org.scijava.ops.OpEnvironment;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.ops.matcher.OpCandidate.StatusCode;
 import org.scijava.plugin.Plugin;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpAdaptationInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpAdaptationInfo.java
@@ -4,6 +4,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.param.ParameterStructs;
 import org.scijava.param.ValidityException;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpCandidate.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpCandidate.java
@@ -64,7 +64,7 @@ public class OpCandidate {
 		DOES_NOT_CONFORM, OTHER //
 	}
 
-	private final OpEnvironment ops;
+	private final OpEnvironment env;
 	private final Logger log;
 	private final OpRef ref;
 	private final OpInfo info;
@@ -79,10 +79,10 @@ public class OpCandidate {
 	 * If the op does not, this will be the same as {@link #ref}.getArgs(). */
 	private final Type[] paddedArgs;
 
-	public OpCandidate(final OpEnvironment ops, final Logger log, final OpRef ref, final OpInfo info,
+	public OpCandidate(final OpEnvironment env, final Logger log, final OpRef ref, final OpInfo info,
 		final Map<TypeVariable<?>, Type> typeVarAssigns)
 	{
-		this.ops = ops;
+		this.env = env;
 		this.log = log;
 		this.ref = ref;
 		this.info = info;
@@ -92,8 +92,8 @@ public class OpCandidate {
 	}
 
 	/** Gets the op execution environment of the desired match. */
-	public OpEnvironment ops() {
-		return ops;
+	public OpEnvironment env() {
+		return env;
 	}
 
 	/** Gets the op reference describing the desired match. */

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpCandidate.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpCandidate.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import org.scijava.log.Logger;
 import org.scijava.ops.OpEnvironment;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.param.ValidityProblem;
 import org.scijava.struct.Member;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpClassInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpClassInfo.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.scijava.Priority;
 import org.scijava.ops.OpDependencyMember;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.param.ParameterStructs;
 import org.scijava.param.ValidityException;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpFieldInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpFieldInfo.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import org.scijava.Priority;
 import org.scijava.ops.OpField;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.OpUtils;
 import org.scijava.param.ParameterStructs;
 import org.scijava.param.ValidityException;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMatcher.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMatcher.java
@@ -41,15 +41,15 @@ import org.scijava.ops.OpEnvironment;
 //TODO javadoc
 public interface OpMatcher {
 
-	OpCandidate findSingleMatch(OpEnvironment ops, OpRef ref) throws OpMatchingException;
+	OpCandidate findSingleMatch(OpEnvironment env, OpRef ref) throws OpMatchingException;
 
-	MatchingResult findMatch(OpEnvironment ops, OpRef ref);
+	MatchingResult findMatch(OpEnvironment env, OpRef ref);
 
-	MatchingResult findMatch(OpEnvironment ops, List<OpRef> refs);
+	MatchingResult findMatch(OpEnvironment env, List<OpRef> refs);
 
-	List<OpCandidate> findCandidates(OpEnvironment ops, OpRef ref);
+	List<OpCandidate> findCandidates(OpEnvironment env, OpRef ref);
 
-	List<OpCandidate> findCandidates(OpEnvironment ops, List<OpRef> refs);
+	List<OpCandidate> findCandidates(OpEnvironment env, List<OpRef> refs);
 
 	List<OpCandidate> filterMatches(List<OpCandidate> candidates);
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import org.scijava.ops.FieldOpDependencyMember;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.OpDependencyMember;
-import org.scijava.ops.matcher.OpInfo;
+import org.scijava.ops.OpInfo;
 import org.scijava.ops.util.AnnotationUtils;
 import org.scijava.struct.ItemIO;
 import org.scijava.struct.Member;

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AbstractTestEnvironment.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AbstractTestEnvironment.java
@@ -11,8 +11,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.scijava.Context;
 import org.scijava.cache.CacheService;
-import org.scijava.ops.core.builder.OpBuilder;
+import org.scijava.plugin.PluginService;
 import org.scijava.thread.ThreadService;
+import org.scijava.types.TypeService;
 
 public abstract class AbstractTestEnvironment {
 
@@ -21,7 +22,7 @@ public abstract class AbstractTestEnvironment {
 
 	@BeforeClass
 	public static void setUp() {
-		context = new Context(OpService.class, CacheService.class, ThreadService.class);
+		context = new Context(OpService.class, CacheService.class, ThreadService.class, PluginService.class, TypeService.class);
 		ops = context.service(OpService.class);
 	}
 
@@ -30,10 +31,6 @@ public abstract class AbstractTestEnvironment {
 		context.dispose();
 		context = null;
 		ops = null;
-	}
-	
-	protected static OpBuilder op(String name) {
-		return new OpBuilder(ops, name);
 	}
 	
 	protected static boolean arrayEquals(double[] arr1, Double... arr2) {

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
@@ -46,7 +46,7 @@ public class AdaptersTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testComputerAsFunction() {
-		final Computers.Arity2<double[], double[], double[]> computer = ops.findOp( //
+		final Computers.Arity2<double[], double[], double[]> computer = ops.op( //
 				"test.adaptersC", new Nil<Computers.Arity2<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray, nilDoubleArray }, //
@@ -67,7 +67,7 @@ public class AdaptersTest extends AbstractTestEnvironment {
 	@Test
 	public void testFunctionAsComputer() {
 		// look up a function: Double result = math.add(Double v1, Double v2)
-		BiFunction<double[], double[], double[]> function = ops.findOp( //
+		BiFunction<double[], double[], double[]> function = ops.op( //
 				"test.adaptersF", new Nil<BiFunction<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
@@ -38,10 +38,10 @@ import org.scijava.ops.util.Adapt;
 
 public class AdaptersTest extends AbstractTestEnvironment {
 
-	private static Nil<Double> nilDouble = new Nil<Double>() {
+	private static Nil<Double> nilDouble = new Nil<>() {
 	};
 
-	private static Nil<double[]> nilDoubleArray = new Nil<double[]>() {
+	private static Nil<double[]> nilDoubleArray = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AdaptersTest.java
@@ -46,7 +46,7 @@ public class AdaptersTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testComputerAsFunction() {
-		final Computers.Arity2<double[], double[], double[]> computer = ops.op( //
+		final Computers.Arity2<double[], double[], double[]> computer = ops.env().op( //
 				"test.adaptersC", new Nil<Computers.Arity2<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray, nilDoubleArray }, //
@@ -67,7 +67,7 @@ public class AdaptersTest extends AbstractTestEnvironment {
 	@Test
 	public void testFunctionAsComputer() {
 		// look up a function: Double result = math.add(Double v1, Double v2)
-		BiFunction<double[], double[], double[]> function = ops.op( //
+		BiFunction<double[], double[], double[]> function = ops.env().op( //
 				"test.adaptersF", new Nil<BiFunction<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AutoTransformTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AutoTransformTest.java
@@ -51,7 +51,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		// There is no sqrt function for iterables in the system, however we can auto
 		// transform
 		// as there is a lifter for Functions to iterables
-		Function<Iterable<Double>, Iterable<Double>> sqrtFunction = ops.op( //
+		Function<Iterable<Double>, Iterable<Double>> sqrtFunction = ops.env().op( //
 				"math.sqrt", new Nil<Function<Iterable<Double>, Iterable<Double>>>() {}, //
 				new Nil[] { nilIterableDouble }, //
 				nilIterableDouble//
@@ -67,8 +67,8 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		// however we can auto
 		// transform
 		// as there is a lifter for Functions to iterables
-		Computers.Arity2<Iterable<double[]>, Iterable<double[]>, Iterable<double[]>> sqrtFunction = new OpBuilder(ops,
-				"test.adaptersF").inType(new Nil<Iterable<double[]>>() {}, new Nil<Iterable<double[]>>() {})
+		Computers.Arity2<Iterable<double[]>, Iterable<double[]>, Iterable<double[]>> sqrtFunction =
+				ops.op("test.adaptersF").inType(new Nil<Iterable<double[]>>() {}, new Nil<Iterable<double[]>>() {})
 						.outType(new Nil<Iterable<double[]>>() {}).computer();
 
 		Iterable<double[]> res = Arrays.asList(new double[] {1.0, 0.0, 0.0});
@@ -81,7 +81,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		// check transformation as a Function<Iterable, Iterable>
 		Nil<Iterable<double[]>> n = new Nil<Iterable<double[]>>() {};
 
-		Function<Iterable<double[]>, Iterable<double[]>> sqrtListFunction = ops.op( //
+		Function<Iterable<double[]>, Iterable<double[]>> sqrtListFunction = ops.env().op( //
 				"test.liftSqrt", new Nil<Function<Iterable<double[]>, Iterable<double[]>>>() {}, //
 				new Nil[] { n }, //
 				n//
@@ -100,7 +100,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		Nil<Iterable<double[]>> n = new Nil<Iterable<double[]>>() {};
 		Nil<List<double[]>> l = new Nil<List<double[]>>() {};
 
-		Function<List<double[]>, Iterable<double[]>> sqrtListFunction = ops.op( //
+		Function<List<double[]>, Iterable<double[]>> sqrtListFunction = ops.env().op( //
 				"test.liftSqrt", new Nil<Function<List<double[]>, Iterable<double[]>>>() {}, //
 				new Nil[] { l }, //
 				n//

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/AutoTransformTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/AutoTransformTest.java
@@ -51,7 +51,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		// There is no sqrt function for iterables in the system, however we can auto
 		// transform
 		// as there is a lifter for Functions to iterables
-		Function<Iterable<Double>, Iterable<Double>> sqrtFunction = ops.findOp( //
+		Function<Iterable<Double>, Iterable<Double>> sqrtFunction = ops.op( //
 				"math.sqrt", new Nil<Function<Iterable<Double>, Iterable<Double>>>() {}, //
 				new Nil[] { nilIterableDouble }, //
 				nilIterableDouble//
@@ -81,7 +81,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		// check transformation as a Function<Iterable, Iterable>
 		Nil<Iterable<double[]>> n = new Nil<Iterable<double[]>>() {};
 
-		Function<Iterable<double[]>, Iterable<double[]>> sqrtListFunction = ops.findOp( //
+		Function<Iterable<double[]>, Iterable<double[]>> sqrtListFunction = ops.op( //
 				"test.liftSqrt", new Nil<Function<Iterable<double[]>, Iterable<double[]>>>() {}, //
 				new Nil[] { n }, //
 				n//
@@ -100,7 +100,7 @@ public class AutoTransformTest extends AbstractTestEnvironment {
 		Nil<Iterable<double[]>> n = new Nil<Iterable<double[]>>() {};
 		Nil<List<double[]>> l = new Nil<List<double[]>>() {};
 
-		Function<List<double[]>, Iterable<double[]>> sqrtListFunction = ops.findOp( //
+		Function<List<double[]>, Iterable<double[]>> sqrtListFunction = ops.op( //
 				"test.liftSqrt", new Nil<Function<List<double[]>, Iterable<double[]>>>() {}, //
 				new Nil[] { l }, //
 				n//

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/ComputersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/ComputersTest.java
@@ -40,7 +40,7 @@ public class ComputersTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testUnaryComputers() {
-		Computers.Arity1<double[], double[]> sqrtComputer = Computers.match(ops,
+		Computers.Arity1<double[], double[]> sqrtComputer = Computers.match(ops.env(),
 			"math.sqrt", nilDoubleArray, nilDoubleArray);
 
 		double[] result = new double[3];
@@ -51,7 +51,7 @@ public class ComputersTest extends AbstractTestEnvironment {
 	@Test
 	public void testBinaryComputers() {
 		Computers.Arity2<double[], double[], double[]> addComputer = //
-			Computers.match(ops, "math.add", nilDoubleArray, nilDoubleArray,
+			Computers.match(ops.env(), "math.add", nilDoubleArray, nilDoubleArray,
 				nilDoubleArray);
 
 		double[] result = new double[3];

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/ComputersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/ComputersTest.java
@@ -35,7 +35,7 @@ import org.scijava.types.Nil;
 
 public class ComputersTest extends AbstractTestEnvironment {
 
-	private static Nil<double[]> nilDoubleArray = new Nil<double[]>() {
+	private static Nil<double[]> nilDoubleArray = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/FunctionsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/FunctionsTest.java
@@ -38,7 +38,7 @@ import org.scijava.types.Nil;
 
 public class FunctionsTest extends AbstractTestEnvironment {
 
-	private static Nil<Double> nilDouble = new Nil<Double>() {
+	private static Nil<Double> nilDouble = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/FunctionsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/FunctionsTest.java
@@ -43,19 +43,19 @@ public class FunctionsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testUnaryFunctions() {
-		Function<Double, Double> sqrtFunction = Functions.match(ops, "math.sqrt", nilDouble, nilDouble);
+		Function<Double, Double> sqrtFunction = Functions.match(ops.env(), "math.sqrt", nilDouble, nilDouble);
 		double answer = sqrtFunction.apply(16.0);
 		assert 4.0 == answer;
 	}
 
 	@Test
 	public void testBinaryFunctions() {
-		BiFunction<Double, Double, Double> addFunction = Functions.match(ops, "math.add", nilDouble, nilDouble,
+		BiFunction<Double, Double, Double> addFunction = Functions.match(ops.env(), "math.add", nilDouble, nilDouble,
 				nilDouble);
 		double answer = addFunction.apply(16.0, 14.0);
 		assert 30.0 == answer;
 
-		BiFunction<Double, Double, Double> powerFunction = Functions.match(ops, "math.pow", nilDouble,
+		BiFunction<Double, Double, Double> powerFunction = Functions.match(ops.env(), "math.pow", nilDouble,
 				nilDouble, nilDouble);
 		answer = powerFunction.apply(2.0, 10.0);
 		assert 1024.0 == answer;

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/InplacesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/InplacesTest.java
@@ -40,7 +40,7 @@ public class InplacesTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testUnaryInplaces() {
-		Inplaces.Arity1<double[]> inplaceSqrt = Inplaces.match(ops, "math.sqrt", nilDoubleArray);
+		Inplaces.Arity1<double[]> inplaceSqrt = Inplaces.match(ops.env(), "math.sqrt", nilDoubleArray);
 		final double[] a1 = { 4, 100, 36 };
 		inplaceSqrt.mutate(a1);
 		assert arrayEquals(a1, 2.0, 10.0, 6.0);
@@ -48,7 +48,7 @@ public class InplacesTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testBinaryInplaces() {
-		final Inplaces.Arity2_1<double[], double[]> inplaceAdd = Inplaces.match1(ops, "math.add", nilDoubleArray,
+		final Inplaces.Arity2_1<double[], double[]> inplaceAdd = Inplaces.match1(ops.env(), "math.add", nilDoubleArray,
 				nilDoubleArray);
 		final double[] a1 = { 3, 5, 7 };
 		final double[] a2 = { 2, 4, 9 };

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/InplacesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/InplacesTest.java
@@ -35,7 +35,7 @@ import org.scijava.types.Nil;
 
 public class InplacesTest extends AbstractTestEnvironment {
 
-	private static Nil<double[]> nilDoubleArray = new Nil<double[]>() {
+	private static Nil<double[]> nilDoubleArray = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/LiftTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/LiftTest.java
@@ -45,10 +45,10 @@ import org.scijava.ops.util.Maps;
 
 public class LiftTest extends AbstractTestEnvironment {
 
-	Nil<Double> nilDouble = new Nil<Double>() {
+	Nil<Double> nilDouble = new Nil<>() {
 	};
 
-	Nil<double[]> nilDoubleArray = new Nil<double[]>() {
+	Nil<double[]> nilDoubleArray = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/LiftTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/LiftTest.java
@@ -53,7 +53,7 @@ public class LiftTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testliftFunction(){
-		Function<Double, Double> powFunction = Functions.match(ops, "test.liftFunction", nilDouble, nilDouble);
+		Function<Double, Double> powFunction = Functions.match(ops.env(), "test.liftFunction", nilDouble, nilDouble);
 
 		Function<Iterable<Double>, Iterable<Double>> liftedToIterable = Maps.FunctionMaps.Iterables.liftBoth(powFunction);
 		Iterable<Double> res2 = liftedToIterable.apply(Arrays.asList(1.0, 2.0, 3.0, 4.0));
@@ -71,7 +71,7 @@ public class LiftTest extends AbstractTestEnvironment {
 	@Test
 	public void testliftComputer() {
 
-		Computers.Arity1<double[], double[]> powComputer = Computers.match(ops, "test.liftComputer", nilDoubleArray, nilDoubleArray);
+		Computers.Arity1<double[], double[]> powComputer = Computers.match(ops.env(), "test.liftComputer", nilDoubleArray, nilDoubleArray);
 
 		Computers.Arity1<Iterable<double[]>, Iterable<double[]>> liftedToIterable = Maps.ComputerMaps.Iterables
 				.liftBoth(powComputer);

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
@@ -42,7 +42,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 	
 	@Test
 	public void testOpCollection() throws ValidityException {
-		BiFunction<Double, Double, Double> divFunction = ops.findOp( //
+		BiFunction<Double, Double, Double> divFunction = ops.op( //
 				"math.div", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -50,7 +50,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 1.0 == divFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> addFunction = ops.findOp( //
+		BiFunction<Double, Double, Double> addFunction = ops.op( //
 				"math.add", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -58,7 +58,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 4.0 == addFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> mulFunction = ops.findOp( //
+		BiFunction<Double, Double, Double> mulFunction = ops.op( //
 				"math.mul", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -66,7 +66,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 4.0 == mulFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> subFunction = ops.findOp( //
+		BiFunction<Double, Double, Double> subFunction = ops.op( //
 				"math.sub", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
@@ -37,7 +37,7 @@ import org.scijava.param.ValidityException;
 
 public class OpCollectionTest extends AbstractTestEnvironment {
 
-	Nil<Double> nilDouble = new Nil<Double>() {
+	Nil<Double> nilDouble = new Nil<>() {
 	};
 	
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCollectionTest.java
@@ -42,7 +42,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 	
 	@Test
 	public void testOpCollection() throws ValidityException {
-		BiFunction<Double, Double, Double> divFunction = ops.op( //
+		BiFunction<Double, Double, Double> divFunction = ops.env().op( //
 				"math.div", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -50,7 +50,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 1.0 == divFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> addFunction = ops.op( //
+		BiFunction<Double, Double, Double> addFunction = ops.env().op( //
 				"math.add", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -58,7 +58,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 4.0 == addFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> mulFunction = ops.op( //
+		BiFunction<Double, Double, Double> mulFunction = ops.env().op( //
 				"math.mul", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -66,7 +66,7 @@ public class OpCollectionTest extends AbstractTestEnvironment {
 		);
 		assert 4.0 == mulFunction.apply(2.0, 2.0);
 		
-		BiFunction<Double, Double, Double> subFunction = ops.op( //
+		BiFunction<Double, Double, Double> subFunction = ops.env().op( //
 				"math.sub", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
@@ -62,7 +62,7 @@ public class OpPriorityTest extends AbstractTestEnvironment {
 	@Test
 	public void testOpPriority() {
 
-		Producer<Number> testFunc = ops.op("test.priority", new Nil<Producer<Number>>() {}, new Nil[] {}, new Nil<Number>() {});
+		Producer<Number> testFunc = ops.env().op("test.priority", new Nil<Producer<Number>>() {}, new Nil[] {}, new Nil<Number>() {});
 		Number x = testFunc.create();
 		assertTrue(x instanceof Double);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
@@ -62,7 +62,7 @@ public class OpPriorityTest extends AbstractTestEnvironment {
 	@Test
 	public void testOpPriority() {
 
-		Producer<Number> testFunc = ops.findOp("test.priority", new Nil<Producer<Number>>() {}, new Nil[] {}, new Nil<Number>() {});
+		Producer<Number> testFunc = ops.op("test.priority", new Nil<Producer<Number>>() {}, new Nil[] {}, new Nil<Number>() {});
 		Number x = testFunc.create();
 		assertTrue(x instanceof Double);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
@@ -48,7 +48,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	@Test
 	public void unaryFunction() {
 		// Look up a function type safe
-		Function<Double, Double> sqrtFunction = ops.op( //
+		Function<Double, Double> sqrtFunction = ops.env().op( //
 				"math.sqrt", new Nil<Function<Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble }, //
@@ -61,7 +61,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	@Test
 	public void binaryFunction() {
 		// look up a function: Double result = math.add(Double v1, Double v2)
-		BiFunction<Double, Double, Double> addFunction = ops.op( //
+		BiFunction<Double, Double, Double> addFunction = ops.env().op( //
 				"math.add", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -72,7 +72,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void nullaryComputer() {
-		Computers.Arity0<double[]> sqrtComputer = ops.op( //
+		Computers.Arity0<double[]> sqrtComputer = ops.env().op( //
 				"math.zero", new Nil<Computers.Arity0<double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray }, //
@@ -85,7 +85,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	
 	@Test
 	public void unaryComputer() {
-		Computers.Arity1<double[], double[]> sqrtComputer = ops.op( //
+		Computers.Arity1<double[], double[]> sqrtComputer = ops.env().op( //
 				"math.sqrt", new Nil<Computers.Arity1<double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //
@@ -98,7 +98,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void binaryComputer() {
-		Computers.Arity2<double[], double[], double[]> computer = ops.op( //
+		Computers.Arity2<double[], double[], double[]> computer = ops.env().op( //
 				"math.add", new Nil<Computers.Arity2<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray, nilDoubleArray }, //
@@ -113,7 +113,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void unaryInplace() {
-		Inplaces.Arity1<double[]> inplaceSqrt = ops.op( //
+		Inplaces.Arity1<double[]> inplaceSqrt = ops.env().op( //
 				"math.sqrt", new Nil<Inplaces.Arity1<double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray }, //
@@ -126,7 +126,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void binaryInplace() {
-		Inplaces.Arity2_1<double[], double[]> inplaceAdd = ops.op( //
+		Inplaces.Arity2_1<double[], double[]> inplaceAdd = ops.env().op( //
 				"math.add", new Nil<Inplaces.Arity2_1<double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //
@@ -146,7 +146,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		Exception error = null;
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
+//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.env().op( //
 //					"math.add", //
 //					new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -162,7 +162,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		// Generic typed BiFunction does not matches
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Double, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
+//			BiFunction<Double, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.env().op( //
 //					"math.add", //
 //					new Nil<BiFunction<Double, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -178,7 +178,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		// Output does not match
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
+//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.env().op( //
 //					"math.add", //
 //					new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -192,7 +192,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		error = null;
 //
 //		// We have a generic function which adds two iterables of numbers and gives an iterable of double
-//		BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
+//		BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.env().op( //
 //				"math.add", //
 //				new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //				}, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
@@ -48,7 +48,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	@Test
 	public void unaryFunction() {
 		// Look up a function type safe
-		Function<Double, Double> sqrtFunction = ops.findOp( //
+		Function<Double, Double> sqrtFunction = ops.op( //
 				"math.sqrt", new Nil<Function<Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble }, //
@@ -61,7 +61,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	@Test
 	public void binaryFunction() {
 		// look up a function: Double result = math.add(Double v1, Double v2)
-		BiFunction<Double, Double, Double> addFunction = ops.findOp( //
+		BiFunction<Double, Double, Double> addFunction = ops.op( //
 				"math.add", new Nil<BiFunction<Double, Double, Double>>() {
 				}, //
 				new Nil[] { nilDouble, nilDouble }, //
@@ -72,7 +72,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void nullaryComputer() {
-		Computers.Arity0<double[]> sqrtComputer = ops.findOp( //
+		Computers.Arity0<double[]> sqrtComputer = ops.op( //
 				"math.zero", new Nil<Computers.Arity0<double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray }, //
@@ -85,7 +85,7 @@ public class OpsTest extends AbstractTestEnvironment {
 	
 	@Test
 	public void unaryComputer() {
-		Computers.Arity1<double[], double[]> sqrtComputer = ops.findOp( //
+		Computers.Arity1<double[], double[]> sqrtComputer = ops.op( //
 				"math.sqrt", new Nil<Computers.Arity1<double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //
@@ -98,7 +98,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void binaryComputer() {
-		Computers.Arity2<double[], double[], double[]> computer = ops.findOp( //
+		Computers.Arity2<double[], double[], double[]> computer = ops.op( //
 				"math.add", new Nil<Computers.Arity2<double[], double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray, nilDoubleArray }, //
@@ -113,7 +113,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void unaryInplace() {
-		Inplaces.Arity1<double[]> inplaceSqrt = ops.findOp( //
+		Inplaces.Arity1<double[]> inplaceSqrt = ops.op( //
 				"math.sqrt", new Nil<Inplaces.Arity1<double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray }, //
@@ -126,7 +126,7 @@ public class OpsTest extends AbstractTestEnvironment {
 
 	@Test
 	public void binaryInplace() {
-		Inplaces.Arity2_1<double[], double[]> inplaceAdd = ops.findOp( //
+		Inplaces.Arity2_1<double[], double[]> inplaceAdd = ops.op( //
 				"math.add", new Nil<Inplaces.Arity2_1<double[], double[]>>() {
 				}, //
 				new Nil[] { nilDoubleArray, nilDoubleArray }, //
@@ -146,7 +146,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		Exception error = null;
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.findOp( //
+//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
 //					"math.add", //
 //					new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -162,7 +162,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		// Generic typed BiFunction does not matches
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Double, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.findOp( //
+//			BiFunction<Double, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
 //					"math.add", //
 //					new Nil<BiFunction<Double, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -178,7 +178,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		// Output does not match
 //		try {
 //			@SuppressWarnings("unused")
-//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.findOp( //
+//			BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
 //					"math.add", //
 //					new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //					}, //
@@ -192,7 +192,7 @@ public class OpsTest extends AbstractTestEnvironment {
 //		error = null;
 //
 //		// We have a generic function which adds two iterables of numbers and gives an iterable of double
-//		BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.findOp( //
+//		BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>> addDoubleIters = ops.op( //
 //				"math.add", //
 //				new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
 //				}, //

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpsTest.java
@@ -39,10 +39,10 @@ import org.scijava.types.Nil;
 
 public class OpsTest extends AbstractTestEnvironment {
 
-	private static Nil<Double> nilDouble = new Nil<Double>() {
+	private static Nil<Double> nilDouble = new Nil<>() {
 	};
 
-	private static Nil<double[]> nilDoubleArray = new Nil<double[]>() {
+	private static Nil<double[]> nilDoubleArray = new Nil<>() {
 	};
 
 	@Test

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/OpAdaptationPriorityTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/OpAdaptationPriorityTest.java
@@ -95,7 +95,7 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testPriority() {
-		PriorityThing pThing = new OpBuilder(ops, "test.priorityOp").input(
+		PriorityThing pThing = ops.op("test.priorityOp").input(
 			new Double(10)).outType(PriorityThing.class).apply();
 		assertEquals(20, pThing.getPriority(), 0.);
 		// This would be the value of pThing if it were created using

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/complexLift/ComputerToFunctionIterablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/complexLift/ComputerToFunctionIterablesTest.java
@@ -58,7 +58,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer1ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {1., 2., 3. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -66,7 +66,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer2ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {2., 4., 6. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -74,7 +74,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer3ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {3., 6., 9. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -82,7 +82,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer4ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {4., 8., 12. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -90,7 +90,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer5ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {5., 10., 15. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -98,7 +98,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer6ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {6., 12., 18. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -106,7 +106,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer7ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {7., 14., 21. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -114,7 +114,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer8ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {8., 16., 24. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -122,7 +122,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer9ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {9., 18., 27. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -130,7 +130,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer10ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {10., 20., 30. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -138,7 +138,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer11ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {11., 22., 33. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -146,7 +146,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer12ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {12., 24., 36. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -154,7 +154,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer13ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {13., 26., 39. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -162,7 +162,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer14ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {14., 28., 42. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -170,7 +170,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer15ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {15., 30., 45. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 
@@ -178,7 +178,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer16ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] {16., 32., 48. });
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/complexLift/FunctionToComputerIterablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/complexLift/FunctionToComputerIterablesTest.java
@@ -48,7 +48,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction1ToComputer1() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in).output(output).compute();
+		ops.op("test.FtC").input(in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {2, 4}, output.get(0), 0);
 	}
 
@@ -56,7 +56,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction2ToComputer2() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {4, 8}, output.get(0), 0);
 	}
 
@@ -64,7 +64,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction3ToComputer3() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {6, 12}, output.get(0), 0);
 	}
 
@@ -72,7 +72,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction4ToComputer4() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {8, 16}, output.get(0), 0);
 	}
 
@@ -80,7 +80,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction5ToComputer5() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {10, 20}, output.get(0), 0);
 	}
 
@@ -88,7 +88,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction6ToComputer6() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {12, 24}, output.get(0), 0);
 	}
 
@@ -96,7 +96,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction7ToComputer7() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {14, 28}, output.get(0), 0);
 	}
 
@@ -104,7 +104,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction8ToComputer8() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {16, 32}, output.get(0), 0);
 	}
 
@@ -112,7 +112,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction9ToComputer9() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {18, 36}, output.get(0), 0);
 	}
 
@@ -120,7 +120,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction10ToComputer10() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {20, 40}, output.get(0), 0);
 	}
 
@@ -128,7 +128,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction11ToComputer11() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {22, 44}, output.get(0), 0);
 	}
 
@@ -136,7 +136,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction12ToComputer12() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {24, 48}, output.get(0), 0);
 	}
 
@@ -144,7 +144,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction13ToComputer13() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {26, 52}, output.get(0), 0);
 	}
 
@@ -152,7 +152,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction14ToComputer14() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {28, 56}, output.get(0), 0);
 	}
 
@@ -160,7 +160,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction15ToComputer15() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {30, 60}, output.get(0), 0);
 	}
 
@@ -168,7 +168,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction16ToComputer16() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {32, 64}, output.get(0), 0);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/ComputerToFunctionAdaptTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/ComputerToFunctionAdaptTest.java
@@ -45,7 +45,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer1ToFunction1() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in).outType(double[].class).apply();
 		double[] expected = {2, 4}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -53,7 +53,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer2ToFunction2() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in).outType(double[].class).apply();
 		double[] expected = {4, 8}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -61,7 +61,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer3ToFunction3() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in).outType(double[].class).apply();
 		double[] expected = {6, 12}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -69,7 +69,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer4ToFunction4() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in).outType(double[].class).apply();
 		double[] expected = {8, 16}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -77,7 +77,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer5ToFunction5() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {10, 20}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -85,7 +85,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer6ToFunction6() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {12, 24}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -93,7 +93,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer7ToFunction7() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {14, 28}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -101,7 +101,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer8ToFunction8() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {16, 32}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -109,7 +109,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer9ToFunction9() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {18, 36}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -117,7 +117,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer10ToFunction10() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {20, 40}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -125,7 +125,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer11ToFunction11() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {22, 44}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -133,7 +133,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer12ToFunction12() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {24, 48}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -141,7 +141,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer13ToFunction13() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {26, 52}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -149,7 +149,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer14ToFunction14() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {28, 56}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -157,7 +157,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer15ToFunction15() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {30, 60}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}
@@ -165,7 +165,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer16ToFunction16() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).outType(double[].class).apply();
 		double[] expected = {32, 64}; 
 		Assert.assertArrayEquals(expected, output, 0);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/FunctionToComputerAdaptTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/FunctionToComputerAdaptTest.java
@@ -45,7 +45,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction1ToComputer1() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in).output(output).compute();
+		ops.op("test.FtC").input(in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {2, 4}, output, 0);
 	}
 
@@ -53,7 +53,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction2ToComputer2() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {4, 8}, output, 0);
 	}
 
@@ -61,7 +61,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction3ToComputer3() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {6, 12}, output, 0);
 	}
 
@@ -69,7 +69,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction4ToComputer4() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {8, 16}, output, 0);
 	}
 
@@ -77,7 +77,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction5ToComputer5() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {10, 20}, output, 0);
 	}
 
@@ -85,7 +85,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction6ToComputer6() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {12, 24}, output, 0);
 	}
 
@@ -93,7 +93,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction7ToComputer7() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {14, 28}, output, 0);
 	}
 
@@ -101,7 +101,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction8ToComputer8() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {16, 32}, output, 0);
 	}
 
@@ -109,7 +109,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction9ToComputer9() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {18, 36}, output, 0);
 	}
 
@@ -117,7 +117,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction10ToComputer10() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {20, 40}, output, 0);
 	}
 
@@ -125,7 +125,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction11ToComputer11() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {22, 44}, output, 0);
 	}
 
@@ -133,7 +133,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction12ToComputer12() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {24, 48}, output, 0);
 	}
 
@@ -141,7 +141,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction13ToComputer13() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {26, 52}, output, 0);
 	}
 
@@ -149,7 +149,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction14ToComputer14() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {28, 56}, output, 0);
 	}
 
@@ -157,7 +157,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction15ToComputer15() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {30, 60}, output, 0);
 	}
 
@@ -165,7 +165,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction16ToComputer16() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
+		ops.op("test.FtC").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).output(output).compute();
 		Assert.assertArrayEquals(new double[] {32, 64}, output, 0);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/InplaceToFunctionAdaptTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/functional/InplaceToFunctionAdaptTest.java
@@ -3038,6 +3038,6 @@ public class InplaceToFunctionAdaptTest extends AbstractTestEnvironment {
 	}
 
 	private OpBuilder name(String opName) {
-		return new OpBuilder(ops, opName);
+		return ops.op(opName);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/lift/ComputerToIterablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/lift/ComputerToIterablesTest.java
@@ -58,7 +58,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 1., 2., 3. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -70,7 +70,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 2., 4., 6. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -82,7 +82,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 3., 6., 9. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -94,7 +94,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 4., 8., 12. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -106,7 +106,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 5., 10., 15. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -118,7 +118,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 6., 12., 18. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -130,7 +130,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 7., 14., 21. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -142,7 +142,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 8., 16., 24. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -154,7 +154,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 9., 18., 27. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -166,7 +166,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 10., 20., 30. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -178,7 +178,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 11., 22., 33. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -190,7 +190,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 12., 24., 36. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -202,7 +202,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 13., 26., 39. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -214,7 +214,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 14., 28., 42. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -226,7 +226,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 15., 30., 45. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());
@@ -238,7 +238,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] { 16., 32., 48. });
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/lift/FunctionToIterablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/lift/FunctionToIterablesTest.java
@@ -55,7 +55,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction1ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(1., 2., 3.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -66,7 +66,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction2ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(2., 4., 6.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -77,7 +77,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction3ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(3., 6., 9.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -88,7 +88,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction4ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(4., 8., 12.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -99,7 +99,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction5ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(5., 10., 15.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -110,7 +110,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction6ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(6., 12., 18.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -121,7 +121,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction7ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(7., 14., 21.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -132,7 +132,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction8ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(8., 16., 24.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -143,7 +143,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction9ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(9., 18., 27.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -154,7 +154,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction10ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(10., 20., 30.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -165,7 +165,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction11ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(11., 22., 33.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -176,7 +176,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction12ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(12., 24., 36.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -187,7 +187,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction13ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(13., 26., 39.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -198,7 +198,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction14ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(14., 28., 42.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -209,7 +209,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction15ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(15., 30., 45.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();
@@ -220,7 +220,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction16ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = Arrays.asList(16., 32., 48.);
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderTest.java
@@ -12374,6 +12374,6 @@ public class OpBuilderTest extends AbstractTestEnvironment {
 	// -- Helper methods --
 
 	private OpBuilder name(String opName) {
-		return new OpBuilder(ops, opName);
+		return ops.op(opName);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/core/function/OpWrappersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/core/function/OpWrappersTest.java
@@ -30,7 +30,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	@Test
 	public void testWrapProducer() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
-		Producer<Double> op = Functions.match(ops, "test.addDoubles", nilDouble);
+		Producer<Double> op = Functions.match(ops.env(), "test.addDoubles", nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -38,7 +38,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction1() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Function<Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -47,7 +47,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction2() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		BiFunction<Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -56,7 +56,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction3() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity3<Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -65,7 +65,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction4() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity4<Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -74,7 +74,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction5() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity5<Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -83,7 +83,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction6() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity6<Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -92,7 +92,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction7() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity7<Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -101,7 +101,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction8() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity8<Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -110,7 +110,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction9() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity9<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -119,7 +119,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction10() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity10<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -128,7 +128,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction11() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity11<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -137,7 +137,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction12() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity12<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -146,7 +146,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction13() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity13<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -155,7 +155,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction14() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity14<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -164,7 +164,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction15() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity15<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -173,7 +173,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction16() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		Functions.Arity16<Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double, Double> op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -182,7 +182,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity1<double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -190,7 +190,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity2<double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -198,7 +198,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity3<double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -206,7 +206,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity4<double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -214,7 +214,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity5<double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -222,7 +222,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity6<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -230,7 +230,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity7<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -238,7 +238,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity8<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -246,7 +246,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -254,7 +254,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -262,7 +262,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -270,7 +270,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -278,7 +278,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer13() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity13<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -286,7 +286,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer14() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity14<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -294,7 +294,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer15() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity15<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -302,7 +302,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer16() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Computers.Arity16<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Computers.match(ops, "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Computers.match(ops.env(), "test.addArrays", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -310,7 +310,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity1<double[]> op = //
-			Inplaces.match(ops, "test.mulArrays1_1", nilDouble);
+			Inplaces.match(ops.env(), "test.mulArrays1_1", nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -318,7 +318,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace2_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity2_1<double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays2_1", nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays2_1", nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -326,7 +326,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace2_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity2_2<double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays2_2", nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays2_2", nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -334,7 +334,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace3_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity3_1<double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays3_1", nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays3_1", nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -342,7 +342,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace3_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity3_2<double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays3_2", nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays3_2", nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -350,7 +350,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace3_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity3_3<double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays3_3", nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays3_3", nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -358,7 +358,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace4_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity4_1<double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays4_1", nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays4_1", nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -366,7 +366,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace4_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity4_2<double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays4_2", nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays4_2", nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -374,7 +374,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace4_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity4_3<double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays4_3", nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays4_3", nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -382,7 +382,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace4_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity4_4<double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays4_4", nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays4_4", nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -390,7 +390,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace5_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity5_1<double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays5_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays5_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -398,7 +398,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace5_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity5_2<double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays5_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays5_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -406,7 +406,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace5_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity5_3<double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays5_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays5_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -414,7 +414,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace5_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity5_4<double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays5_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays5_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -422,7 +422,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace5_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity5_5<double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays5_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays5_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -430,7 +430,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_1<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays6_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays6_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -438,7 +438,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_2<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays6_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays6_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -446,7 +446,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_3<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays6_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays6_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -454,7 +454,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_4<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays6_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays6_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -462,7 +462,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_5<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays6_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays6_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -470,7 +470,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace6_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity6_6<double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays6_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays6_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -478,7 +478,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_1<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays7_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays7_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -486,7 +486,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_2<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays7_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays7_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -494,7 +494,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_3<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays7_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays7_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -502,7 +502,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_4<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays7_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays7_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -510,7 +510,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_5<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays7_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays7_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -518,7 +518,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_6<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays7_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays7_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -526,7 +526,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace7_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity7_7<double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays7_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays7_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -534,7 +534,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_1<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays8_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays8_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -542,7 +542,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_2<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays8_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays8_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -550,7 +550,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_3<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays8_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays8_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -558,7 +558,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_4<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays8_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays8_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -566,7 +566,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_5<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays8_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays8_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -574,7 +574,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_6<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays8_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays8_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -582,7 +582,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_7<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays8_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays8_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -590,7 +590,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace8_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity8_8<double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays8_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays8_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -598,7 +598,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_1<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays9_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays9_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -606,7 +606,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_2<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays9_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays9_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -614,7 +614,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_3<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays9_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays9_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -622,7 +622,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_4<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays9_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays9_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -630,7 +630,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_5<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays9_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays9_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -638,7 +638,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_6<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays9_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays9_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -646,7 +646,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_7<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays9_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays9_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -654,7 +654,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_8<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays9_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays9_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -662,7 +662,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace9_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity9_9<double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays9_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays9_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -670,7 +670,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays10_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays10_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -678,7 +678,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays10_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays10_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -686,7 +686,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays10_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays10_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -694,7 +694,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays10_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays10_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -702,7 +702,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays10_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays10_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -710,7 +710,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays10_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays10_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -718,7 +718,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays10_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays10_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -726,7 +726,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays10_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays10_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -734,7 +734,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays10_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays10_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -742,7 +742,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace10_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity10_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays10_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays10_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -750,7 +750,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays11_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays11_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -758,7 +758,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays11_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays11_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -766,7 +766,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays11_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays11_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -774,7 +774,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays11_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays11_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -782,7 +782,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays11_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays11_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -790,7 +790,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays11_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays11_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -798,7 +798,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays11_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays11_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -806,7 +806,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays11_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays11_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -814,7 +814,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays11_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays11_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -822,7 +822,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays11_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays11_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -830,7 +830,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace11_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity11_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays11_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays11_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -838,7 +838,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays12_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays12_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -846,7 +846,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays12_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays12_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -854,7 +854,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays12_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays12_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -862,7 +862,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays12_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays12_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -870,7 +870,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays12_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays12_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -878,7 +878,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays12_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays12_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -886,7 +886,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays12_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays12_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -894,7 +894,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays12_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays12_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -902,7 +902,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays12_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays12_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -910,7 +910,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays12_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays12_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -918,7 +918,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays12_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays12_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -926,7 +926,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace12_12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity12_12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match12(ops, "test.mulArrays12_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match12(ops.env(), "test.mulArrays12_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -934,7 +934,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays13_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays13_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -942,7 +942,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays13_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays13_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -950,7 +950,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays13_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays13_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -958,7 +958,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays13_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays13_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -966,7 +966,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays13_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays13_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -974,7 +974,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays13_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays13_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -982,7 +982,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays13_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays13_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -990,7 +990,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays13_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays13_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -998,7 +998,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays13_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays13_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1006,7 +1006,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays13_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays13_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1014,7 +1014,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays13_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays13_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1022,7 +1022,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match12(ops, "test.mulArrays13_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match12(ops.env(), "test.mulArrays13_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1030,7 +1030,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace13_13() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity13_13<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match13(ops, "test.mulArrays13_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match13(ops.env(), "test.mulArrays13_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1038,7 +1038,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays14_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays14_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1046,7 +1046,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays14_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays14_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1054,7 +1054,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays14_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays14_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1062,7 +1062,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays14_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays14_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1070,7 +1070,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays14_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays14_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1078,7 +1078,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays14_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays14_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1086,7 +1086,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays14_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays14_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1094,7 +1094,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays14_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays14_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1102,7 +1102,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays14_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays14_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1110,7 +1110,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays14_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays14_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1118,7 +1118,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays14_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays14_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1126,7 +1126,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match12(ops, "test.mulArrays14_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match12(ops.env(), "test.mulArrays14_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1134,7 +1134,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_13() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_13<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match13(ops, "test.mulArrays14_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match13(ops.env(), "test.mulArrays14_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1142,7 +1142,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace14_14() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity14_14<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match14(ops, "test.mulArrays14_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match14(ops.env(), "test.mulArrays14_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1150,7 +1150,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays15_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays15_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1158,7 +1158,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays15_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays15_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1166,7 +1166,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays15_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays15_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1174,7 +1174,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays15_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays15_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1182,7 +1182,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays15_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays15_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1190,7 +1190,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays15_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays15_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1198,7 +1198,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays15_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays15_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1206,7 +1206,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays15_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays15_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1214,7 +1214,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays15_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays15_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1222,7 +1222,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays15_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays15_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1230,7 +1230,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays15_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays15_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1238,7 +1238,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match12(ops, "test.mulArrays15_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match12(ops.env(), "test.mulArrays15_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1246,7 +1246,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_13() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_13<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match13(ops, "test.mulArrays15_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match13(ops.env(), "test.mulArrays15_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1254,7 +1254,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_14() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_14<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match14(ops, "test.mulArrays15_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match14(ops.env(), "test.mulArrays15_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1262,7 +1262,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace15_15() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity15_15<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match15(ops, "test.mulArrays15_15", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match15(ops.env(), "test.mulArrays15_15", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1270,7 +1270,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_1() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_1<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match1(ops, "test.mulArrays16_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match1(ops.env(), "test.mulArrays16_1", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1278,7 +1278,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_2() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_2<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match2(ops, "test.mulArrays16_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match2(ops.env(), "test.mulArrays16_2", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1286,7 +1286,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_3() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_3<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match3(ops, "test.mulArrays16_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match3(ops.env(), "test.mulArrays16_3", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1294,7 +1294,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_4() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_4<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match4(ops, "test.mulArrays16_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match4(ops.env(), "test.mulArrays16_4", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1302,7 +1302,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_5() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_5<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match5(ops, "test.mulArrays16_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match5(ops.env(), "test.mulArrays16_5", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1310,7 +1310,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_6() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_6<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match6(ops, "test.mulArrays16_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match6(ops.env(), "test.mulArrays16_6", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1318,7 +1318,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_7() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_7<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match7(ops, "test.mulArrays16_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match7(ops.env(), "test.mulArrays16_7", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1326,7 +1326,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_8() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_8<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match8(ops, "test.mulArrays16_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match8(ops.env(), "test.mulArrays16_8", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1334,7 +1334,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_9() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_9<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match9(ops, "test.mulArrays16_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match9(ops.env(), "test.mulArrays16_9", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1342,7 +1342,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_10() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_10<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match10(ops, "test.mulArrays16_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match10(ops.env(), "test.mulArrays16_10", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1350,7 +1350,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_11() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_11<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match11(ops, "test.mulArrays16_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match11(ops.env(), "test.mulArrays16_11", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1358,7 +1358,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_12() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_12<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match12(ops, "test.mulArrays16_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match12(ops.env(), "test.mulArrays16_12", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1366,7 +1366,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_13() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_13<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match13(ops, "test.mulArrays16_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match13(ops.env(), "test.mulArrays16_13", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1374,7 +1374,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_14() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_14<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match14(ops, "test.mulArrays16_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match14(ops.env(), "test.mulArrays16_14", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1382,7 +1382,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_15() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_15<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match15(ops, "test.mulArrays16_15", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match15(ops.env(), "test.mulArrays16_15", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -1390,7 +1390,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace16_16() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		Inplaces.Arity16_16<double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[], double[]> op = //
-			Inplaces.match16(ops, "test.mulArrays16_16", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
+			Inplaces.match16(ops.env(), "test.mulArrays16_16", nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble, nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -75,7 +75,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Supplier<N>> y2 = new Nil<Supplier<N>>() {
 		};
-		Nil<Double> n1 = new Nil<Double>() {
+		Nil<Double> n1 = new Nil<>() {
 		};
 
 		assertAll(Single.class, true, y1, y2);
@@ -93,7 +93,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Supplier<Number>> y2 = new Nil<Supplier<Number>>() {
 		};
-		Nil<Double> n1 = new Nil<Double>() {
+		Nil<Double> n1 = new Nil<>() {
 		};
 
 		assertAll(Single.class, true, y1, y2);
@@ -107,7 +107,7 @@ public class MatchingUtilsTest {
 
 		Nil<Supplier<Double>> y1 = new Nil<Supplier<Double>>() {
 		};
-		Nil<Double> n1 = new Nil<Double>() {
+		Nil<Double> n1 = new Nil<>() {
 		};
 		Nil<String> n2 = new Nil<String>() {
 		};
@@ -121,7 +121,7 @@ public class MatchingUtilsTest {
 		abstract class SingleVarBoundedUsedNested<I extends Number> implements Supplier<List<I>> {
 		}
 
-		Nil<Double> n1 = new Nil<Double>() {
+		Nil<Double> n1 = new Nil<>() {
 		};
 		Nil<String> n2 = new Nil<String>() {
 		};
@@ -147,41 +147,41 @@ public class MatchingUtilsTest {
 				implements Function<List<I>, List<? extends Number>> {
 		}
 
-		Nil<Function<List<Double>, Double>> y1 = new Nil<Function<List<Double>, Double>>() {
+		Nil<Function<List<Double>, Double>> y1 = new Nil<>() {
 		};
-		Nil<Function<Double, Double>> n1 = new Nil<Function<Double, Double>>() {
+		Nil<Function<Double, Double>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Double>> n2 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> n2 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, String>> n3 = new Nil<Function<List<Double>, String>>() {
+		Nil<Function<List<Double>, String>> n3 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedUsedNestedAndOther.class, true, y1);
 		assertAll(SingleVarBoundedUsedNestedAndOther.class, false, n1, n2, n3);
 
-		Nil<Function<List<Double>, List<Double>>> y2 = new Nil<Function<List<Double>, List<Double>>>() {
+		Nil<Function<List<Double>, List<Double>>> y2 = new Nil<>() {
 		};
-		Nil<Function<Double, List<Double>>> n4 = new Nil<Function<Double, List<Double>>>() {
+		Nil<Function<Double, List<Double>>> n4 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Double>>> n5 = new Nil<Function<List<String>, List<Double>>>() {
 		};
-		Nil<Function<List<Double>, List<String>>> n6 = new Nil<Function<List<Double>, List<String>>>() {
+		Nil<Function<List<Double>, List<String>>> n6 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedUsedNestedAndOtherNested.class, true, y2);
 		assertAll(SingleVarBoundedUsedNestedAndOtherNested.class, false, n4, n5, n6);
 
-		Nil<Function<Double, List<Double>>> n7 = new Nil<Function<Double, List<Double>>>() {
+		Nil<Function<Double, List<Double>>> n7 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Double>>> n8 = new Nil<Function<List<String>, List<Double>>>() {
 		};
-		Nil<Function<List<Double>, List<String>>> n9 = new Nil<Function<List<Double>, List<String>>>() {
+		Nil<Function<List<Double>, List<String>>> n9 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Double>>> n10 = new Nil<Function<List<Double>, List<Double>>>() {
+		Nil<Function<List<Double>, List<Double>>> n10 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Integer>>> n11 = new Nil<Function<List<Double>, List<Integer>>>() {
+		Nil<Function<List<Double>, List<Integer>>> n11 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<? extends Number>>> y3 = new Nil<Function<List<Double>, List<? extends Number>>>() {
+		Nil<Function<List<Double>, List<? extends Number>>> y3 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedUsedNestedAndOtherNestedWildcard.class, false, n7, n8, n9, n10, n11);
@@ -196,33 +196,33 @@ public class MatchingUtilsTest {
 				implements Function<I, List<Double>> {
 		}
 
-		Nil<Function<List<String>, Double>> y1 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> y1 = new Nil<>() {
 		};
-		Nil<Function<Iterable<String>, Double>> y2 = new Nil<Function<Iterable<String>, Double>>() {
+		Nil<Function<Iterable<String>, Double>> y2 = new Nil<>() {
 		};
-		Nil<Function<Double, Double>> n1 = new Nil<Function<Double, Double>>() {
+		Nil<Function<Double, Double>> n1 = new Nil<>() {
 		};
 		Nil<Function<List<String>, String>> n2 = new Nil<Function<List<String>, String>>() {
 		};
-		Nil<Function<Iterable<Double>, Double>> n3 = new Nil<Function<Iterable<Double>, Double>>() {
+		Nil<Function<Iterable<Double>, Double>> n3 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedNestedAndOther.class, true, y1, y2);
 		assertAll(SingleVarBoundedNestedAndOther.class, false, n1, n2, n3);
 
-		Nil<Function<List<Integer>, List<Double>>> y3 = new Nil<Function<List<Integer>, List<Double>>>() {
+		Nil<Function<List<Integer>, List<Double>>> y3 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Double>>> y4 = new Nil<Function<List<Double>, List<Double>>>() {
+		Nil<Function<List<Double>, List<Double>>> y4 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, List<Double>>> y5 = new Nil<Function<Iterable<Double>, List<Double>>>() {
+		Nil<Function<Iterable<Double>, List<Double>>> y5 = new Nil<>() {
 		};
-		Nil<Function<List<Integer>, Double>> n4 = new Nil<Function<List<Integer>, Double>>() {
+		Nil<Function<List<Integer>, Double>> n4 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Integer>>> n5 = new Nil<Function<List<Double>, List<Integer>>>() {
+		Nil<Function<List<Double>, List<Integer>>> n5 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, Iterable<Double>>> n6 = new Nil<Function<Iterable<Double>, Iterable<Double>>>() {
+		Nil<Function<Iterable<Double>, Iterable<Double>>> n6 = new Nil<>() {
 		};
-		Nil<Function<Integer, List<Double>>> n7 = new Nil<Function<Integer, List<Double>>>() {
+		Nil<Function<Integer, List<Double>>> n7 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Double>>> n8 = new Nil<Function<List<String>, List<Double>>>() {
 		};
@@ -246,7 +246,7 @@ public class MatchingUtilsTest {
 
 		Nil<Function<List<String>, List<String>>> y1 = new Nil<Function<List<String>, List<String>>>() {
 		};
-		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<Function<Iterable<String>, Iterable<String>>>() {
+		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<Function<List<String>, List<Integer>>>() {
 		};
@@ -256,11 +256,11 @@ public class MatchingUtilsTest {
 		assertAll(SingleVarBoundedNestedMultipleOccurence.class, true, y1, y2);
 		assertAll(SingleVarBoundedNestedMultipleOccurence.class, false, n1, n2);
 
-		Nil<Function<List<Double>, List<Double>>> y3 = new Nil<Function<List<Double>, List<Double>>>() {
+		Nil<Function<List<Double>, List<Double>>> y3 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, Iterable<Double>>> y4 = new Nil<Function<Iterable<Double>, Iterable<Double>>>() {
+		Nil<Function<Iterable<Double>, Iterable<Double>>> y4 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, Iterable<Integer>>> n3 = new Nil<Function<Iterable<Double>, Iterable<Integer>>>() {
+		Nil<Function<Iterable<Double>, Iterable<Integer>>> n3 = new Nil<>() {
 		};
 		Nil<Function<List<String>, Integer>> n4 = new Nil<Function<List<String>, Integer>>() {
 		};
@@ -268,9 +268,9 @@ public class MatchingUtilsTest {
 		assertAll(SingleVarBoundedNestedWildcardMultipleOccurence.class, true, y3, y4);
 		assertAll(SingleVarBoundedNestedWildcardMultipleOccurence.class, false, n3, n4);
 
-		Nil<Function<List<Double>, Iterable<List<Double>>>> n5 = new Nil<Function<List<Double>, Iterable<List<Double>>>>() {
+		Nil<Function<List<Double>, Iterable<List<Double>>>> n5 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, List<Iterable<Double>>>> y5 = new Nil<Function<Iterable<Double>, List<Iterable<Double>>>>() {
+		Nil<Function<Iterable<Double>, List<Iterable<Double>>>> y5 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedNestedWildcardMultipleOccurenceUsedNested.class, true, y5);
@@ -278,7 +278,7 @@ public class MatchingUtilsTest {
 		
 		abstract class SingleVarMultipleOccurenceUsedNested<I> implements Function<I, List<I>> {}
 		
-		Nil<Function<Integer, List<Number>>> n6 = new Nil<Function<Integer,List<Number>>>() {
+		Nil<Function<Integer, List<Number>>> n6 = new Nil<>() {
 		};
 		assertAll(SingleVarMultipleOccurenceUsedNested.class, false, n6);
 	}
@@ -293,7 +293,7 @@ public class MatchingUtilsTest {
 
 		Nil<Function<List<String>, List<String>>> y1 = new Nil<Function<List<String>, List<String>>>() {
 		};
-		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<Function<Iterable<String>, Iterable<String>>>() {
+		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Integer>>> y3 = new Nil<Function<List<String>, List<Integer>>>() {
 		};
@@ -306,9 +306,9 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<List<String>, Float>> y6 = new Nil<Function<List<String>, Float>>() {
 		};
-		Nil<Function<Iterable<String>, Double>> n1 = new Nil<Function<Iterable<String>, Double>>() {
+		Nil<Function<Iterable<String>, Double>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, Integer>> n2 = new Nil<Function<List<Double>, Integer>>() {
+		Nil<Function<List<Double>, Integer>> n2 = new Nil<>() {
 		};
 		Nil<Function<List<String>, String>> n3 = new Nil<Function<List<String>, String>>() {
 		};
@@ -325,37 +325,37 @@ public class MatchingUtilsTest {
 		abstract class IBoundedByN<N extends Number, I extends Iterable<N>> implements BiFunction<I, I, N> {
 		}
 
-		Nil<Function<List<Integer>, List<Integer>>> y1 = new Nil<Function<List<Integer>, List<Integer>>>() {
+		Nil<Function<List<Integer>, List<Integer>>> y1 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Integer>, List<Integer>>> y2 = new Nil<Function<Iterable<Integer>, List<Integer>>>() {
+		Nil<Function<Iterable<Integer>, List<Integer>>> y2 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Integer>, Iterable<Integer>>> y3 = new Nil<Function<Iterable<Integer>, Iterable<Integer>>>() {
+		Nil<Function<Iterable<Integer>, Iterable<Integer>>> y3 = new Nil<>() {
 		};
 		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<Function<List<String>, List<Integer>>>() {
 		};
 		Nil<Function<List<String>, Double>> n2 = new Nil<Function<List<String>, Double>>() {
 		};
-		Nil<Function<List<Integer>, List<Double>>> n3 = new Nil<Function<List<Integer>, List<Double>>>() {
+		Nil<Function<List<Integer>, List<Double>>> n3 = new Nil<>() {
 		};
-		Nil<Function<Integer, List<Integer>>> n4 = new Nil<Function<Integer, List<Integer>>>() {
+		Nil<Function<Integer, List<Integer>>> n4 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Integer>, Integer>> n5 = new Nil<Function<Iterable<Integer>, Integer>>() {
+		Nil<Function<Iterable<Integer>, Integer>> n5 = new Nil<>() {
 		};
 		
 		assertAll(BExtendsI.class, true, y1, y2, y3);
 		assertAll(BExtendsI.class, false, n1, n2, n3, n4, n5);
 
-		Nil<BiFunction<List<Integer>, List<Integer>, Integer>> y4 = new Nil<BiFunction<List<Integer>, List<Integer>, Integer>>() {
+		Nil<BiFunction<List<Integer>, List<Integer>, Integer>> y4 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<Integer>, Iterable<Integer>, Integer>> y5 = new Nil<BiFunction<Iterable<Integer>, Iterable<Integer>, Integer>>() {
+		Nil<BiFunction<Iterable<Integer>, Iterable<Integer>, Integer>> y5 = new Nil<>() {
 		};
-		Nil<BiFunction<List<Integer>, List<Integer>, Double>> n6 = new Nil<BiFunction<List<Integer>, List<Integer>, Double>>() {
+		Nil<BiFunction<List<Integer>, List<Integer>, Double>> n6 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<Double>, Iterable<Integer>, Integer>> n7 = new Nil<BiFunction<Iterable<Double>, Iterable<Integer>, Integer>>() {
+		Nil<BiFunction<Iterable<Double>, Iterable<Integer>, Integer>> n7 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<Integer>, List<Integer>, Integer>> n8 = new Nil<BiFunction<Iterable<Integer>, List<Integer>, Integer>>() {
+		Nil<BiFunction<Iterable<Integer>, List<Integer>, Integer>> n8 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<String>, List<String>, String>> n9 = new Nil<BiFunction<Iterable<String>, List<String>, String>>() {
+		Nil<BiFunction<Iterable<String>, List<String>, String>> n9 = new Nil<>() {
 		};
 
 		assertAll(IBoundedByN.class, true, y4, y5);
@@ -368,7 +368,7 @@ public class MatchingUtilsTest {
 				implements BiFunction<I, I, List<String>> {
 		}
 
-		Nil<BiFunction<Iterable<Double>, Iterable<Double>, List<String>>> y1 = new Nil<BiFunction<Iterable<Double>, Iterable<Double>, List<String>>>() {
+		Nil<BiFunction<Iterable<Double>, Iterable<Double>, List<String>>> y1 = new Nil<>() {
 		};
 		
 		assertAll(IBoundedByNImplicitely.class, true, y1);
@@ -380,21 +380,21 @@ public class MatchingUtilsTest {
 				implements BiFunction<I, I, Iterable<M>> {
 		}
 
-		Nil<BiFunction<Iterable<Double>, Double, Iterable<Double>>> n1 = new Nil<BiFunction<Iterable<Double>, Double, Iterable<Double>>>() {
+		Nil<BiFunction<Iterable<Double>, Double, Iterable<Double>>> n1 = new Nil<>() {
 		};
-		Nil<BiFunction<Double, Iterable<Double>, Iterable<Double>>> n2 = new Nil<BiFunction<Double, Iterable<Double>, Iterable<Double>>>() {
+		Nil<BiFunction<Double, Iterable<Double>, Iterable<Double>>> n2 = new Nil<>() {
 		};
-		Nil<BiFunction<List<Float>, List<Number>, Iterable<Double>>> n3 = new Nil<BiFunction<List<Float>, List<Number>, Iterable<Double>>>() {
+		Nil<BiFunction<List<Float>, List<Number>, Iterable<Double>>> n3 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<Double>, List<Double>, Iterable<Double>>> n4 = new Nil<BiFunction<Iterable<Double>, List<Double>, Iterable<Double>>>() {
+		Nil<BiFunction<Iterable<Double>, List<Double>, Iterable<Double>>> n4 = new Nil<>() {
 		};
-		Nil<BiFunction<List<Double>, List<Double>, List<Double>>> n5 = new Nil<BiFunction<List<Double>, List<Double>, List<Double>>>() {
+		Nil<BiFunction<List<Double>, List<Double>, List<Double>>> n5 = new Nil<>() {
 		};
-		Nil<BiFunction<List<Integer>, List<Double>, Iterable<Double>>> n6 = new Nil<BiFunction<List<Integer>, List<Double>, Iterable<Double>>>() {
+		Nil<BiFunction<List<Integer>, List<Double>, Iterable<Double>>> n6 = new Nil<>() {
 		};
-		Nil<BiFunction<List<Double>, List<Double>, Iterable<Double>>> y1 = new Nil<BiFunction<List<Double>, List<Double>, Iterable<Double>>>() {
+		Nil<BiFunction<List<Double>, List<Double>, Iterable<Double>>> y1 = new Nil<>() {
 		};
-		Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>> y2 = new Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>>() {
+		Nil<BiFunction<Iterable<Double>, Iterable<Double>, Iterable<Double>>> y2 = new Nil<>() {
 		};
 
 		assertAll(DoubleVarBoundedAndWildcard.class, true, y1, y2);
@@ -406,15 +406,15 @@ public class MatchingUtilsTest {
 		abstract class Wildcards implements Function<List<? extends Number>, List<? extends Number>> {
 		}
 
-		Nil<Function<List<? extends Number>, List<? extends Number>>> y1 = new Nil<Function<List<? extends Number>, List<? extends Number>>>() {
+		Nil<Function<List<? extends Number>, List<? extends Number>>> y1 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Integer>, Iterable<Double>>> n1 = new Nil<Function<Iterable<Integer>, Iterable<Double>>>() {
+		Nil<Function<Iterable<Integer>, Iterable<Double>>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Integer>>> n2 = new Nil<Function<List<Double>, List<Integer>>>() {
+		Nil<Function<List<Double>, List<Integer>>> n2 = new Nil<>() {
 		};
-		Nil<Function<List<Double>, List<Double>>> n3 = new Nil<Function<List<Double>, List<Double>>>() {
+		Nil<Function<List<Double>, List<Double>>> n3 = new Nil<>() {
 		};
-		Nil<Function<Iterable<Double>, Iterable<Double>>> n4 = new Nil<Function<Iterable<Double>, Iterable<Double>>>() {
+		Nil<Function<Iterable<Double>, Iterable<Double>>> n4 = new Nil<>() {
 		};
 
 		assertAll(Wildcards.class, true, y1);

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
@@ -31,10 +31,10 @@ public class MatchingWithAnyTest extends AbstractTestEnvironment {
 	public void testAny() {
 
 		NestedThing<String, Thing<String>> nthing = new NestedThing<>();
-		Double e = new OpBuilder(ops, "test.nestedAny").input(nthing).outType(Double.class).apply();
+		Double e = ops.op("test.nestedAny").input(nthing).outType(Double.class).apply();
 
 		Thing<Double> thing = new Thing<>();
-		Double d = new OpBuilder(ops, "test.any").input(thing).outType(Double.class).apply();
+		Double d = ops.op("test.any").input(thing).outType(Double.class).apply();
 
 		assert d == 5.;
 		assert e == 5.;
@@ -50,7 +50,7 @@ public class MatchingWithAnyTest extends AbstractTestEnvironment {
 	public void testExceptionalThing() {
 
 		ExceptionalThing<Double> ething = new ExceptionalThing<>(0.5);
-		Double d = new OpBuilder(ops, "test.exceptionalAny").input(ething).outType(Double.class).apply();
+		Double d = ops.op("test.exceptionalAny").input(ething).outType(Double.class).apply();
 
 	}
 
@@ -81,7 +81,7 @@ public class MatchingWithAnyTest extends AbstractTestEnvironment {
 	public void testRunAnyFunction1FromComputer2() {
 		final int in1 = 11;
 		final long in2 = 31;
-		final MutableNotAny out = new OpBuilder(ops, "test.integerAndLongAndNotAnyComputer").input(in1, in2).outType(MutableNotAny.class).apply();
+		final MutableNotAny out = ops.op("test.integerAndLongAndNotAnyComputer").input(in1, in2).outType(MutableNotAny.class).apply();
 		assertEquals(Long.toString(in1 + in2), out.getValue());
 	}
 	

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithGCSTTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithGCSTTest.java
@@ -69,7 +69,7 @@ public class MatchingWithGCSTTest extends AbstractTestEnvironment {
 		things.add(new YThing());
 		List<Double> actual = fooOP.apply(things);
 		// N.B. The type reifier reifies this list to a List<Thing>
-		List<Double> expected = new OpBuilder(ops, "test.listTypeReification").input(things)
+		List<Double> expected = ops.op("test.listTypeReification").input(things)
 				.outType(new Nil<List<Double>>() {}).apply();
 		assertEquals(actual, expected);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/monitor/OpMonitorTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/monitor/OpMonitorTest.java
@@ -32,7 +32,7 @@ public class OpMonitorTest extends AbstractTestEnvironment {
 	 */
 	@Test(expected = CancellationException.class)
 	public void testCancellation() {
-		Function<OpMonitor, BigInteger> bigOp = Functions.match(ops, "test.opMonitor", new Nil<OpMonitor>() {},
+		Function<OpMonitor, BigInteger> bigOp = Functions.match(ops.env(), "test.opMonitor", new Nil<OpMonitor>() {},
 				new Nil<BigInteger>() {});
 		OpMonitor monitor = new DefaultOpMonitor();
 		monitor.cancel();
@@ -49,7 +49,7 @@ public class OpMonitorTest extends AbstractTestEnvironment {
 	 */
 	@Test(expected = CancellationException.class)
 	public void testCancellationDifferentThread() throws InterruptedException {
-		Function<OpMonitor, BigInteger> bigOp = Functions.match(ops, "test.opMonitor", new Nil<OpMonitor>() {},
+		Function<OpMonitor, BigInteger> bigOp = Functions.match(ops.env(), "test.opMonitor", new Nil<OpMonitor>() {},
 				new Nil<BigInteger>() {});
 		OpMonitor monitor = new DefaultOpMonitor();
 		try {
@@ -65,7 +65,7 @@ public class OpMonitorTest extends AbstractTestEnvironment {
 	
 	@Test
 	public void testProgress() throws InterruptedException, ExecutionException{
-		BiFunction<OpMonitor, BigInteger, BigInteger> bigOp = Functions.match(ops, "test.progress", new Nil<OpMonitor>() {},
+		BiFunction<OpMonitor, BigInteger, BigInteger> bigOp = Functions.match(ops.env(), "test.progress", new Nil<OpMonitor>() {},
 				new Nil<BigInteger>() {}, new Nil<BigInteger>() {});
 		
 		OpMonitor monitor = new DefaultOpMonitor();

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/stats/MeanTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/stats/MeanTest.java
@@ -16,7 +16,7 @@ public class MeanTest <N extends Number> extends AbstractTestEnvironment{
 	@Test
 	public void regressionTest() {
 
-		Function<Iterable<Integer>, Double> goodFunc = Functions.match(ops, "stats.mean", new Nil<Iterable<Integer>>() {}, new Nil<Double>() {});
+		Function<Iterable<Integer>, Double> goodFunc = Functions.match(ops.env(), "stats.mean", new Nil<Iterable<Integer>>() {}, new Nil<Double>() {});
 
 		List<Integer> goodNums = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 		double expected = 5.5;

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/util/OpsAsParametersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/util/OpsAsParametersTest.java
@@ -46,7 +46,7 @@ public class OpsAsParametersTest extends AbstractTestEnvironment {
 		list.add(20.5);
 		list.add(4.0d);
 
-		List<Double> output = new OpBuilder(ops, "test.parameter.op").input(list, func).outType(new Nil<List<Double>>() {}).apply();
+		List<Double> output = ops.op("test.parameter.op").input(list, func).outType(new Nil<List<Double>>() {}).apply();
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class OpsAsParametersTest extends AbstractTestEnvironment {
 		list.add(20.5);
 		list.add(4.0d);
 
-		BiFunction<List<Number>, Function<Number, Double>, List<Double>> thing = Functions.match(ops,
+		BiFunction<List<Number>, Function<Number, Double>, List<Double>> thing = Functions.match(ops.env(),
 				"test.parameter.op", new Nil<List<Number>>() {
 				}, new Nil<Function<Number, Double>>() {
 				}, new Nil<List<Double>>() {
@@ -75,12 +75,12 @@ public class OpsAsParametersTest extends AbstractTestEnvironment {
 		list.add(20.5);
 		list.add(4.0d);
 
-		Function<Number, Double> funcClass = Functions.match(ops, "test.parameter.class", new Nil<Number>() {
+		Function<Number, Double> funcClass = Functions.match(ops.env(), "test.parameter.class", new Nil<Number>() {
 		}, new Nil<Double>() {
 		});
 
 		@SuppressWarnings("unused")
-		List<Double> output = new OpBuilder(ops, "test.parameter.op").input(list, funcClass).outType(new Nil<List<Double>>() {}).apply();
+		List<Double> output = ops.op("test.parameter.op").input(list, funcClass).outType(new Nil<List<Double>>() {}).apply();
 	}
 
 }

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/complexLift/ComputersToFunctionsAndLift.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/complexLift/ComputersToFunctionsAndLift.vm
@@ -71,7 +71,7 @@ package org.scijava.ops.adapt.complexLift;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.core.Priority;
+import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/complexLift/FunctionsToComputersAndLift.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/complexLift/FunctionsToComputersAndLift.vm
@@ -37,7 +37,7 @@ package org.scijava.ops.adapt.complexLift;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.core.Priority;
+import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/functional/ComputersToFunctionsViaSource.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/functional/ComputersToFunctionsViaSource.vm
@@ -37,7 +37,7 @@ package org.scijava.ops.adapt.functional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.core.Priority;
+import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/lift/FunctionToIterables.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/adapt/lift/FunctionToIterables.vm
@@ -87,11 +87,11 @@ public class FunctionToIterables$classGenerics.call($maxArity) {
 	static <E> Iterable<E> lazyIterable(final Function<Iterator<?>[], E> nexter,
 		final Iterable<?>... iterables)
 	{
-		return new Iterable<E>() {
+		return new Iterable<>() {
 
 			@Override
 			public Iterator<E> iterator() {
-				return new Iterator<E>() {
+				return new Iterator<>() {
 
 					private Iterator<?>[] iterators;
 					{

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
@@ -171,7 +171,7 @@ public class OpBuilder {
 						Object.class });
 				}
 			};
-			return ops.findOp(opName, specialType, new Nil<?>[0], Nil.of(
+			return ops.op(opName, specialType, new Nil<?>[0], Nil.of(
 				Object.class));
 		}
 
@@ -203,7 +203,7 @@ public class OpBuilder {
 						.getType() });
 				}
 			};
-			return ops.findOp(opName, specialType, new Nil<?>[0], outType);
+			return ops.op(opName, specialType, new Nil<?>[0], outType);
 		}
 
 		public Computers.Arity0<O> computer() {

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
@@ -163,7 +163,7 @@ public class OpBuilder {
 		}
 
 		public Producer<?> producer() {
-			final Nil<Producer<Object>> specialType = new Nil<Producer<Object>>() {
+			final Nil<Producer<Object>> specialType = new Nil<>() {
 
 				@Override
 				public Type getType() {
@@ -195,7 +195,7 @@ public class OpBuilder {
 		}
 
 		public Producer<O> producer() {
-			final Nil<Producer<O>> specialType = new Nil<Producer<O>>() {
+			final Nil<Producer<O>> specialType = new Nil<>() {
 
 				@Override
 				public Type getType() {

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/core/builder/OpBuilder.vm
@@ -38,7 +38,7 @@ import java.lang.reflect.Type;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Inplaces;
@@ -59,11 +59,11 @@ import org.scijava.types.Types;
  */
 public class OpBuilder {
 
-	private final OpService ops;
+	private final OpEnvironment env;
 	private final String opName;
 
-	public OpBuilder(final OpService ops, final String opName) {
-		this.ops = ops;
+	public OpBuilder(final OpEnvironment env, final String opName) {
+		this.env = env;
 		this.opName = opName;
 	}
 
@@ -96,7 +96,8 @@ public class OpBuilder {
 
 	@SuppressWarnings({ "unchecked" })
 	private <T> Nil<T> type(Object obj) {
-		return (Nil<T>) Nil.of(ops.context().service(TypeService.class).reify(obj));
+		// FIXME: This vacuous T and unsafe cast is wrong.
+		return (Nil<T>) Nil.of(env.genericType(obj));
 	}
 
 	private void checkComputerRefs(Object... objects) {
@@ -171,7 +172,7 @@ public class OpBuilder {
 						Object.class });
 				}
 			};
-			return ops.op(opName, specialType, new Nil<?>[0], Nil.of(
+			return env.op(opName, specialType, new Nil<?>[0], Nil.of(
 				Object.class));
 		}
 
@@ -203,11 +204,11 @@ public class OpBuilder {
 						.getType() });
 				}
 			};
-			return ops.op(opName, specialType, new Nil<?>[0], outType);
+			return env.op(opName, specialType, new Nil<?>[0], outType);
 		}
 
 		public Computers.Arity0<O> computer() {
-			return Computers.match(ops, opName, outType);
+			return Computers.match(env, opName, outType);
 		}
 
 		public O create() {
@@ -231,7 +232,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity0<O> computer() {
-			return Computers.match(ops, opName, type(out));
+			return Computers.match(env, opName, type(out));
 		}
 
 		public void compute() {
@@ -266,16 +267,16 @@ public class OpBuilder {
 		}
 
 		public $functionArity.call($arity)$generics.call($arity) function() {
-			return Functions.match(ops, opName, $inputTypesWithOutput.call($arity));
+			return Functions.match(env, opName, $inputTypesWithOutput.call($arity));
 		}
 
 		public Computers.Arity${arity}$generics.call($arity) computer() {
-			return Computers.match(ops, opName, $inputTypesWithOutput.call($arity));
+			return Computers.match(env, opName, $inputTypesWithOutput.call($arity));
 		}
 
 #foreach($a in [1..$arity])
 		public Inplaces.Arity$inplaceSuffix.call($arity, $a)$genericsWithoutOutput.call($arity) inplace${inplaceMatchNumber.call($arity, $a)}() {
-			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(ops, opName, $inputTypes.call($arity));
+			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(env, opName, $inputTypes.call($arity));
 		}
 
 #end
@@ -311,12 +312,12 @@ public class OpBuilder {
 		}
 
 		public $functionArity.call($arity)$genericsWildcardFunction.call($arity) function() {
-			return Functions.match(ops, opName, $inputTypes.call($arity), Nil.of(Object.class));
+			return Functions.match(env, opName, $inputTypes.call($arity), Nil.of(Object.class));
 		}
 
 #foreach($a in [1..$arity])
 		public Inplaces.Arity$inplaceSuffix.call($arity, $a)$genericsWithoutOutput.call($arity) inplace${inplaceMatchNumber.call($arity, $a)}() {
-			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(ops, opName, $inputTypes.call($arity));
+			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(env, opName, $inputTypes.call($arity));
 		}
 
 #end
@@ -347,11 +348,11 @@ public class OpBuilder {
 		}
 
 		public $functionArity.call($arity)$generics.call($arity) function() {
-			return Functions.match(ops, opName, $inputTypesFromArgs.call($arity), outType);
+			return Functions.match(env, opName, $inputTypesFromArgs.call($arity), outType);
 		}
 	
 		public Computers.Arity${arity}$generics.call($arity) computer() {
-			return Computers.match(ops, opName, $inputTypesFromArgs.call($arity), outType);
+			return Computers.match(env, opName, $inputTypesFromArgs.call($arity), outType);
 		}
 	
 		public O apply() {
@@ -394,13 +395,13 @@ public class OpBuilder {
 		}
 
 		public $functionArity.call($arity)$genericsWildcardFunction.call($arity) function() {
-			return Functions.match(ops, opName, $inputTypesFromArgs.call($arity), Nil.of(Object.class));
+			return Functions.match(env, opName, $inputTypesFromArgs.call($arity), Nil.of(Object.class));
 		}
 
 #foreach($a in [1..$arity])
 		public Inplaces.Arity$inplaceSuffix.call($arity, $a)$genericsWithoutOutput.call($arity) inplace${inplaceMatchNumber.call($arity, $a)}() {
 			checkInplaceRefs($a, $inputObjects.call($arity));
-			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(ops, opName, $inputTypesFromArgs.call($arity));
+			return Inplaces.match${inplaceMatchNumber.call($arity, $a)}(env, opName, $inputTypesFromArgs.call($arity));
 		}
 
 #end
@@ -440,7 +441,7 @@ public class OpBuilder {
 		}
 
 		public Computers.Arity${arity}${generics.call($arity)} computer() {
-			return Computers.match(ops, opName, $inputTypesFromArgs.call($arity), type(out));
+			return Computers.match(env, opName, $inputTypesFromArgs.call($arity), type(out));
 		}
 
 		public void compute() {

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.param.Mutable;
 import org.scijava.types.Types;
@@ -72,14 +72,14 @@ public final class Computers {
 
 #foreach($arity in [0..$maxArity])
 	@SuppressWarnings("unchecked")
-	public static $generics.call($arity) $computerArity.call($arity)$generics.call($arity) match(final OpService ops, final String opName, $matchParams.call($arity))
+	public static $generics.call($arity) $computerArity.call($arity)$generics.call($arity) match(final OpEnvironment env, final String opName, $matchParams.call($arity))
 	{
-		return matchHelper(ops, opName, ${computerArity.call($arity)}.class, $nilArgs.call($arity));
+		return matchHelper(env, opName, ${computerArity.call($arity)}.class, $nilArgs.call($arity));
 	}
 
 #end
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName, final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
+	private static <T> T matchHelper(final OpEnvironment env, final String opName, final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length + 1];
 		for (int i = 0; i < inTypes.length; i++)
@@ -89,7 +89,7 @@ public final class Computers {
 		final Nil<?>[] nils = new Nil[inTypes.length + 1];
 		System.arraycopy(inTypes, 0, nils, 0, inTypes.length);
 		nils[nils.length - 1] = outType;
-		return (T) ops.op(opName, Nil.of(specialType), nils, outType);
+		return (T) env.op(opName, Nil.of(specialType), nils, outType);
 	}
 
 	// -- END TEMP --

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
@@ -89,7 +89,7 @@ public final class Computers {
 		final Nil<?>[] nils = new Nil[inTypes.length + 1];
 		System.arraycopy(inTypes, 0, nils, 0, inTypes.length);
 		nils[nils.length - 1] = outType;
-		return (T) ops.findOp(opName, Nil.of(specialType), nils, outType);
+		return (T) ops.op(opName, Nil.of(specialType), nils, outType);
 	}
 
 	// -- END TEMP --

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Functions.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Functions.vm
@@ -103,7 +103,7 @@ public final class Functions {
 			types[i] = inTypes[i].getType();
 		types[types.length - 1] = outType.getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.findOp(opName, Nil.of(specialType), inTypes, outType);
+		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 #foreach($arity in $arities)

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Functions.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Functions.vm
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 
@@ -69,18 +69,18 @@ public final class Functions {
 
 #foreach($arity in [0..$maxArity])
 	@SuppressWarnings({ "unchecked" })
-	public static $generics.call($arity) $functionArity.call($arity)$generics.call($arity) match(final OpService ops, final String opName, $matchParams.call($arity))
+	public static $generics.call($arity) $functionArity.call($arity)$generics.call($arity) match(final OpEnvironment env, final String opName, $matchParams.call($arity))
 	{
-		return matchHelper(ops, opName, ${functionArity.call($arity)}.class, $nilArgs.call($arity));
+		return matchHelper(env, opName, ${functionArity.call($arity)}.class, $nilArgs.call($arity));
 	}
 
 #end
 
 	@SuppressWarnings({ "unchecked" })
-	public static <O, T> Functions.ArityN<O> matchN(final OpService ops,
+	public static <O, T> Functions.ArityN<O> matchN(final OpEnvironment env,
 		final String opName, final Nil<O> outType, final Nil<?>... inTypes)
 	{
-		Object op = matchHelper(ops, opName, ALL_FUNCTIONS.get(inTypes.length),
+		Object op = matchHelper(env, opName, ALL_FUNCTIONS.get(inTypes.length),
 			outType, inTypes);
 		if (op instanceof Producer) {
 			return new Arity0AsN<>((Producer<O>) op);
@@ -95,7 +95,7 @@ public final class Functions {
 	}
 
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName,
+	private static <T> T matchHelper(final OpEnvironment env, final String opName,
 		final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length + 1];
@@ -103,7 +103,7 @@ public final class Functions {
 			types[i] = inTypes[i].getType();
 		types[types.length - 1] = outType.getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
+		return (T) env.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 #foreach($arity in $arities)

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Inplaces.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Inplaces.vm
@@ -110,7 +110,7 @@ public final class Inplaces {
 		for (int i = 0; i < inTypes.length; i++)
 			types[i] = inTypes[i].getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.findOp(opName, Nil.of(specialType), inTypes, outType);
+		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	public static class InplaceInfo {

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Inplaces.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Inplaces.vm
@@ -15,7 +15,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.scijava.ops.OpService;
+import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
 import org.scijava.param.Mutable;
 import org.scijava.types.Types;
@@ -95,22 +95,22 @@ public final class Inplaces {
 #foreach($arity in $arities)
 #foreach($a in [1..$arity])
 	@SuppressWarnings({ "unchecked" })
-	public static $generics.call($arity, $a) $simplifiedInplace.call($arity, $a)$generics.call($arity, $a) $matchName.call($arity, $a)(final OpService ops, final String opName, $matchParams.call($arity, $a))
+	public static $generics.call($arity, $a) $simplifiedInplace.call($arity, $a)$generics.call($arity, $a) $matchName.call($arity, $a)(final OpEnvironment env, final String opName, $matchParams.call($arity, $a))
 	{
-		return matchHelper(ops, opName, ${simplifiedInplace.call($arity, $a)}.class, ioType, new Nil[] {${basicParams.call($arity, $a)}});
+		return matchHelper(env, opName, ${simplifiedInplace.call($arity, $a)}.class, ioType, new Nil[] {${basicParams.call($arity, $a)}});
 	}
 
 #end
 #end
 	@SuppressWarnings({ "unchecked" })
-	private static <T> T matchHelper(final OpService ops, final String opName,
+	private static <T> T matchHelper(final OpEnvironment env, final String opName,
 		final Class<T> opClass, final Nil<?> outType, final Nil<?>... inTypes)
 	{
 		final Type[] types = new Type[inTypes.length];
 		for (int i = 0; i < inTypes.length; i++)
 			types[i] = inTypes[i].getType();
 		final Type specialType = Types.parameterize(opClass, types);
-		return (T) ops.op(opName, Nil.of(specialType), inTypes, outType);
+		return (T) env.op(opName, Nil.of(specialType), inTypes, outType);
 	}
 
 	public static class InplaceInfo {

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/OpWrappers.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/OpWrappers.vm
@@ -9,7 +9,6 @@ import java.lang.reflect.Type;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.scijava.ops.matcher.OpInfo;
 import org.scijava.types.GenericTyped;
 import org.scijava.ops.util.OpWrapper;
 import org.scijava.param.Mutable;

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/complexLift/ComputerToFunctionIterablesTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/complexLift/ComputerToFunctionIterablesTest.vm
@@ -59,7 +59,7 @@ public class ComputerToFunctionIterablesTest extends AbstractTestEnvironment {
 	public void testComputer${arity}ToIterables() {
 		final List<double[]> in = Arrays.asList(new double[] { 1, 2, 3 });
 		final List<double[]> expected = Arrays.asList(new double[] $expectedList.call($arity));
-		final Iterable<double[]> out = new OpBuilder(ops, "test.addArrays").input($inputList.call($arity)).outType(new Nil<Iterable<double[]>>(){}).apply();
+		final Iterable<double[]> out = ops.op("test.addArrays").input($inputList.call($arity)).outType(new Nil<Iterable<double[]>>(){}).apply();
 		assertArrayEquals(out.iterator().next(), expected.get(0), 0);
 	}
 

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/complexLift/FunctionToComputerIterablesTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/complexLift/FunctionToComputerIterablesTest.vm
@@ -49,7 +49,7 @@ public class FunctionToComputerIterablesTest extends AbstractTestEnvironment {
 	public void testFunction${arity}ToComputer${arity}() {
 		List<double[]> in = Arrays.asList(new double[] { 2, 4 });
 		List<double[]> output = Arrays.asList(new double[] { 0, 0 });
-		new OpBuilder(ops, "test.FtC").input($inList.call($arity)).output(output).compute();
+		ops.op("test.FtC").input($inList.call($arity)).output(output).compute();
 		Assert.assertArrayEquals(new double[] $expectedValue.call($arity), output.get(0), 0);
 	}
 #end

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/ComputerToFunctionAdaptTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/ComputerToFunctionAdaptTest.vm
@@ -46,7 +46,7 @@ public class ComputerToFunctionAdaptTest extends AbstractTestEnvironment {
 	@Test
 	public void testComputer${arity}ToFunction${arity}() {
 		double[] in = {2, 4};
-		double[] output = new OpBuilder(ops, "test.CtF").input($inList.call($arity)).outType(double[].class).apply();
+		double[] output = ops.op("test.CtF").input($inList.call($arity)).outType(double[].class).apply();
 		double[] expected = $expectedValue.call($arity); 
 		Assert.assertArrayEquals(expected, output, 0);
 	}

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/FunctionToComputerAdaptTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/FunctionToComputerAdaptTest.vm
@@ -46,7 +46,7 @@ public class FunctionToComputerAdaptTest extends AbstractTestEnvironment {
 	public void testFunction${arity}ToComputer${arity}() {
 		double[] in = { 2, 4 };
 		double[] output = { 0, 0 };
-		new OpBuilder(ops, "test.FtC").input($inList.call($arity)).output(output).compute();
+		ops.op("test.FtC").input($inList.call($arity)).output(output).compute();
 		Assert.assertArrayEquals(new double[] $expectedValue.call($arity), output, 0);
 	}
 #end

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/InplaceToFunctionAdaptTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/functional/InplaceToFunctionAdaptTest.vm
@@ -64,6 +64,6 @@ public class InplaceToFunctionAdaptTest extends AbstractTestEnvironment {
 #end
 #end
 	private OpBuilder name(String opName) {
-		return new OpBuilder(ops, opName);
+		return ops.op(opName);
 	}
 }

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/lift/ComputerToIterablesTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/lift/ComputerToIterablesTest.vm
@@ -59,7 +59,7 @@ public class ComputerToIterablesTest extends AbstractTestEnvironment {
 		final List<double[]> out = Arrays.asList(new double[] { 0, 0, 0 });
 		final List<double[]> expected = //
 			Arrays.asList(new double[] $expectedList.call($arity));
-		new OpBuilder(ops, "test.addArrays") //
+		ops.op("test.addArrays") //
 			.input($inputList.call($arity)) //
 			.output(out).compute();
 		assertArrayEquals(out.toArray(), expected.toArray());

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/lift/FunctionToIterablesTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/adapt/lift/FunctionToIterablesTest.vm
@@ -56,7 +56,7 @@ public class FunctionToIterablesTest extends AbstractTestEnvironment {
 	public void testFunction${arity}ToIterables() {
 		List<Double> in = Arrays.asList(1., 2., 3.);
 		List<Double> expected = $inplaceExpectedList.call($arity)
-		Iterable<Double> output = new OpBuilder(ops, "test.addDoubles") //
+		Iterable<Double> output = ops.op("test.addDoubles") //
 			.input($inputList.call($arity)) //
 			.outType(new Nil<Iterable<Double>>()
 			{}).apply();

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/builder/OpBuilderTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/builder/OpBuilderTest.vm
@@ -348,6 +348,6 @@ public class OpBuilderTest extends AbstractTestEnvironment {
 	// -- Helper methods --
 
 	private OpBuilder name(String opName) {
-		return new OpBuilder(ops, opName);
+		return ops.op(opName);
 	}
 }

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/function/OpWrappersTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/function/OpWrappersTest.vm
@@ -30,7 +30,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	@Test
 	public void testWrapProducer() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
-		Producer<Double> op = Functions.match(ops, "test.addDoubles", nilDouble);
+		Producer<Double> op = Functions.match(ops.env(), "test.addDoubles", nilDouble);
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -39,7 +39,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapFunction$arity() {
 		Nil<Double> nilDouble = Nil.of(Double.class);
 		$functionArity.call($arity)$doubleTypeParams.call($arity) op = //
-			Functions.match(ops, "test.addDoubles", //
+			Functions.match(ops.env(), "test.addDoubles", //
 				$nilDoubleList.call($arity));
 		assertTrue(op instanceof GenericTyped);
 	}
@@ -50,7 +50,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapComputer$arity() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		$computerArity.call($arity)$doubleArrayTypeParams.call($arity) op = //
-			Computers.match(ops, "test.addArrays", $nilDoubleList.call($arity));
+			Computers.match(ops.env(), "test.addArrays", $nilDoubleList.call($arity));
 		assertTrue(op instanceof GenericTyped);
 	}
 
@@ -62,7 +62,7 @@ public class OpWrappersTest extends AbstractTestEnvironment {
 	public void testWrapInplace$inplaceSuffix.call($arity, $a)() {
 		Nil<double[]> nilDouble = Nil.of(double[].class);
 		$inplaceType.call($arity, $a)$doubleArrayTypeParams.call($t) op = //
-			Inplaces.$matchName.call($arity, $a)(ops, "test.mulArrays${arity}_${a}", $nilDoubleList.call($t));
+			Inplaces.$matchName.call($arity, $a)(ops.env(), "test.mulArrays${arity}_${a}", $nilDoubleList.call($t));
 		assertTrue(op instanceof GenericTyped);
 	}
 


### PR DESCRIPTION
This PR tidies up the `OpService` and extracts much of the behavior into `DefaultOpEnvironment` (with exposed API belonging in `OpEnvironment`. 

The PR also rewrites calls to the `OpService`/`OpEnvironment` to reflect the changes in these files.