### PR TITLE
Add Ops obtaining minimum and maximum value of RealTypes

### DIFF
--- a/imagej/imagej-ops2/src/main/java/module-info.java
+++ b/imagej/imagej-ops2/src/main/java/module-info.java
@@ -116,6 +116,8 @@ module net.imagej.ops2 {
 	opens net.imagej.ops2.transform to org.scijava, org.scijava.ops;
 	opens net.imagej.ops2.types to org.scijava, org.scijava.ops;
 	opens net.imagej.ops2.types.adapt to org.scijava, org.scijava.ops;
+	opens net.imagej.ops2.types.maxValue to org.scijava, org.scijava.ops;
+	opens net.imagej.ops2.types.minValue to org.scijava, org.scijava.ops;
 	
 	requires java.desktop;
 	requires java.scripting;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/types/maxValue/MaxValueRealTypes.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/types/maxValue/MaxValueRealTypes.java
@@ -1,0 +1,201 @@
+
+package net.imagej.ops2.types.maxValue;
+
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.scijava.ops.OpField;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This collection of Ops can be used to obtain the maximum value of any
+ * {@link RealType}. This method of determining the maximum value of a
+ * {@link RealType} is preferable since it is safe and extensible.
+ * 
+ * @author Gabriel Selzer
+ */
+@Plugin(type = OpCollection.class)
+public class MaxValueRealTypes {
+
+	final BitType maxBit = new BitType(true);
+
+	@OpField(names = "types.maxValue")
+	public final Function<BitType, BitType> maxBitType = in -> {
+		return maxBit;
+	};
+
+	final BoolType maxBool = new BoolType(true);
+
+	@OpField(names = "types.maxValue")
+	public final Function<BoolType, BoolType> maxBoolType = in -> {
+		return maxBool;
+	};
+
+	final NativeBoolType maxNativeBool = new NativeBoolType(true);
+
+	@OpField(names = "types.maxValue")
+	public final Function<NativeBoolType, NativeBoolType> maxNativeBoolType =
+		in -> {
+			return maxNativeBool;
+		};
+
+	final ByteType maxByte = new ByteType(Byte.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<ByteType, ByteType> maxByteType = in -> {
+		return maxByte;
+	};
+
+	final UnsignedByteType maxUnsignedByte = new UnsignedByteType(
+		-Byte.MIN_VALUE + Byte.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<UnsignedByteType, UnsignedByteType> maxUnsignedByteType =
+		in -> {
+			return maxUnsignedByte;
+		};
+
+	final IntType maxInt = new IntType(Integer.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<IntType, IntType> maxIntType = in -> {
+		return maxInt;
+	};
+
+	final UnsignedIntType maxUnsignedInt = new UnsignedIntType(0xffffffffL);
+
+	@OpField(names = "types.maxValue")
+	public final Function<UnsignedIntType, UnsignedIntType> maxUnsignedIntType =
+		in -> {
+			return maxUnsignedInt;
+		};
+
+	final LongType maxLong = new LongType(Long.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<LongType, LongType> maxLongType = in -> {
+		return maxLong;
+	};
+
+	final UnsignedLongType maxUnsignedLong = new UnsignedLongType(
+		new UnsignedLongType().getMaxBigIntegerValue());
+
+	@OpField(names = "types.maxValue")
+	public final Function<UnsignedLongType, UnsignedLongType> maxUnsignedLongType =
+		in -> {
+			return maxUnsignedLong;
+		};
+
+	final ShortType maxShort = new ShortType(Short.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<ShortType, ShortType> maxShortType = in -> {
+		return maxShort;
+	};
+
+	final UnsignedShortType maxUnsignedShort = new UnsignedShortType(
+		-Short.MIN_VALUE + Short.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<UnsignedShortType, UnsignedShortType> maxUnsignedShortType =
+		in -> {
+			return maxUnsignedShort;
+		};
+
+	final FloatType maxFloat = new FloatType(Float.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<FloatType, FloatType> maxFloatType = in -> {
+		return maxFloat;
+	};
+
+	final DoubleType maxDouble = new DoubleType(Double.MAX_VALUE);
+
+	@OpField(names = "types.maxValue")
+	public final Function<DoubleType, DoubleType> maxDoubleType = in -> {
+		return maxDouble;
+	};
+
+	final Unsigned2BitType max2Bit = new Unsigned2BitType(3);
+
+	@OpField(names = "types.maxValue")
+	public final Function<Unsigned2BitType, Unsigned2BitType> max2BitType =
+		in -> {
+			return max2Bit;
+		};
+
+	final Unsigned4BitType max4Bit = new Unsigned4BitType(15);
+
+	@OpField(names = "types.maxValue")
+	public final Function<Unsigned4BitType, Unsigned4BitType> max4BitType =
+		in -> {
+			return max4Bit;
+		};
+
+	final Unsigned12BitType max12Bit = new Unsigned12BitType(4095);
+
+	@OpField(names = "types.maxValue")
+	public final Function<Unsigned12BitType, Unsigned12BitType> max12BitType =
+		in -> {
+			return max12Bit;
+		};
+
+	final Unsigned128BitType max128Bit = new Unsigned128BitType(
+		new Unsigned128BitType().getMaxBigIntegerValue());
+
+	@OpField(names = "types.maxValue")
+	public final Function<Unsigned128BitType, Unsigned128BitType> max128BitType =
+		in -> {
+			return max128Bit;
+		};
+
+	// TODO: UnboundedIntegerType
+
+	/**
+	 * Due to the variable length of this type, we cannot simply return some final
+	 * value. The best we can do is quickly compute the answer. Note that so long
+	 * as the bit length of the type is less than 64, we can losslessly compute
+	 * the maximum within long math. If it is 64 or larger, we must use BigInteger
+	 * (this should never happen in practice since {@link UnsignedLongType} is
+	 * more efficient as a 64 bit type and bit lengths greater than 64 are
+	 * unsupported). TODO: Is there some way we could cache the values? Is that
+	 * worth it??
+	 */
+	@OpField(names = "types.maxValue")
+	public final Function<UnsignedVariableBitLengthType, UnsignedVariableBitLengthType> maxVarLengthType =
+		in -> {
+			int nBits = in.getBitsPerPixel();
+			if (nBits < 64) {
+				long maxVal = (1l << nBits) - 1;
+				return new UnsignedVariableBitLengthType(maxVal, nBits);
+			}
+			BigInteger maxVal = BigInteger.TWO.pow(nBits - 1).subtract(
+				BigInteger.ONE);
+			UnsignedVariableBitLengthType typeMax = new UnsignedVariableBitLengthType(
+				nBits);
+			typeMax.setBigInteger(maxVal);
+			return typeMax;
+		};
+
+}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/types/minValue/MinValueRealTypes.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/types/minValue/MinValueRealTypes.java
@@ -1,0 +1,183 @@
+
+package net.imagej.ops2.types.minValue;
+
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.scijava.ops.OpField;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This collection of Ops can be used to obtain the minimum value of any
+ * {@link RealType}. This method of determining the minimum value of a
+ * {@link RealType} is preferable since it is safe and extensible.
+ * 
+ * @author Gabriel Selzer
+ */
+@Plugin(type = OpCollection.class)
+public class MinValueRealTypes {
+
+	final BitType minBit = new BitType(false);
+
+	@OpField(names = "types.minValue")
+	public final Function<BitType, BitType> minBitType = in -> {
+		return minBit;
+	};
+
+	final BoolType minBool = new BoolType(false);
+
+	@OpField(names = "types.minValue")
+	public final Function<BoolType, BoolType> minBoolType = in -> {
+		return minBool;
+	};
+
+	final NativeBoolType minNativeBool = new NativeBoolType(false);
+
+	@OpField(names = "types.minValue")
+	public final Function<NativeBoolType, NativeBoolType> minNativeBoolType =
+		in -> {
+			return minNativeBool;
+		};
+
+	final ByteType minByte = new ByteType(Byte.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<ByteType, ByteType> minByteType = in -> {
+		return minByte;
+	};
+
+	final UnsignedByteType minUnsignedByte = new UnsignedByteType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<UnsignedByteType, UnsignedByteType> minUnsignedByteType =
+		in -> {
+			return minUnsignedByte;
+		};
+
+	final IntType minInt = new IntType(Integer.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<IntType, IntType> minIntType = in -> {
+		return minInt;
+	};
+
+	final UnsignedIntType minUnsignedInt = new UnsignedIntType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<UnsignedIntType, UnsignedIntType> minUnsignedIntType =
+		in -> {
+			return minUnsignedInt;
+		};
+
+	final LongType minLong = new LongType(Long.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<LongType, LongType> minLongType = in -> {
+		return minLong;
+	};
+
+	final UnsignedLongType minUnsignedLong = new UnsignedLongType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<UnsignedLongType, UnsignedLongType> minUnsignedLongType =
+		in -> {
+			return minUnsignedLong;
+		};
+
+	final ShortType minShort = new ShortType(Short.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<ShortType, ShortType> minShortType = in -> {
+		return minShort;
+	};
+
+	final UnsignedShortType minUnsignedShort = new UnsignedShortType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<UnsignedShortType, UnsignedShortType> minUnsignedShortType =
+		in -> {
+			return minUnsignedShort;
+		};
+
+	final FloatType minFloat = new FloatType(Float.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<FloatType, FloatType> minFloatType = in -> {
+		return minFloat;
+	};
+
+	final DoubleType minDouble = new DoubleType(Double.MIN_VALUE);
+
+	@OpField(names = "types.minValue")
+	public final Function<DoubleType, DoubleType> minDoubleType = in -> {
+		return minDouble;
+	};
+
+	final Unsigned2BitType min2Bit = new Unsigned2BitType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<Unsigned2BitType, Unsigned2BitType> min2BitType =
+		in -> {
+			return min2Bit;
+		};
+
+	final Unsigned4BitType min4Bit = new Unsigned4BitType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<Unsigned4BitType, Unsigned4BitType> min4BitType =
+		in -> {
+			return min4Bit;
+		};
+
+	final Unsigned12BitType min12Bit = new Unsigned12BitType(0);
+
+	@OpField(names = "types.minValue")
+	public final Function<Unsigned12BitType, Unsigned12BitType> min12BitType =
+		in -> {
+			return min12Bit;
+		};
+
+	final Unsigned128BitType min128Bit = new Unsigned128BitType(BigInteger.ZERO);
+
+	@OpField(names = "types.minValue")
+	public final Function<Unsigned128BitType, Unsigned128BitType> min128BitType =
+		in -> {
+			return min128Bit;
+		};
+
+	// TODO: UnboundedIntegerType
+
+	/**
+	 * Due to the variable length of this type, we cannot simply return some final
+	 * value. The best we can do is quickly compute the answer. TODO: Is there
+	 * some way we could cache the values? Is that worth it??
+	 */
+	@OpField(names = "types.minValue")
+	public final Function<UnsignedVariableBitLengthType, UnsignedVariableBitLengthType> minVarLengthType =
+		in -> {
+			int nBits = in.getBitsPerPixel();
+			return new UnsignedVariableBitLengthType(0l, nBits);
+		};
+
+}

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/maxValue/MaxValueRealTypesTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/maxValue/MaxValueRealTypesTest.java
@@ -1,0 +1,168 @@
+package net.imagej.ops2.types.maxValue;
+
+import net.imagej.ops2.AbstractOpTest;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression Tests for {@link MaxValueRealTypes} ops.
+ * 
+ * @author Gabriel Selzer
+ */
+public class MaxValueRealTypesTest extends AbstractOpTest{
+	
+	@Test
+	public void testMaxValueBitType() {
+		BitType maxValue = ops.op("types.maxValue").input(new BitType()).outType(BitType.class).apply();
+		BitType expected = new BitType(true);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+
+	@Test
+	public void testMaxValueBoolType() {
+		BoolType maxValue = ops.op("types.maxValue").input(new BoolType()).outType(BoolType.class).apply();
+		BoolType expected = new BoolType(true);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+
+	@Test
+	public void testMaxValueNativeBoolType() {
+		NativeBoolType maxValue = ops.op("types.maxValue").input(new NativeBoolType()).outType(NativeBoolType.class).apply();
+		NativeBoolType expected = new NativeBoolType(true);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueByteType() {
+		ByteType maxValue = ops.op("types.maxValue").input(new ByteType()).outType(ByteType.class).apply();
+		ByteType expected = new ByteType(Byte.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsignedByteType() {
+		UnsignedByteType maxValue = ops.op("types.maxValue").input(new UnsignedByteType()).outType(UnsignedByteType.class).apply();
+		UnsignedByteType expected = new UnsignedByteType(-Byte.MIN_VALUE + Byte.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueIntType() {
+		IntType maxValue = ops.op("types.maxValue").input(new IntType()).outType(IntType.class).apply();
+		IntType expected = new IntType(Integer.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsignedIntType() {
+		UnsignedIntType maxValue = ops.op("types.maxValue").input(new UnsignedIntType()).outType(UnsignedIntType.class).apply();
+		UnsignedIntType expected = new UnsignedIntType(0xffffffffL);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueLongType() {
+		LongType maxValue = ops.op("types.maxValue").input(new LongType()).outType(LongType.class).apply();
+		LongType expected = new LongType(Long.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsignedLongType() {
+		UnsignedLongType maxValue = ops.op("types.maxValue").input(new UnsignedLongType()).outType(UnsignedLongType.class).apply();
+		UnsignedLongType expected = new UnsignedLongType(new UnsignedLongType().getMaxBigIntegerValue());
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueShortType() {
+		ShortType maxValue = ops.op("types.maxValue").input(new ShortType()).outType(ShortType.class).apply();
+		ShortType expected = new ShortType(Short.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsignedShortType() {
+		UnsignedShortType maxValue = ops.op("types.maxValue").input(new UnsignedShortType()).outType(UnsignedShortType.class).apply();
+		UnsignedShortType expected = new UnsignedShortType(-Short.MIN_VALUE + Short.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsigned2BitType() {
+		Unsigned2BitType maxValue = ops.op("types.maxValue").input(new Unsigned2BitType()).outType(Unsigned2BitType.class).apply();
+		Unsigned2BitType expected = new Unsigned2BitType(3);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsigned4BitType() {
+		Unsigned4BitType maxValue = ops.op("types.maxValue").input(new Unsigned4BitType()).outType(Unsigned4BitType.class).apply();
+		Unsigned4BitType expected = new Unsigned4BitType(15);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsigned12BitType() {
+		Unsigned12BitType maxValue = ops.op("types.maxValue").input(new Unsigned12BitType()).outType(Unsigned12BitType.class).apply();
+		Unsigned12BitType expected = new Unsigned12BitType(4095);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsigned128BitType() {
+		Unsigned128BitType maxValue = ops.op("types.maxValue").input(new Unsigned128BitType()).outType(Unsigned128BitType.class).apply();
+		Unsigned128BitType expected = new Unsigned128BitType(new Unsigned128BitType().getMaxBigIntegerValue());
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueFloatType() {
+		FloatType maxValue = ops.op("types.maxValue").input(new FloatType()).outType(FloatType.class).apply();
+		FloatType expected = new FloatType(Float.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueDoubleType() {
+		DoubleType maxValue = ops.op("types.maxValue").input(new DoubleType()).outType(DoubleType.class).apply();
+		DoubleType expected = new DoubleType(Double.MAX_VALUE);
+		Assertions.assertTrue(maxValue.equals(expected));
+	}
+	
+	@Test
+	public void testMaxValueUnsignedVariableBitLengthType() {
+		// bit length of 5
+		UnsignedVariableBitLengthType maxValue5 = ops.op("types.maxValue").input(new UnsignedVariableBitLengthType(5)).outType(UnsignedVariableBitLengthType.class).apply();
+		UnsignedVariableBitLengthType expected5 = new UnsignedVariableBitLengthType(31, 5);
+		Assertions.assertTrue(maxValue5.equals(expected5));
+
+		// - Ensure different bitlength results in different maximum value - //
+		
+		// bit length of 17
+		UnsignedVariableBitLengthType maxValue17 = ops.op("types.maxValue").input(new UnsignedVariableBitLengthType(17)).outType(UnsignedVariableBitLengthType.class).apply();
+		UnsignedVariableBitLengthType expected17 = new UnsignedVariableBitLengthType(131071, 17);
+		Assertions.assertTrue(maxValue17.equals(expected17));
+	}
+
+}
+

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/minValue/MinValueRealTypesTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/types/minValue/MinValueRealTypesTest.java
@@ -1,0 +1,168 @@
+package net.imagej.ops2.types.minValue;
+
+import net.imagej.ops2.AbstractOpTest;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.logic.NativeBoolType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression Tests for {@link MinValueRealTypes} ops.
+ * 
+ * @author Gabriel Selzer
+ */
+public class MinValueRealTypesTest extends AbstractOpTest{
+	
+	@Test
+	public void testMinValueBitType() {
+		BitType minValue = ops.op("types.minValue").input(new BitType()).outType(BitType.class).apply();
+		BitType expected = new BitType(false);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+
+	@Test
+	public void testMinValueBoolType() {
+		BoolType minValue = ops.op("types.minValue").input(new BoolType()).outType(BoolType.class).apply();
+		BoolType expected = new BoolType(false);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+
+	@Test
+	public void testMinValueNativeBoolType() {
+		NativeBoolType minValue = ops.op("types.minValue").input(new NativeBoolType()).outType(NativeBoolType.class).apply();
+		NativeBoolType expected = new NativeBoolType(false);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueByteType() {
+		ByteType minValue = ops.op("types.minValue").input(new ByteType()).outType(ByteType.class).apply();
+		ByteType expected = new ByteType(Byte.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsignedByteType() {
+		UnsignedByteType minValue = ops.op("types.minValue").input(new UnsignedByteType()).outType(UnsignedByteType.class).apply();
+		UnsignedByteType expected = new UnsignedByteType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueIntType() {
+		IntType minValue = ops.op("types.minValue").input(new IntType()).outType(IntType.class).apply();
+		IntType expected = new IntType(Integer.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsignedIntType() {
+		UnsignedIntType minValue = ops.op("types.minValue").input(new UnsignedIntType()).outType(UnsignedIntType.class).apply();
+		UnsignedIntType expected = new UnsignedIntType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueLongType() {
+		LongType minValue = ops.op("types.minValue").input(new LongType()).outType(LongType.class).apply();
+		LongType expected = new LongType(Long.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsignedLongType() {
+		UnsignedLongType minValue = ops.op("types.minValue").input(new UnsignedLongType()).outType(UnsignedLongType.class).apply();
+		UnsignedLongType expected = new UnsignedLongType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueShortType() {
+		ShortType minValue = ops.op("types.minValue").input(new ShortType()).outType(ShortType.class).apply();
+		ShortType expected = new ShortType(Short.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsignedShortType() {
+		UnsignedShortType minValue = ops.op("types.minValue").input(new UnsignedShortType()).outType(UnsignedShortType.class).apply();
+		UnsignedShortType expected = new UnsignedShortType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsigned2BitType() {
+		Unsigned2BitType minValue = ops.op("types.minValue").input(new Unsigned2BitType()).outType(Unsigned2BitType.class).apply();
+		Unsigned2BitType expected = new Unsigned2BitType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsigned4BitType() {
+		Unsigned4BitType minValue = ops.op("types.minValue").input(new Unsigned4BitType()).outType(Unsigned4BitType.class).apply();
+		Unsigned4BitType expected = new Unsigned4BitType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsigned12BitType() {
+		Unsigned12BitType minValue = ops.op("types.minValue").input(new Unsigned12BitType()).outType(Unsigned12BitType.class).apply();
+		Unsigned12BitType expected = new Unsigned12BitType(0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsigned128BitType() {
+		Unsigned128BitType minValue = ops.op("types.minValue").input(new Unsigned128BitType()).outType(Unsigned128BitType.class).apply();
+		Unsigned128BitType expected = new Unsigned128BitType(0, 0);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueFloatType() {
+		FloatType minValue = ops.op("types.minValue").input(new FloatType()).outType(FloatType.class).apply();
+		FloatType expected = new FloatType(Float.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueDoubleType() {
+		DoubleType minValue = ops.op("types.minValue").input(new DoubleType()).outType(DoubleType.class).apply();
+		DoubleType expected = new DoubleType(Double.MIN_VALUE);
+		Assertions.assertTrue(minValue.equals(expected));
+	}
+	
+	@Test
+	public void testMinValueUnsignedVariableBitLengthType() {
+		// bit length of 5
+		UnsignedVariableBitLengthType minValue5 = ops.op("types.minValue").input(new UnsignedVariableBitLengthType(5)).outType(UnsignedVariableBitLengthType.class).apply();
+		UnsignedVariableBitLengthType expected5 = new UnsignedVariableBitLengthType(0, 5);
+		Assertions.assertTrue(minValue5.equals(expected5));
+
+		// - Ensure different bitlength results in same minimum value - //
+		
+		// bit length of 17
+		UnsignedVariableBitLengthType minValue17 = ops.op("types.minValue").input(new UnsignedVariableBitLengthType(17)).outType(UnsignedVariableBitLengthType.class).apply();
+		UnsignedVariableBitLengthType expected17 = new UnsignedVariableBitLengthType(0, 17);
+		Assertions.assertTrue(minValue17.equals(expected17));
+	}
+
+}
+


### PR DESCRIPTION
This PR introduces a set of Ops, callable using the names `types.minValue` and `types.maxValue`, that, given some `RealType`, return the minimum or maximum value of that `RealType`. These ops return a `T`, not a `double`, which will allow for lossless operations for many Ops. The fact that we have elected to get the minimum and maximum values via Ops (instead of through, for example, the `RealType` API) allows this process to also be extensible.

I opted to make these Ops `Function`s over `Producer`s for uniformity; we need an input object specifically for `UnsignedVariableBitLengthType` (so we know how many bits there are in the type). I would prefer that all of these Ops be `Producer`s for simplicity, however the `Function` type will allow for more extensibility.

TODO:

* We need `Function`s specific to `UnboundedIntegerType`. This is a bit difficult, however, since `UnboundedIntegerType` is, of course, unbounded.