### PR TITLE
Multithread Ops2 Ops using LoopBuilder

### DIFF
--- a/imagej/imagej-ops2/pom.xml
+++ b/imagej/imagej-ops2/pom.xml
@@ -288,6 +288,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
+			<artifactId>scijava-testutil</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
 			<artifactId>scijava-types</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyRAI.java
@@ -30,6 +30,7 @@
 package net.imagej.ops2.copy;
 
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
@@ -52,13 +53,13 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "copy", itemIO = ItemIO.BOTH)
 public class CopyRAI<T> implements Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 
-	@OpDependency(name = "copy.type")
-	private Computers.Arity1<Iterable<T>, Iterable<T>> mapComputer;
+	@OpDependency(name = "copy")
+	private Computers.Arity1<T, T> mapComputer;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final RandomAccessibleInterval<T> output) {
 		if (!Intervals.equalDimensions(input, output))
 			throw new IllegalArgumentException("input and output must be of the same dimensionality!");
-		mapComputer.compute(Views.flatIterable(input), Views.flatIterable(output));
+		LoopBuilder.setImages(input, output).forEachPixel((in, out) -> mapComputer.compute(in, out));
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/AbstractHaralickFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/AbstractHaralickFeature.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.CooccurrenceMatrix2D;
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -45,18 +45,17 @@ import org.scijava.ops.function.Functions;
  * @param <T>
  */
 public abstract class AbstractHaralickFeature<T extends RealType<T>>
-		implements Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> {
+		implements Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> {
 
 	@OpDependency(name = "image.cooccurrenceMatrix")
-	private Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, double[][]> coocFunc;
+	private Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, double[][]> coocFunc;
 
 	/**
-	 * Creates {@link CooccurrenceMatrix2D} from {@link IterableInterval} on demand,
 	 * given the specified parameters. No caching!
 	 * 
 	 * @return the {@link CooccurrenceMatrix2D}
 	 */
-	protected double[][] getCooccurrenceMatrix(final IterableInterval<T> input, final Integer numGreyLevels,
+	protected double[][] getCooccurrenceMatrix(final RandomAccessibleInterval<T> input, final Integer numGreyLevels,
 			final Integer distance, final MatrixOrientation matrixOrientation) {
 		if (matrixOrientation.numDims() != input.numDimensions())
 			throw new IllegalArgumentException("MatrixOrientation must be of the same dimensions as the input!");

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultASM.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultASM.java
@@ -29,7 +29,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 public class DefaultASM<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		final int nrGrayLevels = matrix.length;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterPromenence.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterPromenence.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -63,7 +63,7 @@ public class DefaultClusterPromenence<T extends RealType<T>> extends AbstractHar
 	private Function<double[][], DoubleType> coocMeanYFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterShade.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterShade.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -62,7 +62,7 @@ public class DefaultClusterShade<T extends RealType<T>> extends AbstractHaralick
 	private Function<double[][], DoubleType> coocMeanYFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultContrast.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultContrast.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -61,7 +61,7 @@ public class DefaultContrast<T extends RealType<T>> extends AbstractHaralickFeat
 	private Function<double[][], double[]> coocPXMinusYFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		final double[] pxminusxy = coocPXMinusYFunc.apply(matrix);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultCorrelation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultCorrelation.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -70,7 +70,7 @@ public class DefaultCorrelation<T extends RealType<T>> extends
 	private Function<double[][], DoubleType> coocStdXFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceEntropy.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -64,7 +64,7 @@ public class DefaultDifferenceEntropy<T extends RealType<T>> extends AbstractHar
 	private Function<double[][], double[]> coocPXMinusYFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceVariance.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -63,7 +63,7 @@ public class DefaultDifferenceVariance<T extends RealType<T>> extends AbstractHa
 	private Function<double[][], double[]> coocPXMinusYFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		final double[] pxminusy = coocPXMinusYFunc.apply(matrix);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultEntropy.java
@@ -29,7 +29,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -59,7 +59,7 @@ public class DefaultEntropy<T extends RealType<T>> extends AbstractHaralickFeatu
 	private static final double EPSILON = Double.MIN_NORMAL;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		double res = 0;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM1.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM1.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -61,10 +61,10 @@ public class DefaultICM1<T extends RealType<T>> extends AbstractHaralickFeature<
 	@OpDependency(name = "features.haralick.coocHXY")
 	private Function<double[][], double[]> coocHXYFunc;
 	@OpDependency(name = "features.haralick.entropy")
-	private Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> entropy;
+	private Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> entropy;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM2.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM2.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -60,10 +60,10 @@ public class DefaultICM2<T extends RealType<T>> extends AbstractHaralickFeature<
 	@OpDependency(name = "features.haralick.coocHXY")
 	private Function<double[][], double[]> coocHXYFunc;
 	@OpDependency(name = "features.haralick.entropy")
-	private Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> entropy;
+	private Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, DoubleType> entropy;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultIFDM.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultIFDM.java
@@ -29,7 +29,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 public class DefaultIFDM<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultMaxProbability.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultMaxProbability.java
@@ -29,7 +29,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 public class DefaultMaxProbability<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumAverage.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumAverage.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -60,7 +60,7 @@ public class DefaultSumAverage<T extends RealType<T>> extends AbstractHaralickFe
 	private Function<double[][], double[]> coocPXPlusFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		final double[] pxplusy = coocPXPlusFunc.apply(matrix);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumEntropy.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -65,7 +65,7 @@ public class DefaultSumEntropy<T extends RealType<T>> extends
 	private Function<double[][], double[]> coocPXPlusFunc;
 	
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 		final double[] pxplusy = coocPXPlusFunc.apply(matrix);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumVariance.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.features.haralick;
 import java.util.function.Function;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -63,10 +63,10 @@ public class DefaultSumVariance<T extends RealType<T>> extends AbstractHaralickF
 	private Function<double[][], double[]> coocPXPlusYFunc;
 	@SuppressWarnings("rawtypes")
 	@OpDependency(name = "features.haralick.sumEntropy")
-	private Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, RealType> sumEntropyFunc;
+	private Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, RealType> sumEntropyFunc;
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultTextureHomogeneity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultTextureHomogeneity.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 public class DefaultTextureHomogeneity<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultVariance.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.features.haralick;
 
 import net.imagej.ops2.image.cooccurrenceMatrix.MatrixOrientation;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 public class DefaultVariance<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override
-	public DoubleType apply(final IterableInterval<T> input, final Integer numGreyLevels, final Integer distance,
+	public DoubleType apply(final RandomAccessibleInterval<T> input, final Integer numGreyLevels, final Integer distance,
 			final MatrixOrientation orientation) {
 		final double[][] matrix = getCooccurrenceMatrix(input, numGreyLevels, distance, orientation);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultCoarsenessFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultCoarsenessFeature.java
@@ -72,7 +72,7 @@ public class DefaultCoarsenessFeature<I extends RealType<I>, O extends RealType<
 
 	@OpDependency(name = "filter.mean")
 	private Computers.Arity3<RandomAccessibleInterval<I>, Shape, //
-			OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, IterableInterval<I>> meanOp;
+			OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, RandomAccessibleInterval<I>> meanOp;
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/max/DefaultMaxFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/max/DefaultMaxFilter.java
@@ -29,7 +29,7 @@
 
 package net.imagej.ops2.filter.max;
 
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -55,18 +55,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultMaxFilter<T, V> implements
-		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, IterableInterval<V>> {
+		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.max")
 	private Computers.Arity1<Iterable<T>, V> statsOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			final IterableInterval<V> output) {
+			final RandomAccessibleInterval<V> output) {
 		RandomAccessibleInterval<T> extended = outOfBoundsFactory == null ? input
 			: Views.interval((Views.extend(input, outOfBoundsFactory)), input);
 		mapper.compute(extended, inputNeighborhoodShape, statsOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/mean/DefaultMeanFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/mean/DefaultMeanFilter.java
@@ -55,18 +55,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultMeanFilter<T, V> implements
-		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, IterableInterval<V>> {
+		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.mean")
 	private Computers.Arity1<Iterable<T>, V> statsOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			final IterableInterval<V> output) {
+			final RandomAccessibleInterval<V> output) {
 		RandomAccessibleInterval<T> extended = outOfBoundsFactory == null ? input
 			: Views.interval((Views.extend(input, outOfBoundsFactory)), input);
 		mapper.compute(extended, inputNeighborhoodShape, statsOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/median/DefaultMedianFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/median/DefaultMedianFilter.java
@@ -29,7 +29,6 @@
 
 package net.imagej.ops2.filter.median;
 
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -55,18 +54,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultMedianFilter<T, V> implements
-		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, IterableInterval<V>> {
+		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.median")
 	private Computers.Arity1<Iterable<T>, V> statsOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			final IterableInterval<V> output) {
+			final RandomAccessibleInterval<V> output) {
 		RandomAccessibleInterval<T> extended = outOfBoundsFactory == null ? input
 			: Views.interval((Views.extend(input, outOfBoundsFactory)), input);
 		mapper.compute(extended, inputNeighborhoodShape, statsOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/min/DefaultMinFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/min/DefaultMinFilter.java
@@ -29,7 +29,6 @@
 
 package net.imagej.ops2.filter.min;
 
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -55,18 +54,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultMinFilter<T, V> implements
-		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, IterableInterval<V>> {
+		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.min")
 	private Computers.Arity1<Iterable<T>, V> statsOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			final IterableInterval<V> output) {
+			final RandomAccessibleInterval<V> output) {
 		RandomAccessibleInterval<T> extended = outOfBoundsFactory == null ? input
 			: Views.interval((Views.extend(input, outOfBoundsFactory)), input);
 		mapper.compute(extended, inputNeighborhoodShape, statsOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sigma/DefaultSigmaFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sigma/DefaultSigmaFilter.java
@@ -29,7 +29,6 @@
 
 package net.imagej.ops2.filter.sigma;
 
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -60,18 +59,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "minPixelFraction")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultSigmaFilter<T extends RealType<T>, V extends RealType<V>> implements
-		Computers.Arity5<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, Double, Double, IterableInterval<V>> {
+		Computers.Arity5<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, Double, Double, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.variance")
 	private Computers.Arity1<Iterable<T>, DoubleType> varianceOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity2<Iterable<T>, T, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity2<Iterable<T>, T, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory, final Double range,
-			final Double minPixelFraction, final IterableInterval<V> output) {
+			final Double minPixelFraction, final RandomAccessibleInterval<V> output) {
 		if (range <= 0)
 			throw new IllegalArgumentException("range must be positive!");
 		Computers.Arity2<Iterable<T>, T, V> mappedOp = (in1, in2, out) -> op.compute(in1, in2, range, minPixelFraction, out);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/variance/DefaultVarianceFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/variance/DefaultVarianceFilter.java
@@ -55,18 +55,18 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class DefaultVarianceFilter<T, V> implements
-		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, IterableInterval<V>> {
+		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 
 	@OpDependency(name = "stats.variance")
 	private Computers.Arity1<Iterable<T>, V> statsOp;
 
 	@OpDependency(name = "map.neighborhood")
-	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, IterableInterval<V>> mapper;
+	private Computers.Arity3<RandomAccessibleInterval<T>, Shape, Computers.Arity1<Iterable<T>, V>, RandomAccessibleInterval<V>> mapper;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			final IterableInterval<V> output) {
+			final RandomAccessibleInterval<V> output) {
 		RandomAccessibleInterval<T> extended = outOfBoundsFactory == null ? input
 			: Views.interval((Views.extend(input, outOfBoundsFactory)), input);
 		mapper.compute(extended, inputNeighborhoodShape, statsOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/cooccurrenceMatrix/CooccurrenceMatrix.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/cooccurrenceMatrix/CooccurrenceMatrix.java
@@ -2,7 +2,7 @@ package net.imagej.ops2.image.cooccurrenceMatrix;
 
 import java.util.function.Function;
 
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Pair;
 
@@ -28,13 +28,13 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "matrixOrientation")
 @Parameter(key = "cooccurrenceMatrix", itemIO = ItemIO.OUTPUT)
 public class CooccurrenceMatrix<T extends RealType<T>>
-		implements Functions.Arity4<IterableInterval<T>, Integer, Integer, MatrixOrientation, double[][]> {
+		implements Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, double[][]> {
 
 	@OpDependency(name = "stats.minMax")
-	private Function<IterableInterval<T>, Pair<T, T>> minmax;
+	private Function<RandomAccessibleInterval<T>, Pair<T, T>> minmax;
 
 	@Override
-	public double[][] apply(IterableInterval<T> input, Integer nrGreyLevels, Integer distance,
+	public double[][] apply(RandomAccessibleInterval<T> input, Integer nrGreyLevels, Integer distance,
 			MatrixOrientation orientation) {
 		if (input.numDimensions() == 3 && orientation.isCompatible(3)) {
 			return CooccurrenceMatrix3D.apply(input, nrGreyLevels, distance, minmax, orientation);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/FillRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/FillRAI.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2018 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops2.image.fill;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.Type;
+
+import org.scijava.Priority;
+import org.scijava.ops.core.Op;
+import org.scijava.ops.function.Computers;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+/**
+ * Fill a {@link RandomAccessibleInterval} with some constant value. Operates in
+ * parallel using imglib2's {@link LoopBuilder} utility
+ * 
+ * @author Gabriel Selzer
+ */
+@Plugin(type = Op.class, name = "image.fill", priority = Priority.HIGH)
+@Parameter(key = "constant")
+@Parameter(key = "iterableOutput", itemIO = ItemIO.BOTH)
+public class FillRAI<T extends Type<T>> implements
+	Computers.Arity1<T, RandomAccessibleInterval<T>> 
+{
+
+	//TODO can we find a way to parallelize this (or use lift?)
+	@Override
+	public void compute(final T constant, final RandomAccessibleInterval<T> output) {
+		LoopBuilder.setImages(output).multiThreaded().forEachPixel(pixel -> pixel.set(constant));
+	}
+}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/Inverters.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/Inverters.java
@@ -4,26 +4,25 @@ import java.math.BigInteger;
 
 import net.imagej.types.UnboundedIntegerType;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.Unsigned128BitType;
 import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.util.Util;
 
 import org.scijava.ops.OpField;
 import org.scijava.ops.core.OpCollection;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
-import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.struct.ItemIO;
 
 @Plugin(type = OpCollection.class)
 public class Inverters<T extends RealType<T>, I extends IntegerType<I>> {
 
 	@OpField(names = "image.invert", params = "input, min, max, invertedOutput")
-	public final Computers.Arity3<IterableInterval<T>, T, T, IterableInterval<T>> delegatorInvert = (input, min, max,
+	public final Computers.Arity3<RandomAccessibleInterval<T>, T, T, RandomAccessibleInterval<T>> delegatorInvert = (input, min, max,
 			output) -> {
 
 		// HACK: Some types are small enough that they can run the faster, double math
@@ -31,7 +30,7 @@ public class Inverters<T extends RealType<T>, I extends IntegerType<I>> {
 		// Others (fortunately all in this category are IntegerTypes)
 		// must use the slower BigInteger inverter.
 		// TODO: Think of a better solution.
-		final T copy = input.firstElement().createVariable();
+		final T copy = Util.getTypeFromInterval(input).createVariable();
 		boolean typeTooBig = false;
 		// if the type is an integer type that can handle Long.MAX_VALUE
 		// then we have to run the slow version
@@ -53,44 +52,39 @@ public class Inverters<T extends RealType<T>, I extends IntegerType<I>> {
 	};
 
 	@OpField(names = "image.invert", params = "input, invertedOutput")
-	public final Computers.Arity1<IterableInterval<T>, IterableInterval<T>> simpleInvert = (input, output) -> delegatorInvert
-			.compute(input, minValue(input.firstElement()), maxValue(input.firstElement()), output);
+	public final Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> simpleInvert =
+		(input, output) -> {
+			T type = Util.getTypeFromInterval(input);
+			delegatorInvert.compute(input, minValue(type), maxValue(type), output);
+		};
 
-	public void computeII(final IterableInterval<T> input, final T min, final T max, final IterableInterval<T> output) {
+	public void computeII(final RandomAccessibleInterval<T> input, final T min, final T max, final RandomAccessibleInterval<T> output) {
 		final double minDouble = min.getRealDouble();
 		final double maxDouble = max.getRealDouble();
 		final double minMax = min.getRealDouble() + max.getRealDouble();
 
-		final Cursor<T> inCursor = input.cursor();
-		final Cursor<T> outCursor = output.cursor();
-		while (inCursor.hasNext()) {
-			T in = inCursor.next();
-			T out = outCursor.next();
+		LoopBuilder.setImages(input, output).multiThreaded().forEachPixel((in, out) -> {
 			if (minMax - in.getRealDouble() <= out.getMinValue()) {
 				out.setReal(out.getMinValue());
 			} else if (minMax - in.getRealDouble() >= out.getMaxValue()) {
 				out.setReal(out.getMaxValue());
 			} else
 				out.setReal(minMax - in.getRealDouble());
-		}
+		});
 	}
 
 	// HACK: this will only be run when our image is of a type too big for default
 	// inverts.
 	// TODO: Think of a better solution.
 	@SuppressWarnings("unchecked")
-	public void computeIIInteger(final IterableInterval<T> input, final T min, final T max,
-			final @Mutable IterableInterval<T> output) {
+	public void computeIIInteger(final RandomAccessibleInterval<T> input, final T min, final T max,
+			final @Mutable RandomAccessibleInterval<T> output) {
 
 		final BigInteger minValue = getBigInteger(min);
 		final BigInteger maxValue = getBigInteger(max);
 		final BigInteger minMax = minValue.add(maxValue);
 
-		final Cursor<T> inCursor = input.cursor();
-		final Cursor<T> outCursor = output.cursor();
-		while (inCursor.hasNext()) {
-			T in = inCursor.next();
-			T out = outCursor.next();
+		LoopBuilder.setImages(input, output).multiThreaded().forEachPixel((in, out) -> {
 			BigInteger inverted = minMax.subtract(getBigInteger(in));
 
 			if (inverted.compareTo(getBigInteger(minValue(out))) <= 0)
@@ -99,7 +93,7 @@ public class Inverters<T extends RealType<T>, I extends IntegerType<I>> {
 				out.set(maxValue(out));
 			else
 				setBigInteger(out, inverted);
-		}
+		});
 
 	}
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIFunction.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIFunction.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.image.normalize;
 import java.util.function.BiFunction;
 
 import net.imglib2.Dimensions;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -44,7 +44,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * Normalizes an {@link IterableInterval} given its minimum and maximum to
+ * Normalizes an {@link RandomAccessibleInterval} given its minimum and maximum to
  * another range defined by minimum and maximum.
  * 
  * @author Christian Dietz (University of Konstanz)
@@ -59,19 +59,24 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "targetMax")
 @Parameter(key = "output", itemIO = ItemIO.OUTPUT)
 public class NormalizeIIFunction<I extends RealType<I>, O extends RealType<O>>
-		implements Functions.Arity5<IterableInterval<I>, I, I, O, O, IterableInterval<O>> {
+	implements
+	Functions.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>>
+{
 
 	@OpDependency(name = "create.img")
-	private BiFunction<Dimensions, O, IterableInterval<O>> imgCreator;
+	private BiFunction<Dimensions, O, RandomAccessibleInterval<O>> imgCreator;
 
 	@OpDependency(name = "image.normalize")
-	private Computers.Arity5<IterableInterval<I>, I, I, O, O, IterableInterval<O>> normalizer;
+	private Computers.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>> normalizer;
 
 	@Override
-	public IterableInterval<O> apply(final IterableInterval<I> input, final I sourceMin, final I sourceMax,
-			final O targetMin, final O targetMax) {
-		IterableInterval<O> output = imgCreator.apply(input, targetMin);
-		normalizer.compute(input, sourceMin, sourceMax, targetMin, targetMax, output);
+	public RandomAccessibleInterval<O> apply(
+		final RandomAccessibleInterval<I> input, final I sourceMin,
+		final I sourceMax, final O targetMin, final O targetMax)
+	{
+		RandomAccessibleInterval<O> output = imgCreator.apply(input, targetMin);
+		normalizer.compute(input, sourceMin, sourceMax, targetMin, targetMax,
+			output);
 		return output;
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
@@ -31,13 +31,13 @@ package net.imagej.ops2.image.normalize;
 
 import java.util.function.Function;
 
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Pair;
+import net.imglib2.util.Util;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
@@ -45,7 +45,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * Normalizes an {@link IterableInterval} given its minimum and maximum to
+ * Normalizes an {@link RandomAccessibleInterval} given its minimum and maximum to
  * another range defined by minimum and maximum.
  * 
  * TODO: Should this be a scale op?
@@ -59,20 +59,20 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class NormalizeIILazy<I extends RealType<I>, O extends RealType<O>>
-		implements Computers.Arity1<IterableInterval<I>, IterableInterval<O>> {
+		implements Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> {
 
 	@OpDependency(name = "stats.minMax")
-	private Function<IterableInterval<I>, Pair<I, I>> minMaxFunc;
+	private Function<RandomAccessibleInterval<I>, Pair<I, I>> minMaxFunc;
 
 	@OpDependency(name = "image.normalize")
-	private Computers.Arity5<IterableInterval<I>, I, I, O, O, IterableInterval<O>> normalizerFunc;
+	private Computers.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>> normalizerFunc;
 
 	@Override
-	public void compute(IterableInterval<I> img, @Mutable IterableInterval<O> output) {
+	public void compute(RandomAccessibleInterval<I> img, @Mutable RandomAccessibleInterval<O> output) {
 		Pair<I, I> sourceMinMax = minMaxFunc.apply(img);
-		O min = output.firstElement().createVariable();
+		O min = Util.getTypeFromInterval(output).createVariable();
 		min.setReal(min.getMinValue());
-		O max = output.firstElement().createVariable();
+		O max = Util.getTypeFromInterval(output).createVariable();
 		max.setReal(max.getMaxValue());
 
 		normalizerFunc.accept(img, sourceMinMax.getA(), sourceMinMax.getB(), min, max, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazyFunction.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazyFunction.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.image.normalize;
 
 import java.util.function.Function;
 
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -42,7 +42,7 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * Normalizes an {@link IterableInterval} given its minimum and maximum to
+ * Normalizes an {@link RandomAccessibleInterval} given its minimum and maximum to
  * another range defined by minimum and maximum.
  * 
  * TODO: Should this be a scale op?
@@ -56,17 +56,17 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "output", itemIO = ItemIO.OUTPUT)
 public class NormalizeIILazyFunction<I extends RealType<I>>
-		implements Function<IterableInterval<I>, IterableInterval<I>> {
+		implements Function<RandomAccessibleInterval<I>, RandomAccessibleInterval<I>> {
 
 	@OpDependency(name = "create.img")
-	private Function<IterableInterval<I>, IterableInterval<I>> createFunc;
+	private Function<RandomAccessibleInterval<I>, RandomAccessibleInterval<I>> createFunc;
 
 	@OpDependency(name = "image.normalize")
-	private Computers.Arity1<IterableInterval<I>, IterableInterval<I>> normalizer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<I>> normalizer;
 
 	@Override
-	public IterableInterval<I> apply(IterableInterval<I> img) {
-		IterableInterval<I> output = createFunc.apply(img);
+	public RandomAccessibleInterval<I> apply(RandomAccessibleInterval<I> img) {
+		RandomAccessibleInterval<I> output = createFunc.apply(img);
 		normalizer.compute(img, output);
 		return output;
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
@@ -103,7 +103,7 @@ public class WatershedBinary<T extends BooleanType<T>, B extends BooleanType<B>>
 	@OpDependency(name = "create.img")
 	private BiFunction<Dimensions, FloatType, RandomAccessibleInterval<FloatType>> imgCreator;
 	@OpDependency(name = "image.invert")
-	private Computers.Arity1<IterableInterval<FloatType>, IterableInterval<FloatType>> imgInverter;
+	private Computers.Arity1<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>> imgInverter;
 	@OpDependency(name = "filter.gauss")
 	private Computers.Arity3<RandomAccessibleInterval<FloatType>, ExecutorService, double[], RandomAccessibleInterval<FloatType>> gaussOp;
 	@OpDependency(name = "image.watershed")
@@ -132,7 +132,7 @@ public class WatershedBinary<T extends BooleanType<T>, B extends BooleanType<B>>
 		final RandomAccessibleInterval<FloatType> distMap = imgCreator.apply(in, new FloatType());
 		distanceTransformer.compute(in, es, distMap);
 		final RandomAccessibleInterval<FloatType> invertedDT = imgCreator.apply(in, new FloatType());
-		imgInverter.compute(Views.iterable(distMap), Views.iterable(invertedDT));
+		imgInverter.compute(distMap, invertedDT);
 		final RandomAccessibleInterval<FloatType> gauss = imgCreator.apply(in, new FloatType());
 		gaussOp.compute(invertedDT, es, sigma, gauss);
 		// run the default watershed

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
@@ -108,7 +108,7 @@ public class WatershedBinarySingleSigma<T extends BooleanType<T>, B extends Bool
 	@OpDependency(name = "create.img")
 	private BiFunction<Dimensions, FloatType, RandomAccessibleInterval<FloatType>> imgCreator;
 	@OpDependency(name = "image.invert")
-	private Computers.Arity1<IterableInterval<FloatType>, IterableInterval<FloatType>> imgInverter;
+	private Computers.Arity1<RandomAccessibleInterval<FloatType>, RandomAccessibleInterval<FloatType>> imgInverter;
 	@OpDependency(name = "filter.gauss")
 	private Computers.Arity3<RandomAccessibleInterval<FloatType>, ExecutorService, Double, RandomAccessibleInterval<FloatType>> gaussOp;
 	@OpDependency(name = "image.watershed")
@@ -133,7 +133,7 @@ public class WatershedBinarySingleSigma<T extends BooleanType<T>, B extends Bool
 		final RandomAccessibleInterval<FloatType> distMap = imgCreator.apply(in, new FloatType());
 		distanceTransformer.compute(in, es, distMap);
 		final RandomAccessibleInterval<FloatType> invertedDT = imgCreator.apply(in, new FloatType());
-		imgInverter.compute(Views.iterable(distMap), Views.iterable(invertedDT));
+		imgInverter.compute(distMap, invertedDT);
 		final RandomAccessibleInterval<FloatType> gauss = imgCreator.apply(in, new FloatType());
 		gaussOp.compute(invertedDT, es, sigma, gauss);
 		// run the default watershed

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/AbstractImageMomentOp.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/AbstractImageMomentOp.java
@@ -29,7 +29,7 @@
 
 package net.imagej.ops2.imagemoments;
 
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpService;
@@ -47,12 +47,12 @@ import org.scijava.ops.function.Computers;
  *            output type
  */
 public interface AbstractImageMomentOp<I extends RealType<I>, O extends RealType<O>>
-		extends Computers.Arity1<IterableInterval<I>, O> {
+		extends Computers.Arity1<RandomAccessibleInterval<I>, O> {
 	
-	public void computeMoment(IterableInterval<I> input, O output);
+	public void computeMoment(RandomAccessibleInterval<I> input, O output);
 
 	@Override
-	default void compute(IterableInterval<I> input, O output) {
+	default void compute(RandomAccessibleInterval<I> input, O output) {
 		if (input.numDimensions() != 2)
 			throw new IllegalArgumentException("Only two-dimensional inputs allowed!");
 		computeMoment(input, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment00.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment00.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.centralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -56,10 +56,10 @@ public class DefaultCentralMoment00<I extends RealType<I>, O extends RealType<O>
 {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Cmp;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Cmp;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		moment00Cmp.compute(input, output);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment01.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment01.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.centralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
@@ -56,7 +56,7 @@ public class DefaultCentralMoment01<I extends RealType<I>, O extends RealType<O>
 {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		output.setReal(0d);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment03.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment03.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
@@ -58,30 +62,44 @@ public class DefaultCentralMoment03<I extends RealType<I>, O extends RealType<O>
 		implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Func;
 	@OpDependency(name = "imageMoments.moment01")
-	private Computers.Arity1<IterableInterval<I>, O> moment01Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment01Func;
+	@OpDependency(name = "math.power")
+	private Computers.Arity2<O, Integer, O> powerOp;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 		final O moment00 = output.createVariable();
 		moment00Func.compute(input, moment00);
 		final O moment01 = output.createVariable();
 		moment01Func.compute(input, moment01);
 
-		final double centerY = moment01.getRealDouble() / moment00.getRealDouble();
+		final O centerY = moment01.copy();
+		centerY.div(moment00);
 
-		double centralmoment03 = 0;
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				O temp = output.createVariable();
+				O y = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					// y = (pixelPos - centerY)^3
+					temp.setReal(pos.getDoublePosition(1));
+					temp.sub(centerY);
+					powerOp.compute(temp, 3, y);
+					// temp = pixelVal * (pixelPos - centerY)^3
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(y);
+					sum.add(temp);
+				});
+				return sum;
+			});
 
-		final Cursor<I> it = input.localizingCursor();
-		while (it.hasNext()) {
-			it.fwd();
-			final double y = it.getDoublePosition(1) - centerY;
-			final double val = it.get().getRealDouble();
-
-			centralmoment03 += val * y * y * y;
-		}
-
-		output.setReal(centralmoment03);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment10.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment10.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.centralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
@@ -56,7 +56,7 @@ public class DefaultCentralMoment10<I extends RealType<I>, O extends RealType<O>
 {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		output.setReal(0d);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment11.java
@@ -31,6 +31,7 @@ package net.imagej.ops2.imagemoments.centralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,19 +58,19 @@ public class DefaultCentralMoment11<I extends RealType<I>, O extends RealType<O>
 		implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Func;
 
 	@OpDependency(name = "imageMoments.moment01")
-	private Computers.Arity1<IterableInterval<I>, O> moment01Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment01Func;
 
 	@OpDependency(name = "imageMoments.moment10")
-	private Computers.Arity1<IterableInterval<I>, O> moment10Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment10Func;
 
 	@OpDependency(name = "imageMoments.moment11")
-	private Computers.Arity1<IterableInterval<I>, O> moment11Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment11Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		moment00Func.compute(input, moment00);
 		final O moment01 = output.createVariable();
@@ -78,9 +79,13 @@ public class DefaultCentralMoment11<I extends RealType<I>, O extends RealType<O>
 		moment10Func.compute(input, moment10);
 		final O moment11 = output.createVariable();
 		moment11Func.compute(input, moment11);
-
-		final double centerX = moment10.getRealDouble() / moment00.getRealDouble();
-
-		output.setReal(moment11.getRealDouble() - (centerX * moment01.getRealDouble()));
+		
+		// output = moment11 - (moment10 * moment01 / moment00)
+		final O centerX = moment10;
+		centerX.div(moment00);
+		centerX.mul(moment01);
+		
+		output.set(moment11);
+		output.sub(centerX);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment12.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment12.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
@@ -58,37 +62,55 @@ public class DefaultCentralMoment12<I extends RealType<I>, O extends RealType<O>
 		implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Func;
 
 	@OpDependency(name = "imageMoments.moment01")
-	private Computers.Arity1<IterableInterval<I>, O> moment01Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment01Func;
 
 	@OpDependency(name = "imageMoments.moment10")
-	private Computers.Arity1<IterableInterval<I>, O> moment10Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment10Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 		final O moment00 = output.createVariable();
 		moment00Func.compute(input, moment00);
 		final O moment01 = output.createVariable();
 		moment01Func.compute(input, moment01);
 		final O moment10 = output.createVariable();
 		moment10Func.compute(input, moment10);
-		final double centerX = moment10.getRealDouble() / moment00.getRealDouble();
-		final double centerY = moment01.getRealDouble() / moment00.getRealDouble();
 
-		double centralmoment12 = 0;
+		final O centerX = moment10.copy();
+		centerX.div(moment00);
+		final O centerY = moment01.copy();
+		centerY.div(moment00);
 
-		final Cursor<I> it = input.localizingCursor();
-		while (it.hasNext()) {
-			it.fwd();
-			final double x = it.getDoublePosition(0) - centerX;
-			final double y = it.getDoublePosition(1) - centerY;
-			final double val = it.get().getRealDouble();
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				sum.setZero();
+				O x = output.createVariable();
+				O y = output.createVariable();
+				O temp = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					x.setReal(pos.getDoublePosition(0));
+					x.sub(centerX);
+					y.setReal(pos.getDoublePosition(1));
+					y.sub(centerY);
+					// temp = pixelVal * x * y * y
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(x);
+					temp.mul(y);
+					temp.mul(y);
+					sum.add(temp);
+				});
 
-			centralmoment12 += val * x * y * y;
-		}
+				return sum;
+			});
 
-		output.setReal(centralmoment12);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment21.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment21.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
@@ -58,16 +62,16 @@ public class DefaultCentralMoment21<I extends RealType<I>, O extends RealType<O>
 		implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Func;
 
 	@OpDependency(name = "imageMoments.moment01")
-	private Computers.Arity1<IterableInterval<I>, O> moment01Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment01Func;
 
 	@OpDependency(name = "imageMoments.moment10")
-	private Computers.Arity1<IterableInterval<I>, O> moment10Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment10Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		moment00Func.compute(input, moment00);
 		final O moment01 = output.createVariable();
@@ -75,21 +79,36 @@ public class DefaultCentralMoment21<I extends RealType<I>, O extends RealType<O>
 		final O moment10 = output.createVariable();
 		moment10Func.compute(input, moment10);
 
-		final double centerX = moment10.getRealDouble() / moment00.getRealDouble();
-		final double centerY = moment01.getRealDouble() / moment00.getRealDouble();
+		final O centerX = moment10.copy();
+		centerX.div(moment00);
+		final O centerY = moment01.copy();
+		centerY.div(moment00);
 
-		double centralmoment21 = 0;
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				sum.setZero();
+				O x = output.createVariable();
+				O y = output.createVariable();
+				O temp = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					x.setReal(pos.getDoublePosition(0));
+					x.sub(centerX);
+					y.setReal(pos.getDoublePosition(1));
+					y.sub(centerY);
+					// temp = pixelVal * x * x * y
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(x);
+					temp.mul(x);
+					temp.mul(y);
+					sum.add(temp);
+				});
 
-		final Cursor<I> it = input.localizingCursor();
-		while (it.hasNext()) {
-			it.fwd();
-			final double x = it.getDoublePosition(0) - centerX;
-			final double y = it.getDoublePosition(1) - centerY;
-			final double val = it.get().getRealDouble();
+				return sum;
+			});
 
-			centralmoment21 += val * x * x * y;
-		}
-
-		output.setReal(centralmoment21);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment30.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment30.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
@@ -58,31 +62,46 @@ public class DefaultCentralMoment30<I extends RealType<I>, O extends RealType<O>
 		implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.moment00")
-	private Computers.Arity1<IterableInterval<I>, O> moment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment00Func;
 
 	@OpDependency(name = "imageMoments.moment10")
-	private Computers.Arity1<IterableInterval<I>, O> moment10Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment10Func;
+
+	@OpDependency(name = "math.power")
+	private Computers.Arity2<O, Integer, O> powerOp;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 		final O moment00 = output.createVariable();
 		moment00Func.compute(input, moment00);
 		final O moment10 = output.createVariable();
 		moment10Func.compute(input, moment10);
 
-		final double centerX = moment10.getRealDouble() / moment00.getRealDouble();
+		final O centerX = moment10.copy();
+		centerX.div(moment00);
 
-		double centralmoment30 = 0;
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				O temp = output.createVariable();
+				O x = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					// x = (pixelPos - centerX)^3
+					temp.setReal(pos.getDoublePosition(0));
+					temp.sub(centerX);
+					powerOp.compute(temp, 3, x);
+					// temp = pixelVal * (pixelPos - centerX)^3
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(x);
+					sum.add(temp);
+				});
+				return sum;
+			});
 
-		final Cursor<I> it = input.localizingCursor();
-		while (it.hasNext()) {
-			it.fwd();
-			final double x = it.getDoublePosition(0) - centerX;
-			final double val = it.get().getRealDouble();
-
-			centralmoment30 += val * x * x * x;
-		}
-
-		output.setReal(centralmoment30);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment00.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment00.java
@@ -29,13 +29,13 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
-import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
 import org.scijava.ops.core.Op;
+import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -54,10 +54,12 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class IterableCentralMoment00<I extends RealType<I>, O extends RealType<O>>
-		implements AbstractImageMomentOp<I, O> {
+		implements Computers.Arity1<IterableInterval<I>, O> {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void compute(final IterableInterval<I> input, final O output) {
+		if (input.numDimensions() != 2)
+			throw new IllegalArgumentException("Only two-dimensional inputs allowed!");
 
 		double moment00 = 0;
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment11.java
@@ -29,13 +29,13 @@
 
 package net.imagej.ops2.imagemoments.centralmoments;
 
-import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
 import org.scijava.ops.core.Op;
+import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -54,10 +54,13 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class IterableCentralMoment11<I extends RealType<I>, O extends RealType<O>>
-		implements AbstractImageMomentOp<I, O> {
+		implements Computers.Arity1<IterableInterval<I>, O> {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void compute(final IterableInterval<I> input, final O output) {
+		if (input.numDimensions() != 2) throw new IllegalArgumentException(
+			"Only two-dimensional inputs allowed!");
+
 		double moment00 = 0d;
 		double moment01 = 0d;
 		double moment10 = 0d;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment1.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment1.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.hu;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -47,6 +47,7 @@ import org.scijava.struct.ItemIO;
  * @author Christian Dietz (University of Konstanz)
  * @param <I> input type
  * @param <O> output type
+ * @see <a href="https://en.wikipedia.org/wiki/Image_moment#Rotation_invariants"> This page </a>
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment1", label = "Image Moment: HuMoment1")
 @Parameter(key = "input")
@@ -56,18 +57,19 @@ public class DefaultHuMoment1<I extends RealType<I>, O extends RealType<O>>
 {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment20")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment20Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment20Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment02")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment02Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment02Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O n20 = output.createVariable();
 		normalizedCentralMoment20Func.compute(input, n20);
 		final O n02 = output.createVariable();
 		normalizedCentralMoment02Func.compute(input, n02);
 
-		output.setReal(n20.getRealDouble() + n02.getRealDouble());
+		output.set(n20);
+		output.add(n02);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.hu;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -49,6 +49,7 @@ import org.scijava.struct.ItemIO;
  *            input type
  * @param <O>
  *            output type
+ * @see <a href="https://en.wikipedia.org/wiki/Image_moment#Rotation_invariants"> This page </a>
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment4", label = "Image Moment: HuMoment4")
 @Parameter(key = "input")
@@ -56,19 +57,21 @@ import org.scijava.struct.ItemIO;
 public class DefaultHuMoment4<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment30Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment30Func;
 
-	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment12Func;
+	@OpDependency(name = "imageMoments.normalizedCentralMoment12")
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment12Func;
 
-	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment21Func;
+	@OpDependency(name = "imageMoments.normalizedCentralMoment21")
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment21Func;
 
-	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment03Func;
+	@OpDependency(name = "imageMoments.normalizedCentralMoment03")
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment03Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 		final O n30 = output.createVariable();
 		normalizedCentralMoment30Func.compute(input, n30);
 		final O n12 = output.createVariable();
@@ -78,7 +81,17 @@ public class DefaultHuMoment4<I extends RealType<I>, O extends RealType<O>> impl
 		final O n03 = output.createVariable();
 		normalizedCentralMoment03Func.compute(input, n30);
 
-		output.setReal(Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-				+ Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2));
+		// term1 = (n30 + n12)^2
+		final O term1 = n30.copy();
+		term1.add(n12);
+		term1.mul(term1);
+
+		// term2 = (n21 + n03)^2
+		final O term2 = n21.copy();
+		term2.add(n03);
+		term2.mul(term2);
+
+		output.set(term1);
+		output.add(term2);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
@@ -79,7 +79,7 @@ public class DefaultHuMoment4<I extends RealType<I>, O extends RealType<O>> impl
 		final O n21 = output.createVariable();
 		normalizedCentralMoment21Func.compute(input, n21);
 		final O n03 = output.createVariable();
-		normalizedCentralMoment03Func.compute(input, n30);
+		normalizedCentralMoment03Func.compute(input, n03);
 
 		// term1 = (n30 + n12)^2
 		final O term1 = n30.copy();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment5.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment5.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.hu;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -49,6 +49,7 @@ import org.scijava.struct.ItemIO;
  *            input type
  * @param <O>
  *            output type
+ * @see <a href="https://en.wikipedia.org/wiki/Image_moment#Rotation_invariants"> This page </a>
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment5", label = "Image Moment: HuMoment5")
 @Parameter(key = "input")
@@ -56,19 +57,19 @@ import org.scijava.struct.ItemIO;
 public class DefaultHuMoment5<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment30Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment30Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment12")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment12Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment12Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment21")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment21Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment21Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment03")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment03Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment03Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O n30 = output.createVariable();
 		normalizedCentralMoment30Func.compute(input, n30);
 		final O n12 = output.createVariable();
@@ -77,12 +78,51 @@ public class DefaultHuMoment5<I extends RealType<I>, O extends RealType<O>> impl
 		normalizedCentralMoment21Func.compute(input, n21);
 		final O n03 = output.createVariable();
 		normalizedCentralMoment03Func.compute(input, n03);
+		
+		// term1 = (n30 - 3*n12)(n30 + n12)[(n30 + n12)^2 - 3*(n21 + n03)^2]
+		// term11 = (n30 - 3*n12)
+		final O term11 = n30.copy();
+		output.set(n12);
+		output.mul(3d);
+		term11.sub(output);
+		// term12 = (n30 + n12)
+		final O term12 = n30.copy();
+		term12.add(n12);
+		// term13 = [(n30 + n12)^2 - 3*(n21 + n03)^2]
+		final O term13 = term12.copy();
+		term13.mul(term12);
+		output.set(n21);
+		output.add(n03);
+		output.mul(output);
+		output.mul(3);
+		term13.sub(output);
+		
+		final O term1 = term11.copy();
+		term1.mul(term12);
+		term1.mul(term13);
+		
+		// term2 = (3*n21 - n03)(n21 + n03)[3*(n30 + n12)^2 - (n21 + n03)^2]
+		// term21 =  (3*n21 - n03)
+		final O term21 = n21.copy();
+		term21.mul(3);
+		term21.sub(n03);
+		// term22 = (n21 + n03)
+		final O term22 = n21.copy();
+		term22.add(n03);
+		// term23 = [3*(n30 + n12)^2 - (n21 + n03)^2] = [3*(term12^2) - term22^2]
+		final O term23 = term12.copy();
+		term23.mul(term12);
+		term23.mul(3);
+		output.set(term22);
+		output.mul(term22);
+		term23.sub(output);
+		
+		final O term2 = term21.copy();
+		term2.mul(term22);
+		term2.mul(term23);
+		
+		output.set(term1);
+		output.add(term2);
 
-		output.setReal((n30.getRealDouble() - 3 * n12.getRealDouble()) * (n30.getRealDouble() + n12.getRealDouble())
-				* (Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-						- 3 * Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2))
-				+ (3 * n21.getRealDouble() - n03.getRealDouble()) * (n21.getRealDouble() + n03.getRealDouble())
-						* (3 * Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-								- Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2)));
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.hu;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -49,6 +49,7 @@ import org.scijava.struct.ItemIO;
  *            input type
  * @param <O>
  *            output type
+ * @see <a href="https://en.wikipedia.org/wiki/Image_moment#Rotation_invariants"> This page </a>
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment6", label = "Image Moment: HuMoment6")
 @Parameter(key = "input")
@@ -56,28 +57,28 @@ import org.scijava.struct.ItemIO;
 public class DefaultHuMoment6<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment30Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment30Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment12")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment12Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment12Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment21")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment21Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment21Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment03")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment03Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment03Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment02")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment02Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment02Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment11")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment11Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment11Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment20")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment20Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment20Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O n02 = output.createVariable();
 		normalizedCentralMoment02Func.compute(input, n02);
 		final O n03 = output.createVariable();
@@ -92,11 +93,37 @@ public class DefaultHuMoment6<I extends RealType<I>, O extends RealType<O>> impl
 		normalizedCentralMoment21Func.compute(input, n21);
 		final O n30 = output.createVariable();
 		normalizedCentralMoment30Func.compute(input, n30);
-
-		output.setReal((n20.getRealDouble() - n02.getRealDouble())
-				* (Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-						- Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2))
-				+ 4 * n11.getRealDouble() * (n30.getRealDouble() + n12.getRealDouble())
-						* (n21.getRealDouble() + n03.getRealDouble()));
+		
+		// term11 = (n20 - n02)
+		final O term11 = n20.copy();
+		term11.sub(n02);
+		// term12 = [(n30 + n12)^2 - (n21 + n03)^2]
+		final O term12 = n30.copy();
+		term12.add(n12);
+		term12.mul(term12);
+		output.set(n21);
+		output.add(n03);
+		output.mul(output);
+		term12.sub(output);
+		// term1 = term11 * term12
+		final O term1 = term11.copy();
+		term1.mul(term12);
+		
+		// term21 = 4*n11
+		final O term21 = n11.copy();
+		term21.mul(4);
+		// term22 = (n20 + n12)
+		final O term22 = n20.copy();
+		term22.add(n12);
+		// term23 = (n21 + n03)
+		final O term23 = n21.copy();
+		term23.add(n03);
+		// term2 = term21 * term22 * term23 
+		final O term2 = term21.copy();
+		term2.mul(term22);
+		term2.mul(term23);
+		
+		output.set(term1);
+		output.add(term2);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
@@ -112,8 +112,8 @@ public class DefaultHuMoment6<I extends RealType<I>, O extends RealType<O>> impl
 		// term21 = 4*n11
 		final O term21 = n11.copy();
 		term21.mul(4);
-		// term22 = (n20 + n12)
-		final O term22 = n20.copy();
+		// term22 = (n30 + n12)
+		final O term22 = n30.copy();
 		term22.add(n12);
 		// term23 = (n21 + n03)
 		final O term23 = n21.copy();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.hu;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -49,6 +49,7 @@ import org.scijava.struct.ItemIO;
  *            input type
  * @param <O>
  *            output type
+ * @see <a href="https://en.wikipedia.org/wiki/Image_moment#Rotation_invariants"> This page </a>
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment7", label = "Image Moment: HuMoment7")
 @Parameter(key = "input")
@@ -56,19 +57,19 @@ import org.scijava.struct.ItemIO;
 public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment30Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment30Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment12")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment12Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment12Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment21")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment21Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment21Func;
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment03")
-	private Computers.Arity1<IterableInterval<I>, O> normalizedCentralMoment03Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> normalizedCentralMoment03Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O n03 = output.createVariable();
 		normalizedCentralMoment03Func.compute(input, n03);
 		final O n12 = output.createVariable();
@@ -77,12 +78,52 @@ public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>> impl
 		normalizedCentralMoment21Func.compute(input, n21);
 		final O n30 = output.createVariable();
 		normalizedCentralMoment30Func.compute(input, n30);
+		
+		// term1 = (3*n21 - n03)(n30 + n12)[(n30 + n12)^2 - 3*(n21 + n03)^2]
+		// term11 = (3*n21 - n03)
+		final O term11 = n21.copy();
+		output.mul(3d);
+		output.set(n03);
+		term11.sub(output);
+		// term12 = (n30 + n12)
+		final O term12 = n30.copy();
+		term12.add(n12);
+		// term13 = [(n30 + n12)^2 - 3*(n21 + n03)^2]
+		final O term13 = term12.copy();
+		term13.mul(term12);
+		output.set(n21);
+		output.add(n03);
+		output.mul(output);
+		output.mul(3);
+		term13.sub(output);
+		
+		final O term1 = term11.copy();
+		term1.mul(term12);
+		term1.mul(term13);
+		
+		// term2 = (n30 - 3*n12)(n21 + n03)[3*(n30 + n12)^2 - (n21 + n03)^2]
+		// term21 = (n30 - 3*n12)
+		final O term21 = n30.copy();
+		output.set(n12);
+		output.mul(3);
+		term21.sub(output);
+		// term22 = (n21 + n03)
+		final O term22 = n21.copy();
+		term22.add(n03);
+		// term23 = [3*(n30 + n12)^2 - (n21 + n03)^2] = [3*(term12^2) - term22^2]
+		final O term23 = term12.copy();
+		term23.mul(term12);
+		term23.mul(3);
+		output.set(term22);
+		output.mul(term22);
+		term23.sub(output);
+		
+		final O term2 = term21.copy();
+		term2.mul(term22);
+		term2.mul(term23);
+		
+		output.set(term1);
+		output.add(term2);
 
-		output.setReal((3 * n21.getRealDouble() - n03.getRealDouble()) * (n30.getRealDouble() + n12.getRealDouble())
-				* (Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-						- 3 * Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2))
-				- (n30.getRealDouble() - 3 * n12.getRealDouble()) * (n21.getRealDouble() + n03.getRealDouble())
-						* (3 * Math.pow(n30.getRealDouble() + n12.getRealDouble(), 2)
-								- Math.pow(n21.getRealDouble() + n03.getRealDouble(), 2)));
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
@@ -82,9 +82,8 @@ public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>> impl
 		// term1 = (3*n21 - n03)(n30 + n12)[(n30 + n12)^2 - 3*(n21 + n03)^2]
 		// term11 = (3*n21 - n03)
 		final O term11 = n21.copy();
-		output.mul(3d);
-		output.set(n03);
-		term11.sub(output);
+		term11.mul(3d);
+		term11.sub(n03);
 		// term12 = (n30 + n12)
 		final O term12 = n30.copy();
 		term12.add(n12);
@@ -123,7 +122,7 @@ public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>> impl
 		term2.mul(term23);
 		
 		output.set(term1);
-		output.add(term2);
+		output.sub(term2);
 
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment01.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment01.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.moments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
 import org.scijava.ops.core.Op;
@@ -57,18 +61,25 @@ public class DefaultMoment01<I extends RealType<I>, O extends RealType<O>>
 {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 
-		double moment01 = 0;
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				sum.setZero();
+				O temp = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(pos.getDoublePosition(1));
+					sum.add(temp);
+				});
+				return sum;
+			});
 
-		final Cursor<I> cur = input.localizingCursor();
-		while (cur.hasNext()) {
-			cur.fwd();
-			double y = cur.getDoublePosition(1);
-			double val = cur.get().getRealDouble();
-			moment01 += y * val;
-		}
-
-		output.setReal(moment01);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment11.java
@@ -29,10 +29,14 @@
 
 package net.imagej.ops2.imagemoments.moments;
 
+import java.util.List;
+
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 
 import org.scijava.Priority;
 import org.scijava.ops.core.Op;
@@ -57,19 +61,26 @@ public class DefaultMoment11<I extends RealType<I>, O extends RealType<O>>
 {
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input,
+		final O output)
+	{
 
-		double moment11 = 0;
+		List<O> sums = LoopBuilder.setImages(input, Intervals.positions(input))
+			.multiThreaded().forEachChunk(chunk -> {
+				O sum = output.createVariable();
+				sum.setZero();
+				O temp = output.createVariable();
+				chunk.forEachPixel((pixel, pos) -> {
+					temp.setReal(pixel.getRealDouble());
+					temp.mul(pos.getDoublePosition(0));
+					temp.mul(pos.getDoublePosition(1));
+					sum.add(temp);
+				});
+				return sum;
+			});
 
-		final Cursor<I> cur = input.localizingCursor();
-		while (cur.hasNext()) {
-			cur.fwd();
-			double x = cur.getDoublePosition(0);
-			double y = cur.getDoublePosition(1);
-			double val = cur.get().getRealDouble();
-			moment11 += x * y * val;
-		}
-
-		output.setReal(moment11);
+		output.setZero();
+		for (O sum : sums)
+			output.add(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment02<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment02")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment02Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment02Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment02 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment03<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment03")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment03Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment03Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment03 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment11<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment11")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment11Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment11Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment11 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment12<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment12")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment12Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment12Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment12 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment20<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment20")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment20Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment20Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment20 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment21<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment21")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment21Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment21Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment21 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.imagemoments.normalizedcentralmoments;
 
 import net.imagej.ops2.imagemoments.AbstractImageMomentOp;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -57,13 +57,13 @@ public class DefaultNormalizedCentralMoment30<I extends RealType<I>, O extends R
 {
 
 	@OpDependency(name = "imageMoments.centralMoment00")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment00Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment00Func;
 
 	@OpDependency(name = "imageMoments.centralMoment30")
-	private Computers.Arity1<IterableInterval<I>, O> centralMoment30Func;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> centralMoment30Func;
 
 	@Override
-	public void computeMoment(final IterableInterval<I> input, final O output) {
+	public void computeMoment(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment00 = output.createVariable();
 		centralMoment00Func.compute(input, moment00);
 		final O moment30 = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/UnaryRealTypeMath.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/UnaryRealTypeMath.java
@@ -34,14 +34,11 @@ import java.util.Random;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.DoubleType;
 
+import org.scijava.Priority;
 import org.scijava.ops.OpField;
 import org.scijava.ops.core.OpCollection;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
-import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.struct.ItemIO;
 
 /**
  * Ops of the {@code math} namespace which operate on {@link RealType}s.
@@ -384,6 +381,18 @@ public final class UnaryRealTypeMath<I extends RealType<I>, O extends RealType<O
 	@OpField(names = "math.power", params = "input, constant, output")
 	public final Computers.Arity2<I, Double, O> power = (input, constant, output) -> output
 			.setReal(Math.pow(input.getRealDouble(), constant));
+	
+	/**
+	 * Uses ImgLib2 Mul interface to take a type to an integer power.
+	 */
+	@OpField(names = "math.power", params = "input, constant, output")
+	public final Computers.Arity2<I, Integer, I> intPower = (input, constant,
+		output) -> {
+		output.setOne();
+		for (int i = 0; i < constant; i++) {
+			output.mul(input);
+		}
+	};
 
 	/**
 	 * Sets the real component of an output real number to a random value using a

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/DefaultProjectParallel.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/DefaultProjectParallel.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2020 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.ops2.project;
+
+import java.util.Iterator;
+
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.util.Intervals;
+
+import org.scijava.Priority;
+import org.scijava.ops.core.Op;
+import org.scijava.ops.function.Computers;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+@Plugin(type = Op.class, name = "project",
+	priority = Priority.LOW + 1)
+@Parameter(key = "input")
+@Parameter(key = "op")
+@Parameter(key = "dim")
+@Parameter(key = "output", itemIO = ItemIO.BOTH)
+public class DefaultProjectParallel<T, V> implements
+	Computers.Arity3<RandomAccessibleInterval<T>, Computers.Arity1<Iterable<T>, V>, Integer, RandomAccessibleInterval<V>>
+{
+
+	@Override
+	public void compute(final RandomAccessibleInterval<T> input, Computers.Arity1<Iterable<T>, V> method, Integer dim,
+		final RandomAccessibleInterval<V> output)
+	{
+		// TODO this first check is too simple, but for now ok
+		if (input.numDimensions() != output.numDimensions() + 1) //
+			throw new IllegalArgumentException(
+				"ERROR: input image must have one dimension more than output image!");
+		if (input.numDimensions() <= dim) //
+			throw new IllegalArgumentException(
+				"ERROR: input image must contain dimension " + dim);
+
+		LoopBuilder.setImages(output, Intervals.positions(output)).multiThreaded().forEachChunk(chunk -> {
+			RandomAccess<T> chunkRA = input.randomAccess();
+			chunk.forEachPixel((pixel, position) -> {
+				for (int d = 0; d < input.numDimensions(); d++) {
+					if (d != dim) {
+						chunkRA
+						.setPosition(position.getIntPosition(d - (d > dim ? 1 : 0)), d);
+					}
+				}
+
+				method.compute(new DimensionIterable(input.dimension(dim), dim, chunkRA),
+					pixel);
+				
+			});
+
+			return null;
+		});
+	}
+
+	final class DimensionIterable implements Iterable<T> {
+
+		private final long size;
+		private final int dim;
+		private final RandomAccess<T> access;
+
+		public DimensionIterable(final long size, final int dim, final RandomAccess<T> access) {
+			this.size = size;
+			this.dim = dim;
+			this.access = access;
+		}
+
+		@Override
+		public Iterator<T> iterator() {
+			return new Iterator<T>() {
+
+				int k = -1;
+
+				@Override
+				public boolean hasNext() {
+					return k < size - 1;
+				}
+
+				@Override
+				public T next() {
+					k++;
+					access.setPosition(k, dim);
+					return access.get();
+				}
+
+				@Override
+				public void remove() {
+					throw new UnsupportedOperationException("Not supported");
+				}
+			};
+		}
+	}
+}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultGeometricMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultGeometricMean.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -52,16 +53,16 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.geometricMean")
 @Parameter(key = "iterableInput")
 @Parameter(key = "geometricMean", itemIO = ItemIO.BOTH)
-public class DefaultGeometricMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
+public class DefaultGeometricMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.size")
-	private Computers.Arity1<Iterable<I>, O> sizeComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> sizeComputer;
 
 	@OpDependency(name = "stats.sumOfLogs")
-	private Computers.Arity1<Iterable<I>, O> sumOfLogsComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> sumOfLogsComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
 		final O size = output.createVariable();
 		sizeComputer.compute(input, size);
 		final O sumOfLogs = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultHarmonicMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultHarmonicMean.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -51,17 +52,17 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "iterableInput")
 @Parameter(key = "harmonicMean", itemIO = ItemIO.BOTH)
 public class DefaultHarmonicMean<I extends RealType<I>, O extends RealType<O>>
-	implements Computers.Arity1<Iterable<I>, O>
+	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {
 	
 	@OpDependency(name = "stats.size")
-	private Computers.Arity1<Iterable<I>, O> sizeComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> sizeComputer;
 
 	@OpDependency(name = "stats.sumOfInverses")
-	private Computers.Arity1<Iterable<I>, O> sumOfInversesComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> sumOfInversesComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
 		final O area = output.createVariable();
 		sizeComputer.compute(input, area);
 		final O sumOfInverses = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultKurtosis.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultKurtosis.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -51,17 +52,17 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "iterableInput")
 @Parameter(key = "kurtosis", itemIO = ItemIO.BOTH)
 public class DefaultKurtosis<I extends RealType<I>, O extends RealType<O>>
-	implements Computers.Arity1<Iterable<I>, O>
+	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {
 
 	@OpDependency(name = "stats.stdDev")
-	private Computers.Arity1<Iterable<I>, O> stdDevComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> stdDevComputer;
 	
 	@OpDependency(name = "stats.moment4AboutMean")
-	private Computers.Arity1<Iterable<I>, O> moment4AboutMeanComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment4AboutMeanComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
 		output.setReal(Double.NaN);
 
 		final O std = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMax.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMax.java
@@ -29,9 +29,14 @@
 
 package net.imagej.ops2.stats;
 
+import java.util.function.Function;
+
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Pair;
 
 import org.scijava.Priority;
+import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
@@ -39,25 +44,21 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.max}.
+ * {@link Op} to calculate the {@code stats.max}. Leans on other Ops.
  * 
- * @author Daniel Seebacher (University of Konstanz)
- * @author Christian Dietz (University of Konstanz)
- * @author Stefan Helfrich (University of Konstanz)
- * @param <T>
- *            input type
+ * @author Gabriel Selzer
+ * @param <T> input type
  */
-@Plugin(type = Op.class, name = "stats.max")
+@Plugin(type = Op.class, name = "stats.max", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
 @Parameter(key = "max", itemIO = ItemIO.BOTH)
-public class IterableMax<T extends RealType<T>> implements Computers.Arity1<Iterable<T>, T> {
+public class DefaultMax<T extends RealType<T>> implements Computers.Arity1<RandomAccessibleInterval<T>, T> {
+	
+	@OpDependency(name = "stats.minMax")
+	private Function<RandomAccessibleInterval<T>, Pair<T, T>> minMaxOp;
 
 	@Override
-	public void compute(final Iterable<T> input, final T output) {
-		// Re-use output to compare against
-		output.setReal(output.getMinValue());
-		for (final T in : input)
-			if (output.compareTo(in) < 0)
-				output.set(in);
+	public void compute(final RandomAccessibleInterval<T> input, final T output) {
+		output.set(minMaxOp.apply(input).getB());
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMean.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
@@ -49,21 +50,22 @@ import org.scijava.struct.ItemIO;
  * @param <O> output type
  */
 @Plugin(type = Op.class, name = "stats.mean",
-	priority = Priority.LOW)
-@Parameter(key = "iterableInput")
+	priority = Priority.HIGH)
+@Parameter(key = "rai")
 @Parameter(key = "mean", itemIO = ItemIO.BOTH)
 public class DefaultMean<I extends RealType<I>, O extends RealType<O>> 
-	implements Computers.Arity1<Iterable<I>, O>
+	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {
 	
 	@OpDependency(name = "stats.sum")
-	private Computers.Arity1<Iterable<I>, O> sumComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> sumComputer;
 	
 	@OpDependency(name = "stats.size")
-	private Computers.Arity1<Iterable<I>, O> areaComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> areaComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
+
 		sumComputer.compute(input, output);
 		final O size = output.createVariable();
 		areaComputer.compute(input, size);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMin.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMin.java
@@ -29,9 +29,14 @@
 
 package net.imagej.ops2.stats;
 
+import java.util.function.Function;
+
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Pair;
 
 import org.scijava.Priority;
+import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
@@ -39,25 +44,21 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.max}.
+ * {@link Op} to calculate the {@code stats.max}. Leans on other Ops.
  * 
- * @author Daniel Seebacher (University of Konstanz)
- * @author Christian Dietz (University of Konstanz)
- * @author Stefan Helfrich (University of Konstanz)
- * @param <T>
- *            input type
+ * @author Gabriel Selzer
+ * @param <T> input type
  */
-@Plugin(type = Op.class, name = "stats.max")
+@Plugin(type = Op.class, name = "stats.min", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
 @Parameter(key = "max", itemIO = ItemIO.BOTH)
-public class IterableMax<T extends RealType<T>> implements Computers.Arity1<Iterable<T>, T> {
+public class DefaultMin<T extends RealType<T>> implements Computers.Arity1<RandomAccessibleInterval<T>, T> {
+	
+	@OpDependency(name = "stats.minMax")
+	private Function<RandomAccessibleInterval<T>, Pair<T, T>> minMaxOp;
 
 	@Override
-	public void compute(final Iterable<T> input, final T output) {
-		// Re-use output to compare against
-		output.setReal(output.getMinValue());
-		for (final T in : input)
-			if (output.compareTo(in) < 0)
-				output.set(in);
+	public void compute(final RandomAccessibleInterval<T> input, final T output) {
+		output.set(minMaxOp.apply(input).getA());
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment1AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment1AboutMean.java
@@ -29,6 +29,8 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -39,11 +41,14 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.moment1AboutMean} using
- * {@code stats.mean} and {@code stats.size}.
+ * {@link Op} to calculate the {@code stats.moment1AboutMean}
+ * <p>
+ * Note that by definition &Sigma;(x<sub>i</sub>-&mu;)=0, thus the output of the
+ * Op <b>must</b> be 0.
  * 
  * @author Daniel Seebacher (University of Konstanz)
  * @author Christian Dietz (University of Konstanz)
+ * @author Gabriel Selzer
  * @param <I> input type
  * @param <O> output type
  */
@@ -51,28 +56,10 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "iterableInput")
 @Parameter(key = "moment1AboutMean", itemIO = ItemIO.BOTH)
 public class DefaultMoment1AboutMean<I extends RealType<I>, O extends RealType<O>>
-	implements Computers.Arity1<Iterable<I>, O>
+	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {
-
-	@OpDependency(name = "stats.mean")
-	private Computers.Arity1<Iterable<I>, O> meanComputer;
-	@OpDependency(name = "stats.size")
-	private Computers.Arity1<Iterable<I>, O> sizeComputer;
-
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
-		final O mean = output.createVariable();
-		meanComputer.compute(input, mean);
-		final O size = output.createVariable();
-		sizeComputer.compute(input, size);
-
-		double res = 0;
-		double m = mean.getRealDouble();
-		for (final I in : input) {
-			final double val = in.getRealDouble() - m;
-			res += val;
-		}
-
-		output.setReal(res / size.getRealDouble());
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
+		output.setZero();
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment4AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment4AboutMean.java
@@ -29,8 +29,10 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
@@ -42,38 +44,22 @@ import org.scijava.struct.ItemIO;
  * {@link Op} to calculate the {@code stats.moment4AboutMean} using
  * {@code stats.mean} and {@code stats.size}.
  * 
- * @author Daniel Seebacher (University of Konstanz)
- * @author Christian Dietz (University of Konstanz)
+ * @author Gabriel Selzer
  * @param <I>
  *            input type
  * @param <O>
  *            output type
  */
-@Plugin(type = Op.class, name = "stats.moment4AboutMean")
+@Plugin(type = Op.class, name = "stats.moment4AboutMean", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
 @Parameter(key = "moment4AboutMean", itemIO = ItemIO.BOTH)
-public class DefaultMoment4AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
+public class DefaultMoment4AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
-	@OpDependency(name = "stats.mean")
-	private Computers.Arity1<Iterable<I>, O> meanComputer;
-	@OpDependency(name = "stats.size")
-	private Computers.Arity1<Iterable<I>, O> sizeComputer;
+	@OpDependency(name = "stats.momentNAboutMean")
+	private Computers.Arity2<RandomAccessibleInterval<I>, Integer, O> momentComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
-
-		final O mean = output.createVariable();
-		meanComputer.compute(input, mean);
-		final O size = output.createVariable();
-		sizeComputer.compute(input, size);
-
-		double res = 0;
-		final double m = mean.getRealDouble();
-		for (final I in : input) {
-			final double val = in.getRealDouble() - m;
-			res += val * val * val * val;
-		}
-
-		output.setReal(res / size.getRealDouble());
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
+		momentComputer.compute(input, 4, output);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSize.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.Interval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.core.Op;
@@ -38,28 +39,23 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.size}.
+ * {@link Op} to calculate the {@code stats.size} of an {@link Interval}.
  * 
- * @author Daniel Seebacher (University of Konstanz)
- * @author Christian Dietz (University of Konstanz)
+ * @author Gabriel Selzer
  * @param <I> input type
  * @param <O> output type
  */
 @Plugin(type = Op.class, name = "stats.size")
-@Parameter(key = "iterableInput")
+@Parameter(key = "interval")
 @Parameter(key = "size", itemIO = ItemIO.BOTH)
 public class DefaultSize<I extends RealType<I>, O extends RealType<O>> 
-	implements Computers.Arity1<Iterable<I>, O>
+	implements Computers.Arity1<Interval, O>
 {
-
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
-		double size = 0;
-
-		for (@SuppressWarnings("unused") final I i : input) {
-			size++;
+	public void compute(final Interval input, final O output) {
+		output.setOne();
+		for(int i = 0; i < input.numDimensions(); i++) {
+			output.mul(input.dimension(i));
 		}
-
-		output.setReal(size);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSkewness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSkewness.java
@@ -29,6 +29,7 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
@@ -52,15 +53,15 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.skewness")
 @Parameter(key = "iterableInput")
 @Parameter(key = "skewness", itemIO = ItemIO.BOTH)
-public class DefaultSkewness<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
+public class DefaultSkewness<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.moment3AboutMean")
-	private Computers.Arity1<Iterable<I>, O> moment3AboutMeanComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> moment3AboutMeanComputer;
 	@OpDependency(name = "stats.stdDev")
-	private Computers.Arity1<Iterable<I>, O> stdDevComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> stdDevComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
 		final O moment3 = output.createVariable();
 		moment3AboutMeanComputer.compute(input, moment3);
 		final O stdDev = output.createVariable();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultStandardDeviation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultStandardDeviation.java
@@ -29,8 +29,10 @@
 
 package net.imagej.ops2.stats;
 
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
+import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
@@ -42,25 +44,28 @@ import org.scijava.struct.ItemIO;
  * {@link Op} to calculate the {@code stats.stdDev} using
  * {@code stats.variance}.
  * 
- * @author Daniel Seebacher (University of Konstanz)
- * @author Christian Dietz (University of Konstanz)
- * @param <I>
- *            input type
- * @param <O>
- *            output type
+ * @author Gabriel Selzer
+ * @param <I> input type
+ * @param <O> output type
  */
-@Plugin(type = Op.class, name = "stats.stdDev")
-@Parameter(key = "iteableInput")
+@Plugin(type = Op.class, name = "stats.stdDev", priority = Priority.HIGH)
+@Parameter(key = "raiInput")
 @Parameter(key = "stdDev", itemIO = ItemIO.BOTH)
 public class DefaultStandardDeviation<I extends RealType<I>, O extends RealType<O>>
-		implements Computers.Arity1<Iterable<I>, O> {
+	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
+{
 
 	@OpDependency(name = "stats.variance")
-	private Computers.Arity1<Iterable<I>, O> varianceComputer;
+	private Computers.Arity1<RandomAccessibleInterval<I>, O> varianceComputer;
+
+	@OpDependency(name = "math.sqrt")
+	private Computers.Arity1<O, O> sqrtComputer;
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
-		varianceComputer.compute(input, output);
+	public void compute(final RandomAccessibleInterval<I> input, final O output) {
+		O variance = output.createVariable();
+		varianceComputer.compute(input, variance);
+		sqrtComputer.compute(variance, output);
 	}
 
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfInverses.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfInverses.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.sumOfInverses", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
 @Parameter(key = "sumOfInverses", itemIO = ItemIO.BOTH)
-public class DefaultSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
+public class DefaultSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity2<RandomAccessibleInterval<I>, O, O> {
 	
 	@OpDependency(name = "create.img")
 	private BiFunction<Dimensions, O, RandomAccessibleInterval<O>> imgCreator;
@@ -69,11 +69,11 @@ public class DefaultSumOfInverses<I extends RealType<I>, O extends RealType<O>> 
 	private Computers.Arity1<RandomAccessibleInterval<O>, O> sumOp;
 
 	@Override
-	public void compute(final RandomAccessibleInterval<I> input, final O output) {
+	public void compute(final RandomAccessibleInterval<I> input, final O dbzValue, final O output) {
 		RandomAccessibleInterval<O> tmpImg = imgCreator.apply(input, output);
 		//TODO: Can we lift this? Would require making a RAI of Doubles.
 		LoopBuilder.setImages(input, tmpImg).multiThreaded().forEachPixel((inPixel, outPixel) -> {
-			reciprocalOp.compute(inPixel, Double.POSITIVE_INFINITY, outPixel);
+			reciprocalOp.compute(inPixel, dbzValue.getRealDouble(), outPixel);
 		});
 		sumOp.compute(tmpImg, output);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMin.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMin.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  * @param <T>
  *            input type
  */
-@Plugin(type = Op.class, name = "stats.min", priority = Priority.VERY_HIGH)
+@Plugin(type = Op.class, name = "stats.min")
 @Parameter(key = "iterableInput")
 @Parameter(key = "min", itemIO = ItemIO.BOTH)
 public class IterableMin<T extends RealType<T>> implements Computers.Arity1<Iterable<T>, T> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSize.java
@@ -29,7 +29,6 @@
 
 package net.imagej.ops2.stats;
 
-import net.imglib2.IterableInterval;
 import net.imglib2.type.numeric.RealType;
 
 import org.scijava.Priority;
@@ -40,23 +39,28 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.size} directly.
+ * {@link Op} to calculate the {@code stats.size}.
  * 
  * @author Daniel Seebacher (University of Konstanz)
  * @author Christian Dietz (University of Konstanz)
- * @param <I>
- *            input type
- * @param <O>
- *            output type
+ * @param <I> input type
+ * @param <O> output type
  */
-@Plugin(type = Op.class, name = "stats.size", priority = Priority.VERY_HIGH)
+@Plugin(type = Op.class, name = "stats.size", priority = Priority.LOW)
 @Parameter(key = "iterableInput")
 @Parameter(key = "size", itemIO = ItemIO.BOTH)
-public class IISize<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<IterableInterval<I>, O> {
+public class IterableSize<I extends RealType<I>, O extends RealType<O>> 
+	implements Computers.Arity1<Iterable<I>, O>
+{
 
 	@Override
-	public void compute(final IterableInterval<I> input, final O output) {
-		output.setReal(input.size());
-	}
+	public void compute(final Iterable<I> input, final O output) {
+		double size = 0;
 
+		for (@SuppressWarnings("unused") final I i : input) {
+			size++;
+		}
+		
+		output.setReal(size);
+	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableStandardDeviation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableStandardDeviation.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  * @param <O>
  *            output type
  */
-@Plugin(type = Op.class, name = "stats.stdDev", priority = Priority.VERY_HIGH)
+@Plugin(type = Op.class, name = "stats.stdDev")
 @Parameter(key = "iterableInput")
 @Parameter(key = "stdDev", itemIO = ItemIO.BOTH)
 public class IterableStandardDeviation<I extends RealType<I>, O extends RealType<O>>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSum.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSum.java
@@ -29,13 +29,8 @@
 
 package net.imagej.ops2.stats;
 
-import java.util.List;
-
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.numeric.RealType;
 
-import org.scijava.Priority;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
@@ -44,31 +39,26 @@ import org.scijava.struct.ItemIO;
 
 /**
  * {@link Op} to calculate the {@code stats.sum}.
- * 
- * @author Gabriel Selzer
+ *
+ * @author Daniel Seebacher (University of Konstanz)
+ * @author Christian Dietz (University of Konstanz)
  * @param <I> input type
  * @param <O> output type
  */
-@Plugin(type = Op.class, name = "stats.sum", priority = Priority.HIGH)
-@Parameter(key = "raiInput")
+@Plugin(type = Op.class, name = "stats.sum")
+@Parameter(key = "iterableInput")
 @Parameter(key = "sum", itemIO = ItemIO.BOTH)
-public class DefaultSum<I extends RealType<I>, O extends RealType<O>> implements
-	Computers.Arity1<RandomAccessibleInterval<I>, O>
+public class IterableSum<I extends RealType<I>, O extends RealType<O>>
+	implements Computers.Arity1<Iterable<I>, O>
 {
 
 	@Override
-	public void compute(final RandomAccessibleInterval<I> input, final O output) {
-		output.setZero();
-		List<O> chunkSums = LoopBuilder.setImages(input).multiThreaded()
-			.forEachChunk(chunk -> {
-				O chunkSum = output.createVariable();
-				chunkSum.setZero();
-				chunk.forEachPixel(pixel -> chunkSum.setReal(chunkSum.getRealDouble() +
-					pixel.getRealDouble()));
-				return chunkSum;
-			});
+	public void compute(final Iterable<I> input, final O output) {
+		double sum = 0;
+		for (final I in : input) {
+			sum += in.getRealDouble();
+		}
 
-		for (O chunkSum : chunkSums)
-			output.add(chunkSum);
+		output.setReal(sum);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfInverses.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfInverses.java
@@ -42,6 +42,7 @@ import org.scijava.struct.ItemIO;
  * 
  * @author Daniel Seebacher (University of Konstanz)
  * @author Christian Dietz (University of Konstanz)
+ * @author Gabriel Selzer
  * @param <I>
  *            input type
  * @param <O>
@@ -50,16 +51,21 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.sumOfInverses")
 @Parameter(key = "iterableInput")
 @Parameter(key = "sumOfInverses", itemIO = ItemIO.BOTH)
-public class IterableSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
+public class IterableSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity2<Iterable<I>, O, O> {
 
 	@Override
-	public void compute(final Iterable<I> input, final O output) {
+	public void compute(final Iterable<I> input, final O dbzValue,
+		final O output)
+	{
 		double res = 0.0;
 		for (final I in : input) {
 			double inVal = in.getRealDouble();
-			if (inVal == 0d) res += Double.POSITIVE_INFINITY;
-			if (inVal == -0d) res += Double.NEGATIVE_INFINITY;
-			res += 1.0d / in.getRealDouble();
+			if (inVal == 0d) {
+				res += dbzValue.getRealDouble();
+			}
+			else {
+				res += 1.0d / in.getRealDouble();
+			}
 		}
 		output.setReal(res);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfLogs.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfLogs.java
@@ -29,16 +29,8 @@
 
 package net.imagej.ops2.stats;
 
-import java.util.function.BiFunction;
-
-import net.imglib2.Dimensions;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.Img;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.real.DoubleType;
 
-import org.scijava.Priority;
-import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
@@ -48,30 +40,24 @@ import org.scijava.struct.ItemIO;
 /**
  * {@link Op} to calculate the {@code stats.sumOfLogs}.
  * 
- * @author Gabriel Selzer
+ * @author Daniel Seebacher (University of Konstanz)
+ * @author Christian Dietz (University of Konstanz)
  * @param <I>
  *            input type
  * @param <O>
  *            output type
  */
-@Plugin(type = Op.class, name = "stats.sumOfLogs", priority = Priority.HIGH)
-@Parameter(key = "raiInput")
+@Plugin(type = Op.class, name = "stats.sumOfLogs")
+@Parameter(key = "iterableInput")
 @Parameter(key = "sumOfLogs", itemIO = ItemIO.BOTH)
-public class DefaultSumOfLogs<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
-	
-	@OpDependency(name = "create.img")
-	private BiFunction<Dimensions, DoubleType, RandomAccessibleInterval<DoubleType>> imgCreator;
-	
-	@OpDependency(name = "math.log")
-	private Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<DoubleType>> logOp;
-	
-	@OpDependency(name = "stats.sum")
-	private Computers.Arity1<RandomAccessibleInterval<DoubleType>, O> sumOp;
+public class IterableSumOfLogs<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override
-	public void compute(final RandomAccessibleInterval<I> input, final O output) {
-		RandomAccessibleInterval<DoubleType> logImg = imgCreator.apply(input, new DoubleType());
-		logOp.compute(input, logImg);
-		sumOp.compute(logImg, output);
+	public void compute(final Iterable<I> input, final O output) {
+		double res = 0.0;
+		for (final I in : input) {
+			res += Math.log(in.getRealDouble());
+		}
+		output.setReal(res);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfSquares.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfSquares.java
@@ -29,14 +29,8 @@
 
 package net.imagej.ops2.stats;
 
-import java.util.function.BiFunction;
-
-import net.imglib2.Dimensions;
-import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
-import org.scijava.Priority;
-import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
@@ -44,32 +38,27 @@ import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
- * {@link Op} to calculate the {@code stats.sumOfSquares}. Leans on other Ops.
+ * {@link Op} to calculate the {@code stats.sumOfSquares}.
  * 
- * @author Gabriel Selzer
+ * @author Daniel Seebacher (University of Konstanz)
+ * @author Christian Dietz (University of Konstanz)
  * @param <I> input type
  * @param <O> output type
  */
-@Plugin(type = Op.class, name = "stats.sumOfSquares", priority = Priority.HIGH)
-@Parameter(key = "raiInput")
+@Plugin(type = Op.class, name = "stats.sumOfSquares")
+@Parameter(key = "iterableInput")
 @Parameter(key = "sumOfSquares", itemIO = ItemIO.BOTH)
-public class DefaultSumOfSquares<I extends RealType<I>, O extends RealType<O>>
-	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
+public class IterableSumOfSquares<I extends RealType<I>, O extends RealType<O>>
+	implements Computers.Arity1<Iterable<I>, O>
 {
 
-	@OpDependency(name = "create.img")
-	private BiFunction<Dimensions, O, RandomAccessibleInterval<O>> imgCreator;
-
-	@OpDependency(name = "math.sqr")
-	private Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> sqrOp;
-
-	@OpDependency(name = "stats.sum")
-	private Computers.Arity1<RandomAccessibleInterval<O>, O> sumOp;
-
 	@Override
-	public void compute(final RandomAccessibleInterval<I> input, final O output) {
-		RandomAccessibleInterval<O> tmpImg = imgCreator.apply(input, output);
-		sqrOp.compute(input, tmpImg);
-		sumOp.compute(tmpImg, output);
+	public void compute(final Iterable<I> input, final O output) {
+		double res = 0.0;
+		for (final I in : input) {
+			final double tmp = in.getRealDouble();
+			res += tmp * tmp;
+		}
+		output.setReal(res);
 	}
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableVariance.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  *      "https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm">
  *      Wikipedia</a>
  */
-@Plugin(type = Op.class, name = "stats.variance", priority = Priority.VERY_HIGH)
+@Plugin(type = Op.class, name = "stats.variance")
 @Parameter(key = "iterableInput")
 @Parameter(key = "variance", itemIO = ItemIO.BOTH)
 public class IterableVariance<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/fill/FillTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/fill/FillTest.java
@@ -31,12 +31,15 @@ package net.imagej.ops2.image.fill;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.imagej.ops2.AbstractOpTest;
-import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.type.numeric.integer.ByteType;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,19 +49,28 @@ import org.junit.jupiter.api.Test;
  */
 public class FillTest extends AbstractOpTest {
 
-	private Img<ByteType> out;
-
-	@BeforeEach
-	public void setUpMethod() {
-		super.setUp();
-		out = ArrayImgs.bytes(10, 10);
-	}
+	private ArrayImg<ByteType, ByteArray> out;
 
 	@Test
-	public void testDefaultFill() {
+	public void testFillRAI() {
+		out = ArrayImgs.bytes(10, 10);
 		ops.op("image.fill").input(new ByteType((byte) 10)).output(out).compute();
 
 		for (ByteType px : out)
 			assertEquals(px.get(), 10);
+	}
+
+	@Test
+	public void testDefaultFill() {
+		List<ByteType> list = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			list.add(new ByteType((byte) 5));
+		}
+
+		ops.op("image.fill").input(new ByteType((byte) 20)).output(list).compute();
+
+		for (ByteType px : list)
+			assertEquals(px.get(), 20);
+
 	}
 }

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
@@ -34,10 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import net.imagej.ops2.AbstractOpTest;
 import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.util.Pair;
+import net.imglib2.view.Views;
 
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.core.builder.OpBuilder;
@@ -70,15 +71,15 @@ public class NormalizeTest extends AbstractOpTest {
 		final ByteType min = new ByteType((byte) in.firstElement().getMinValue());
 		final ByteType max = new ByteType((byte) in.firstElement().getMaxValue());
 
-		final IterableInterval<ByteType> lazyOut = ops.op("image.normalize").input(in)
-				.outType(new Nil<IterableInterval<ByteType>>() {}).apply();
-		final IterableInterval<ByteType> notLazyOut = ops.op("image.normalize")
-				.input(in, minMax.getA(), minMax.getB(), min, max).outType(new Nil<IterableInterval<ByteType>>() {})
+		final RandomAccessibleInterval<ByteType> lazyOut = ops.op("image.normalize").input(in)
+				.outType(new Nil<RandomAccessibleInterval<ByteType>>() {}).apply();
+		final RandomAccessibleInterval<ByteType> notLazyOut = ops.op("image.normalize")
+				.input(in, minMax.getA(), minMax.getB(), min, max).outType(new Nil<RandomAccessibleInterval<ByteType>>() {})
 				.apply();
 
 		final Cursor<ByteType> outCursor = out.cursor();
-		final Cursor<ByteType> lazyCursor = lazyOut.cursor();
-		final Cursor<ByteType> notLazyCursor = notLazyOut.cursor();
+		final Cursor<ByteType> lazyCursor = Views.flatIterable(lazyOut).cursor();
+		final Cursor<ByteType> notLazyCursor = Views.flatIterable(notLazyOut).cursor();
 		while (outCursor.hasNext()) {
 			assertEquals(outCursor.next().get(), lazyCursor.next().get());
 			assertEquals(outCursor.get().get(), notLazyCursor.next().get());

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigmaTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigmaTest.java
@@ -78,7 +78,7 @@ public class WatershedBinarySingleSigmaTest extends AbstractOpTest {
 		ops.op("image.distanceTransform").input(thresholdedImg, es).output(distMap).compute();
 		final RandomAccessibleInterval<FloatType> invertedDistMap = ops.op("create.img").input(distMap, new FloatType())
 				.outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
-		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap)).compute();
+		ops.op("image.invert").input(distMap).output(invertedDistMap).compute();
 
 		Double sigma = 3.0;
 		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img").input(invertedDistMap, new FloatType())

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinaryTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedBinaryTest.java
@@ -81,7 +81,7 @@ public class WatershedBinaryTest extends AbstractOpTest {
 		final RandomAccessibleInterval<FloatType> invertedDistMap = ops.op("create.img")
 				.input(distMap, new FloatType()).outType(new Nil<RandomAccessibleInterval<FloatType>>() {}).apply();
 		double[] sigma = { 3.0, 3.0, 0.0 };
-		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(invertedDistMap))
+		ops.op("image.invert").input(distMap).output(invertedDistMap)
 				.compute();
 
 		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img")

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/watershed/WatershedTest.java
@@ -90,8 +90,7 @@ public class WatershedTest extends AbstractOpTest {
 			"create.img").input(distMap, new FloatType()).outType(
 				new Nil<RandomAccessibleInterval<FloatType>>()
 				{}).apply();
-		ops.op("image.invert").input(Views.iterable(distMap)).output(Views.iterable(
-			invertedDistMap)).compute();
+		ops.op("image.invert").input(distMap).output(invertedDistMap).compute();
 		final RandomAccessibleInterval<FloatType> gauss = ops.op("create.img")
 			.input(invertedDistMap, new FloatType()).outType(
 				new Nil<RandomAccessibleInterval<FloatType>>()

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
@@ -29,7 +29,7 @@
 
 package net.imagej.ops2.imagemoments;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.scijava.testutil.AssertClose.assertCloseEnough;
 
 import java.util.Random;
 
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
  */
 public class ImageMomentsTest extends AbstractOpTest {
 
-	private static final double EPSILON = 1e-8;
+	private static final int EPSILON_EXP = -8;
 	private static Img<UnsignedByteType> img;
 
 	@BeforeAll
@@ -81,10 +81,10 @@ public class ImageMomentsTest extends AbstractOpTest {
 		ops.op("imageMoments.moment01").input(img).output(moment01).compute();
 		DoubleType moment11 = new DoubleType();
 		ops.op("imageMoments.moment11").input(img).output(moment11).compute();
-		assertEquals(1277534.0, moment00.getRealDouble(), EPSILON, "ImageMoments.Moment00");
-		assertEquals(6.3018047E7, moment10.getRealDouble(), EPSILON, "ImageMoments.Moment10");
-		assertEquals(6.3535172E7, moment01.getRealDouble(), EPSILON, "ImageMoments.Moment01");
-		assertEquals(3.12877962E9, moment11.getRealDouble(), EPSILON, "ImageMoments.Moment11");
+		assertCloseEnough(1277534.0, moment00.getRealDouble(), EPSILON_EXP, "ImageMoments.Moment00");
+		assertCloseEnough(6.3018047E7, moment10.getRealDouble(), EPSILON_EXP, "ImageMoments.Moment10");
+		assertCloseEnough(6.3535172E7, moment01.getRealDouble(), EPSILON_EXP, "ImageMoments.Moment01");
+		assertCloseEnough(3.12877962E9, moment11.getRealDouble(), EPSILON_EXP, "ImageMoments.Moment11");
 	}
 
 	/**
@@ -92,34 +92,34 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testCentralMoments() {
-		assertEquals(-5275876.956702709,
+		assertCloseEnough(-5275876.956702709,
 				ops.op("imageMoments.centralMoment11").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment11");
-		assertEquals(1.069446988026993E9,
+				EPSILON_EXP, "ImageMoments.CentralMoment11");
+		assertCloseEnough(1.069446988026993E9,
 				ops.op("imageMoments.centralMoment02").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment02");
-		assertEquals(1.0585772432642086E9,
+				EPSILON_EXP, "ImageMoments.CentralMoment02");
+		assertCloseEnough(1.0585772432642086E9,
 				ops.op("imageMoments.centralMoment20").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment20");
-		assertEquals(5478324.271281064,
+				EPSILON_EXP, "ImageMoments.CentralMoment20");
+		assertCloseEnough(5478324.271281064,
 				ops.op("imageMoments.centralMoment12").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment12");
-		assertEquals(-2.163645568548715E8,
+				EPSILON_EXP, "ImageMoments.CentralMoment12");
+		assertCloseEnough(-2.163645568548715E8,
 				ops.op("imageMoments.centralMoment21").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment21");
-		assertEquals(1.735560232991217E8,
+				EPSILON_EXP, "ImageMoments.CentralMoment21");
+		assertCloseEnough(1.735560232991217E8,
 				ops.op("imageMoments.centralMoment30").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment30");
-		assertEquals(-4.0994213161155105E8,
+				EPSILON_EXP, "ImageMoments.CentralMoment30");
+		assertCloseEnough(-4.0994213161155105E8,
 				ops.op("imageMoments.centralMoment03").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
-				EPSILON, "ImageMoments.CentralMoment03");
+				EPSILON_EXP, "ImageMoments.CentralMoment03");
 	}
 
 	/**
@@ -127,40 +127,40 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testNormalizedCentralMoments() {
-		assertEquals(-3.2325832933879204E-6,
+		assertCloseEnough(-3.2325832933879204E-6,
 				ops.op("imageMoments.normalizedCentralMoment11").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment11");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment11");
 
-		assertEquals(6.552610106398286E-4,
+		assertCloseEnough(6.552610106398286E-4,
 				ops.op("imageMoments.normalizedCentralMoment02").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment02");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment02");
 
-		assertEquals(6.486010078361372E-4,
+		assertCloseEnough(6.486010078361372E-4,
 				ops.op("imageMoments.normalizedCentralMoment20").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment20");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment20");
 
-		assertEquals(2.969727272701925E-9,
+		assertCloseEnough(2.969727272701925E-9,
 				ops.op("imageMoments.normalizedCentralMoment12").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment12");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment12");
 
-		assertEquals(-1.1728837022440002E-7,
+		assertCloseEnough(-1.1728837022440002E-7,
 				ops.op("imageMoments.normalizedCentralMoment21").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment21");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment21");
 
-		assertEquals(9.408242926327751E-8,
+		assertCloseEnough(9.408242926327751E-8,
 				ops.op("imageMoments.normalizedCentralMoment30").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment30");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment30");
 
-		assertEquals(-2.22224218245127E-7,
+		assertCloseEnough(-2.22224218245127E-7,
 				ops.op("imageMoments.normalizedCentralMoment03").input(img).outType(DoubleType.class)
 						.apply().getRealDouble(),
-				EPSILON, "ImageMoments.NormalizedCentralMoment03");
+				EPSILON_EXP, "ImageMoments.NormalizedCentralMoment03");
 	}
 
 	/*
@@ -168,26 +168,26 @@ public class ImageMomentsTest extends AbstractOpTest {
 	 */
 	@Test
 	public void testHuMoments() {
-		assertEquals(0.001303862018475966, ops.op("imageMoments.huMoment1").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(0.001303862018475966, ops.op("imageMoments.huMoment1").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment1");
-		assertEquals(8.615401633994056e-11, ops.op("imageMoments.huMoment2").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(8.615401633994056e-11, ops.op("imageMoments.huMoment2").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment2");
-		assertEquals(2.406124306990366e-14, ops.op("imageMoments.huMoment3").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(2.406124306990366e-14, ops.op("imageMoments.huMoment3").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment3");
-		assertEquals(1.246879188175627e-13, ops.op("imageMoments.huMoment4").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(1.246879188175627e-13, ops.op("imageMoments.huMoment4").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment4");
-		assertEquals(-6.610443880647384e-27, ops.op("imageMoments.huMoment5").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(-6.610443880647384e-27, ops.op("imageMoments.huMoment5").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment5");
-		assertEquals(1.131019166855569e-18, ops.op("imageMoments.huMoment6").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(1.131019166855569e-18, ops.op("imageMoments.huMoment6").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment6");
-		assertEquals(1.716256940536518e-27, ops.op("imageMoments.huMoment7").input(img)
-			.outType(DoubleType.class).apply().getRealDouble(), EPSILON,
+		assertCloseEnough(1.716256940536518e-27, ops.op("imageMoments.huMoment7").input(img)
+			.outType(DoubleType.class).apply().getRealDouble(), EPSILON_EXP,
 			"ImageMoments.HuMoment7");
 	}
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/imagemoments/ImageMomentsTest.java
@@ -96,27 +96,27 @@ public class ImageMomentsTest extends AbstractOpTest {
 				ops.op("imageMoments.centralMoment11").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment11");
-		assertEquals(1.0694469880269902E9,
+		assertEquals(1.069446988026993E9,
 				ops.op("imageMoments.centralMoment02").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment02");
-		assertEquals(1.0585772432642114E9,
+		assertEquals(1.0585772432642086E9,
 				ops.op("imageMoments.centralMoment20").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment20");
-		assertEquals(5478324.271281097,
+		assertEquals(5478324.271281064,
 				ops.op("imageMoments.centralMoment12").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment12");
-		assertEquals(-2.1636455685489437E8,
+		assertEquals(-2.163645568548715E8,
 				ops.op("imageMoments.centralMoment21").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment21");
-		assertEquals(1.7355602329912126E8,
+		assertEquals(1.735560232991217E8,
 				ops.op("imageMoments.centralMoment30").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment30");
-		assertEquals(-4.099421316116555E8,
+		assertEquals(-4.0994213161155105E8,
 				ops.op("imageMoments.centralMoment03").input(img).outType(DoubleType.class).apply()
 						.getRealDouble(),
 				EPSILON, "ImageMoments.CentralMoment03");

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
@@ -242,6 +242,7 @@ public class StatisticsTest extends AbstractOpTest {
 	@Test
 	public void testQuantile() {
 		final DoubleType quantile = new DoubleType();
+		UnsignedByteType test = new UnsignedByteType();
 		ops.op("stats.quantile").input(randomlyFilledImg, 0.5d).output(quantile).compute();
 		Assertions.assertEquals(128d, quantile.getRealDouble(), 0.00001d, "0.5-th Quantile");
 	}
@@ -256,8 +257,8 @@ public class StatisticsTest extends AbstractOpTest {
 	@Test
 	public void testSumOfInverses() {
 		final DoubleType sumOfInverses = new DoubleType();
-		ops.op("stats.sumOfInverses").input(randomlyFilledImg).output(sumOfInverses).compute();
-		Assertions.assertEquals(Double.POSITIVE_INFINITY, sumOfInverses.getRealDouble(), 0.00001d, "Sum Of Inverses");
+		ops.op("stats.sumOfInverses").input(randomlyFilledImg, new DoubleType(0)).output(sumOfInverses).compute();
+		Assertions.assertEquals(236.60641289378648, sumOfInverses.getRealDouble(), 0.00001d, "Sum Of Inverses");
 	}
 
 	@Test

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
@@ -171,7 +171,7 @@ public class StatisticsTest extends AbstractOpTest {
 
 	@Test
 	public void testSum() {
-		final DoubleType sum = new DoubleType();
+		final FloatType sum = new FloatType();
 		ops.op("stats.sum").input(randomlyFilledImg).output(sum).compute();
 		Assertions.assertEquals(1277534.0, sum.getRealDouble(), 0.00001d, "Sum");
 	}

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -50,7 +50,7 @@ public class AssertClose {
 	 * @param actual
 	 * @param deltaExp
 	 */
-	public static void asesrtCloseEnough(double expected, double actual,
+	public static void assertCloseEnough(double expected, double actual,
 		int deltaExp)
 	{
 		double numerator = Math.abs(expected);
@@ -68,7 +68,7 @@ public class AssertClose {
 	 * @param deltaExp
 	 * @param message
 	 */
-	public static void asesrtCloseEnough(double expected, double actual,
+	public static void assertCloseEnough(double expected, double actual,
 		int deltaExp, String message)
 	{
 		double numerator = Math.abs(expected);

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -44,19 +44,19 @@ public class AssertClose {
 
 	/**
 	 * <em>Assert</em> that {@code expected} and {@code actual} are equal within
-	 * the non-negative delta {@code 10^epsilonExp}.
+	 * the non-negative delta {@code 10^deltaExp}.
 	 * 
 	 * @param expected
 	 * @param actual
-	 * @param epsilonExp
+	 * @param deltaExp
 	 */
 	public static void asesrtCloseEnough(double expected, double actual,
-		int epsilonExp)
+		int deltaExp)
 	{
 		double numerator = Math.abs(expected);
-		double denominator = Math.pow(10., epsilonExp);
-		double epsilon = numerator / denominator;
-		assertEquals(expected, actual, epsilon);
+		double denominator = Math.pow(10., deltaExp);
+		double delta = numerator / denominator;
+		assertEquals(expected, actual, delta);
 	}
 
 }

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -59,4 +59,22 @@ public class AssertClose {
 		assertEquals(expected, actual, delta);
 	}
 
+	/**
+	 * <em>Assert</em> that {@code expected} and {@code actual} are equal within
+	 * the non-negative delta {@code 10^deltaExp}.
+	 *
+	 * @param expected
+	 * @param actual
+	 * @param deltaExp
+	 * @param message
+	 */
+	public static void asesrtCloseEnough(double expected, double actual,
+		int deltaExp, String message)
+	{
+		double numerator = Math.abs(expected);
+		double denominator = Math.pow(10., deltaExp);
+		double delta = numerator / denominator;
+		assertEquals(expected, actual, delta, message);
+	}
+
 }

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -48,14 +48,14 @@ public class AssertClose {
 	 * 
 	 * @param expected
 	 * @param actual
-	 * @param deltaExp
+	 * @param order - the order of magnitude of the delta
 	 */
 	public static void assertCloseEnough(double expected, double actual,
-		int deltaExp)
+		int order)
 	{
-		double numerator = Math.abs(expected);
-		double denominator = Math.pow(10., deltaExp);
-		double delta = numerator / denominator;
+		double significand = Math.abs(expected);
+		double exponential = Math.pow(10., order);
+		double delta = significand * exponential;
 		assertEquals(expected, actual, delta);
 	}
 
@@ -65,15 +65,15 @@ public class AssertClose {
 	 *
 	 * @param expected
 	 * @param actual
-	 * @param deltaExp
+	 * @param order - the order of magnitude of the delta
 	 * @param message
 	 */
 	public static void assertCloseEnough(double expected, double actual,
-		int deltaExp, String message)
+		int order, String message)
 	{
-		double numerator = Math.abs(expected);
-		double denominator = Math.pow(10., deltaExp);
-		double delta = numerator / denominator;
+		double significand = Math.abs(expected);
+		double exponential = Math.pow(10., order);
+		double delta = significand * exponential;
 		assertEquals(expected, actual, delta, message);
 	}
 

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -44,7 +44,7 @@ public class AssertClose {
 
 	/**
 	 * <em>Assert</em> that {@code expected} and {@code actual} are equal within
-	 * the non-negative delta {@code 10^deltaExp}.
+	 * the non-negative delta {@code |expected| * 10^deltaExp}.
 	 * 
 	 * @param expected
 	 * @param actual
@@ -61,7 +61,7 @@ public class AssertClose {
 
 	/**
 	 * <em>Assert</em> that {@code expected} and {@code actual} are equal within
-	 * the non-negative delta {@code 10^deltaExp}.
+	 * the non-negative delta {@code |expected| * 10^deltaExp}.
 	 *
 	 * @param expected
 	 * @param actual


### PR DESCRIPTION
This PR multithreads relevant Ops within imagej/imagej-ops2 using imglib2's [LoopBuilder](https://github.com/imglib/imglib2/blob/b33186acc75abb8292da9865b6d100fc0787644d/src/main/java/net/imglib2/loops/LoopBuilder.java#L91) utility. Viable candidates for this method must:
1. Operate on `RandomAccessibleInterval`s
2. Perform some per-pixel behavior. 
Note that many Ops operate on `IterableInterval`s; if it made sense, this PR refactored these Op to use `RAI`s instead. 

Many Ops could not use `LoopBuilder` themselves but underwent performance boosts as an `OpDependency` utilized `LoopBuilder`. Many of these Ops also underwent signature changes.