### PR TITLE
Clean up MatchingUtils

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralMean.java
@@ -55,13 +55,13 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.integralMean")
 @Parameter(key = "iterableInput")
 @Parameter(key = "integralMean", itemIO = ItemIO.BOTH)
-public class IntegralMean<I extends RealType<I>> implements Computers.Arity1<RectangleNeighborhood<Composite<I>>, DoubleType> {
+public class IntegralMean<I extends RealType<I>> implements Computers.Arity1<RectangleNeighborhood<? extends Composite<I>>, DoubleType> {
 
 	@Override
-	public void compute(final RectangleNeighborhood<Composite<I>> input, final DoubleType output) {
+	public void compute(final RectangleNeighborhood<? extends Composite<I>> input, final DoubleType output) {
 		// computation according to
 		// https://en.wikipedia.org/wiki/Summed_area_table
-		final IntegralCursor<Composite<I>> cursor = new IntegralCursor<>(input);
+		final IntegralCursor<? extends Composite<I>> cursor = new IntegralCursor<>(input);
 		final int dimensions = input.numDimensions();
 
 		// Compute \sum (-1)^{dim - ||cornerVector||_{1}} * I(x^{cornerVector})

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralVariance.java
@@ -56,13 +56,13 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "iterableInput")
 @Parameter(key = "integralVariance", itemIO = ItemIO.BOTH)
 public class IntegralVariance<I extends RealType<I>>
-		implements Computers.Arity1<RectangleNeighborhood<Composite<I>>, DoubleType> {
+		implements Computers.Arity1<RectangleNeighborhood<? extends Composite<I>>, DoubleType> {
 
 	@Override
-	public void compute(final RectangleNeighborhood<Composite<I>> input, final DoubleType output) {
+	public void compute(final RectangleNeighborhood<? extends Composite<I>> input, final DoubleType output) {
 		// computation according to
 		// https://en.wikipedia.org/wiki/Summed_area_table
-		final IntegralCursor<Composite<I>> cursorS1 = new IntegralCursor<>(input);
+		final IntegralCursor<? extends Composite<I>> cursorS1 = new IntegralCursor<>(input);
 		final int dimensions = input.numDimensions();
 
 		// Compute \sum (-1)^{dim - ||cornerVector||_{1}} * I(x^{cornerVector})

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
@@ -321,7 +321,7 @@ public final class ApplyThresholdMethodLocal {
 	private abstract static class AbstractApplyLocalHistogramBasedThreshold<T extends RealType<T>>
 		implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-				IterableInterval<BitType>> {
+				RandomAccessibleInterval<BitType>> {
 
 		// TODO: Once optional primary parameters are supported by the matching
 		// system, this can be made a unary function (drop integer parameter, which
@@ -339,7 +339,7 @@ public final class ApplyThresholdMethodLocal {
 		public void compute(final RandomAccessibleInterval<T> input,
 			final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			@Mutable final IterableInterval<BitType> output)
+			@Mutable final RandomAccessibleInterval<BitType> output)
 		{
 			if (thresholdOp == null) thresholdOp = getThresholdOp();
 			ApplyCenterAwareNeighborhoodBasedFilter.compute(input,

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
@@ -31,7 +31,6 @@
 package net.imagej.ops2.threshold.localBernsen;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -40,8 +39,6 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
@@ -62,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalBernsenThreshold<T extends RealType<T>> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	@OpDependency(name = "threshold.localBernsen")
 	private Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp;
@@ -72,7 +69,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> implements
 		final Shape inputNeighborhoodShape, final Double contrastThreshold,
 		final Double halfMaxValue,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, contrastThreshold, halfMaxValue,
 			outOfBoundsFactory, computeThresholdOp, output);
@@ -83,7 +80,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> implements
 		final Double contrastThreshold, final Double halfMaxValue,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, contrastThreshold,

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
@@ -31,7 +31,6 @@
 package net.imagej.ops2.threshold.localContrast;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -40,7 +39,6 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
@@ -58,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalContrastThreshold<T extends RealType<T>> implements
 	Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	@OpDependency(name = "threshold.localContrast")
 	private Computers.Arity2<Iterable<T>, T, BitType> computeThresholdOp;
@@ -67,7 +65,7 @@ public class LocalContrastThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -77,7 +75,7 @@ public class LocalContrastThreshold<T extends RealType<T>> implements
 		final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity2<Iterable<T>, T, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		ApplyCenterAwareNeighborhoodBasedFilter.compute(input,
 			inputNeighborhoodShape, outOfBoundsFactory, computeThresholdOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
@@ -41,7 +41,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
@@ -70,25 +69,17 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
-public class ComputeLocalMeanThresholdIntegral<T extends RealType<T>> implements
-	Computers.Arity3<RectangleNeighborhood<Composite<DoubleType>>, T, Double, BitType>
+public class ComputeLocalMeanThresholdIntegral<T extends RealType<T>, U extends RealType<U>> implements
+	Computers.Arity3<RectangleNeighborhood<? extends Composite<U>>, T, Double, BitType>
 {
 
 	@OpDependency(name = "stats.integralMean")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<U>>, DoubleType> integralMeanOp;
 
 	@Override
 	public void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
-		final T inputCenterPixel, final Double c, @Mutable final BitType output)
-	{
-		compute(inputNeighborhood, inputCenterPixel, c, integralMeanOp, output);
-	}
-
-	public static <T extends RealType<T>> void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
+		final RectangleNeighborhood<? extends Composite<U>> inputNeighborhood,
 		final T inputCenterPixel, final Double c,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp,
 		@Mutable final BitType output)
 	{
 		final DoubleType sum = new DoubleType();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
@@ -31,7 +31,6 @@
 package net.imagej.ops2.threshold.localMedian;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -40,8 +39,6 @@ import net.imglib2.type.numeric.RealType;
 
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
@@ -60,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalMedianThreshold<T extends RealType<T>> implements
 	Computers.Arity4<RandomAccessibleInterval<T>, Shape, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	@OpDependency(name = "threshold.localMedian")
 	private Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp;
@@ -69,7 +66,7 @@ public class LocalMedianThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, c, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -80,7 +77,7 @@ public class LocalMedianThreshold<T extends RealType<T>> implements
 		final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
@@ -31,7 +31,6 @@
 package net.imagej.ops2.threshold.localMidGrey;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Shape;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
@@ -41,8 +40,6 @@ import net.imglib2.type.numeric.RealType;
 import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
-import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
@@ -62,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalMidGreyThreshold<T extends RealType<T>> implements
 	Computers.Arity4<RandomAccessibleInterval<T>, Shape, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	@OpDependency(name = "threshold.localMidGrey")
 	private Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp;
@@ -71,7 +68,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, c, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -82,7 +79,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> implements
 		final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
@@ -71,32 +70,21 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "c")
 @Parameter(key = "k")
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
-public class ComputeLocalNiblackThresholdIntegral<T extends RealType<T>>
+public class ComputeLocalNiblackThresholdIntegral<T extends RealType<T>, U extends RealType<U>>
 	implements
-	Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType>
+	Computers.Arity4<RectangleNeighborhood<? extends Composite<U>>, T, Double, Double, BitType>
 {
 
 	@OpDependency(name = "stats.integralMean")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<U>>, DoubleType> integralMeanOp;
 
 	@OpDependency(name = "stats.integralVariance")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<U>>, DoubleType> integralVarianceOp;
 
 	@Override
 	public void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
+		final RectangleNeighborhood<? extends Composite<U>> inputNeighborhood,
 		final T inputCenterPixel, final Double c, final Double k,
-		@Mutable final BitType output)
-	{
-		compute(inputNeighborhood, inputCenterPixel, c, k, integralMeanOp,
-			integralVarianceOp, output);
-	}
-
-	public static <T extends RealType<T>> void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
-		final T inputCenterPixel, final Double c, final Double k,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp,
 		@Mutable final BitType output)
 	{
 		final DoubleType threshold = new DoubleType(0.0d);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
 import net.imagej.ops2.threshold.ApplyLocalThresholdIntegral;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
@@ -64,9 +63,9 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory", required = false)
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalNiblackThreshold<T extends RealType<T>> extends
-	ApplyLocalThresholdIntegral<T> implements
+	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	private static final int INTEGRAL_IMAGE_ORDER_1 = 1;
 	private static final int INTEGRAL_IMAGE_ORDER_2 = 2;
@@ -75,19 +74,22 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 	private Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdNonIntegralOp;
 
 	@OpDependency(name = "threshold.localNiblack")
-	private Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdIntegralOp;
+	private Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdIntegralOp;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c, final Double k,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
-		if (inputNeighborhoodShape instanceof RectangleShape &&
-			((RectangleShape) inputNeighborhoodShape).getSpan() > 2)
-		{
-			computeIntegral(input, (RectangleShape) inputNeighborhoodShape, c, k,
+		RectangleShape rShape = inputNeighborhoodShape instanceof RectangleShape
+			? (RectangleShape) inputNeighborhoodShape : null;
+		if (rShape != null && rShape.getSpan() > 2 && !rShape.isSkippingCenter()) {
+			// NB: under these conditions, the RectangleShape will produce
+			// RectangleNeighborhoods (which is needed to perform the computations via
+			// an IntegralImg).
+			computeIntegral(input, rShape, c, k,
 				outOfBoundsFactory, getIntegralImageOp(INTEGRAL_IMAGE_ORDER_1),
 				getIntegralImageOp(INTEGRAL_IMAGE_ORDER_2), computeThresholdIntegralOp,
 				output);
@@ -98,12 +100,12 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 		}
 	}
 
-	public static <T extends RealType<T>> void computeNonIntegral(
+	public void computeNonIntegral(
 		final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 		final Double c, final Double k,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, k, o);
@@ -112,18 +114,18 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 			parametrizedComputeThresholdOp, output);
 	}
 
-	public static <T extends RealType<T>> void computeIntegral(
+	public void computeIntegral(
 		final RandomAccessibleInterval<T> input,
 		final RectangleShape inputNeighborhoodShape, final Double c, final Double k,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<? extends RealType<?>>> integralImageOp,
-		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<? extends RealType<?>>> squareIntegralImageOp,
-		final Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
+		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> squareIntegralImageOp,
+		final Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
-		final Computers.Arity2<RectangleNeighborhood<Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
+		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, k, o);
-		ApplyLocalThresholdIntegral.compute(input, inputNeighborhoodShape,
+		compute(input, inputNeighborhoodShape,
 			outOfBoundsFactory, Arrays.asList(integralImageOp, squareIntegralImageOp),
 			parametrizedComputeThresholdOp, output);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
@@ -73,7 +72,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class ComputeLocalPhansalkarThresholdIntegral<T extends RealType<T>>
 	implements
-	Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType>
+	Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType>
 {
 
 	public static final double DEFAULT_K = 0.25;
@@ -83,26 +82,15 @@ public class ComputeLocalPhansalkarThresholdIntegral<T extends RealType<T>>
 	private static final double Q = 10.0;
 
 	@OpDependency(name = "stats.integralMean")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<DoubleType>>, DoubleType> integralMeanOp;
 
 	@OpDependency(name = "stats.integralVariance")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<DoubleType>>, DoubleType> integralVarianceOp;
 
 	@Override
 	public void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
-		final T inputCenterPixel, final Double k, final Double r,
-		@Mutable final BitType output)
-	{
-		compute(inputNeighborhood, inputCenterPixel, k, r, integralMeanOp,
-			integralVarianceOp, output);
-	}
-
-	public static <T extends RealType<T>> void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
+		final RectangleNeighborhood<? extends Composite<DoubleType>> inputNeighborhood,
 		final T inputCenterPixel, Double k, Double r,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp,
 		@Mutable final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 
 import net.imagej.ops2.filter.ApplyCenterAwareNeighborhoodBasedFilter;
 import net.imagej.ops2.threshold.ApplyLocalThresholdIntegral;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleNeighborhood;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
@@ -64,9 +63,9 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory", required = false)
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class LocalPhansalkarThreshold<T extends RealType<T>> extends
-	ApplyLocalThresholdIntegral<T> implements
+	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
-			IterableInterval<BitType>> {
+			RandomAccessibleInterval<BitType>> {
 
 	private static final int INTEGRAL_IMAGE_ORDER_1 = 1;
 	private static final int INTEGRAL_IMAGE_ORDER_2 = 2;
@@ -75,19 +74,22 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 	private Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdNonIntegralOp;
 
 	@OpDependency(name = "threshold.localPhansalkar")
-	private Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdIntegralOp;
+	private Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdIntegralOp;
 
 	@Override
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
-		if (inputNeighborhoodShape instanceof RectangleShape &&
-			((RectangleShape) inputNeighborhoodShape).getSpan() > 2)
-		{
-			computeIntegral(input, (RectangleShape) inputNeighborhoodShape, k, r,
+		RectangleShape rShape = inputNeighborhoodShape instanceof RectangleShape
+			? (RectangleShape) inputNeighborhoodShape : null;
+		if (rShape != null && rShape.getSpan() > 2 && !rShape.isSkippingCenter()) {
+			// NB: under these conditions, the RectangleShape will produce
+			// RectangleNeighborhoods (which is needed to perform the computations via
+			// an IntegralImg).
+			computeIntegral(input, rShape, k, r,
 				outOfBoundsFactory, getIntegralImageOp(INTEGRAL_IMAGE_ORDER_1),
 				getIntegralImageOp(INTEGRAL_IMAGE_ORDER_2), computeThresholdIntegralOp,
 				output);
@@ -98,12 +100,12 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 		}
 	}
 
-	public static <T extends RealType<T>> void computeNonIntegral(
+	public void computeNonIntegral(
 		final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 		final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);
@@ -112,18 +114,18 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 			parametrizedComputeThresholdOp, output);
 	}
 
-	public static <T extends RealType<T>> void computeIntegral(
+	public void computeIntegral(
 		final RandomAccessibleInterval<T> input,
 		final RectangleShape inputNeighborhoodShape, final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<? extends RealType<?>>> integralImageOp,
-		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<? extends RealType<?>>> squareIntegralImageOp,
-		final Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final IterableInterval<BitType> output)
+		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
+		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> squareIntegralImageOp,
+		final Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
+		@Mutable final RandomAccessibleInterval<BitType> output)
 	{
-		final Computers.Arity2<RectangleNeighborhood<Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
+		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);
-		ApplyLocalThresholdIntegral.compute(input, inputNeighborhoodShape,
+		compute(input, inputNeighborhoodShape,
 			outOfBoundsFactory, Arrays.asList(integralImageOp, squareIntegralImageOp),
 			parametrizedComputeThresholdOp, output);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.ops.function.Computers;
 import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
@@ -73,33 +72,22 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "output", itemIO = ItemIO.BOTH)
 public class ComputeLocalSauvolaThresholdIntegral<T extends RealType<T>>
 	implements
-	Computers.Arity4<RectangleNeighborhood<Composite<DoubleType>>, T, Double, Double, BitType>
+	Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType>
 {
 
 	public static final double DEFAULT_K = 0.5;
 	public static final double DEFAULT_R = 0.5;
 
 	@OpDependency(name = "stats.integralMean")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<DoubleType>>, DoubleType> integralMeanOp;
 
 	@OpDependency(name = "stats.integralVariance")
-	private Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp;
+	private Computers.Arity1<RectangleNeighborhood<? extends Composite<DoubleType>>, DoubleType> integralVarianceOp;
 
 	@Override
 	public void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
-		final T inputCenterPixel, final Double k, final Double r,
-		@Mutable final BitType output)
-	{
-		compute(inputNeighborhood, inputCenterPixel, k, r, integralMeanOp,
-			integralVarianceOp, output);
-	}
-
-	public static <T extends RealType<T>> void compute(
-		final RectangleNeighborhood<Composite<DoubleType>> inputNeighborhood,
+		final RectangleNeighborhood<? extends Composite<DoubleType>> inputNeighborhood,
 		final T inputCenterPixel, Double k, Double r,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralMeanOp,
-		final Computers.Arity1<RectangleNeighborhood<Composite<DoubleType>>, DoubleType> integralVarianceOp,
 		@Mutable final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/transform/Transforms.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/transform/Transforms.java
@@ -25,6 +25,7 @@ import net.imglib2.view.SubsampleIntervalView;
 import net.imglib2.view.SubsampleView;
 import net.imglib2.view.TransformView;
 import net.imglib2.view.Views;
+import net.imglib2.view.composite.Composite;
 import net.imglib2.view.composite.CompositeIntervalView;
 import net.imglib2.view.composite.CompositeView;
 import net.imglib2.view.composite.GenericComposite;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
@@ -57,7 +57,6 @@ import net.imagej.ops2.threshold.localNiblack.LocalNiblackThreshold;
 import net.imagej.ops2.threshold.localSauvola.LocalSauvolaThreshold;
 import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
-import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.algorithm.neighborhood.Shape;
@@ -73,6 +72,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.util.Pair;
+import net.imglib2.view.Views;
 
 import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
@@ -264,14 +264,14 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalBernsenThreshold() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localBernsen", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(3, false), 1.0, Double.MAX_VALUE * 0.5,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -285,12 +285,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalContrastThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localContrast", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(3, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -304,12 +304,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalHuangThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.huang", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -323,12 +323,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalIJ1Threshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.ij1", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -342,12 +342,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalIntermodesThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.intermodes", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -362,12 +362,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalIsoDataThreshold() {
 		// NB: Test fails for RectangleShapes of span 1
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.isoData", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(2, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -381,12 +381,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalLiThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.li", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -400,12 +400,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMaxEntropyThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.maxEntropy", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -420,12 +420,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	public void testLocalMaxLikelihoodThreshold() {
 		// NB: Test fails for RectangleShapes of up to span==2
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.maxLikelihood", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(3, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -439,13 +439,13 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalThresholdMean() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localMean", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false), 0d,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -492,7 +492,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	// false), new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(
 	// Boundary.SINGLE), 0.0);
 	//
-	// testIterableIntervalSimilarity(out2, out3);
+	// testRandomAccessibleInterval(out2, out3);
 	// }
 	//
 	/**
@@ -501,13 +501,13 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMedianThreshold() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localMedian", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(3, false), 0d,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -521,13 +521,13 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMidGreyThreshold() {
 		final Computers.Arity4<RandomAccessibleInterval<ByteType>, Shape, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localMidGrey", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(3, false), 0d,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -541,12 +541,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMinErrorThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.minError", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -560,12 +560,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMinimumThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.minimum", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -579,12 +579,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalMomentsThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.moments", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -598,14 +598,14 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalNiblackThreshold() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localNiblack", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false), 0.2, 0.0,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -652,7 +652,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	// new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 	// 0.2, 1.0);
 	//
-	// testIterableIntervalSimilarity(out2, out3);
+	// testRandomAccessibleInterval(out2, out3);
 	// }
 
 	/**
@@ -661,12 +661,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalOtsuThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.otsu", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -680,12 +680,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalPercentileThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.percentile", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -699,14 +699,14 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalPhansalkar() {
 		final Computers.Arity5<RandomAccessibleInterval<DoubleType>, Shape, Double, Double, //
-				OutOfBoundsFactory<DoubleType, RandomAccessibleInterval<DoubleType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<DoubleType, RandomAccessibleInterval<DoubleType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localPhansalkar", //
 								new Nil<RandomAccessibleInterval<DoubleType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<DoubleType, RandomAccessibleInterval<DoubleType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(normalizedIn, new RectangleShape(2, false), 0.25, 0.5,
 				new OutOfBoundsMirrorFactory<DoubleType, RandomAccessibleInterval<DoubleType>>(Boundary.SINGLE), out);
@@ -755,7 +755,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	// new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 	// 0.25, 0.5);
 	//
-	// testIterableIntervalSimilarity(out2, out3);
+	// testRandomAccessibleInterval(out2, out3);
 	// }
 
 	/**
@@ -764,12 +764,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalRenyiEntropyThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.renyiEntropy", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -783,14 +783,14 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalSauvola() {
 		final Computers.Arity5<RandomAccessibleInterval<ByteType>, Shape, Double, Double, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.localSauvola", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<Double>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(2, false), 0.5, 0.5,
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -837,7 +837,7 @@ public class LocalThresholdTest extends AbstractOpTest {
 	// new OutOfBoundsMirrorFactory<ByteType, Img<ByteType>>(Boundary.SINGLE),
 	// 0.5, 0.5);
 	//
-	// testIterableIntervalSimilarity(out2, out3);
+	// testRandomAccessibleInterval(out2, out3);
 	// }
 
 	/**
@@ -846,12 +846,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalShanbhagThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.shanbhag", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -865,12 +865,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalTriangleThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.triangle", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -884,12 +884,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalYenThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.yen", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -903,12 +903,12 @@ public class LocalThresholdTest extends AbstractOpTest {
 	@Test
 	public void testLocalRosinThreshold() {
 		final Computers.Arity3<RandomAccessibleInterval<ByteType>, Shape, //
-				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, IterableInterval<BitType>> opToTest = Computers
+				OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>, RandomAccessibleInterval<BitType>> opToTest = Computers
 						.match(ops.env(), "threshold.rosin", //
 								new Nil<RandomAccessibleInterval<ByteType>>() {}, //
 								new Nil<Shape>() {}, //
 								new Nil<OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>>>() {}, //
-								new Nil<IterableInterval<BitType>>() {}); //
+								new Nil<RandomAccessibleInterval<BitType>>() {}); //
 
 		opToTest.compute(in, new RectangleShape(1, false),
 				new OutOfBoundsMirrorFactory<ByteType, RandomAccessibleInterval<ByteType>>(Boundary.SINGLE), out);
@@ -955,16 +955,16 @@ public class LocalThresholdTest extends AbstractOpTest {
 	}
 
 	/**
-	 * Checks if two {@link IterableInterval} have the same content.
+	 * Checks if two {@link RandomAccessibleInterval} have the same content.
 	 *
 	 * @param ii1
 	 * @param ii2
 	 */
-	public static <T extends RealType<T>, S extends RealType<S>> void testIterableIntervalSimilarity(
-			final IterableInterval<T> ii1, final IterableInterval<S> ii2) {
+	public static <T extends RealType<T>, S extends RealType<S>> void testRandomAccessibleInterval(
+			final RandomAccessibleInterval<T> ii1, final RandomAccessibleInterval<S> ii2) {
 		// Test for pixel-wise equality of the results
-		final Cursor<T> cursor1 = ii1.localizingCursor();
-		final Cursor<S> cursor2 = ii2.cursor();
+		final Cursor<T> cursor1 = Views.flatIterable(ii1).localizingCursor();
+		final Cursor<S> cursor2 = Views.flatIterable(ii2).cursor();
 		while (cursor1.hasNext() && cursor2.hasNext()) {
 			final T value1 = cursor1.next();
 			final S value2 = cursor2.next();

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -382,7 +382,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 
 		for (final OpInfo adaptor : infos("adapt")) {
 			Type adaptTo = adaptor.output().getType();
-			Map<TypeVariable<?>, MappedType> map = new HashMap<>();
+			Map<TypeVariable<?>, Type> map = new HashMap<>();
 			// make sure that the adaptor outputs the correct type
 			if (!adaptOpOutputSatisfiesRefTypes(adaptTo, map, ref)) continue;
 			// make sure that the adaptor is a Function (so we can cast it later)

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -382,7 +382,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 
 		for (final OpInfo adaptor : infos("adapt")) {
 			Type adaptTo = adaptor.output().getType();
-			Map<TypeVariable<?>, Type> map = new HashMap<>();
+			Map<TypeVariable<?>, TypeVarData> map = new HashMap<>();
 			// make sure that the adaptor outputs the correct type
 			if (!adaptOpOutputSatisfiesRefTypes(adaptTo, map, ref)) continue;
 			// make sure that the adaptor is a Function (so we can cast it later)

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -382,7 +382,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 
 		for (final OpInfo adaptor : infos("adapt")) {
 			Type adaptTo = adaptor.output().getType();
-			Map<TypeVariable<?>, TypeVarData> map = new HashMap<>();
+			Map<TypeVariable<?>, MappedType> map = new HashMap<>();
 			// make sure that the adaptor outputs the correct type
 			if (!adaptOpOutputSatisfiesRefTypes(adaptTo, map, ref)) continue;
 			// make sure that the adaptor is a Function (so we can cast it later)

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -1048,7 +1048,7 @@ public final class MatchingUtils {
 		@Override
 		public Type put(TypeVariable<?> typeVar, Type type) {
 			final TypeMapping previousMapping = //
-				map.put(typeVar, new TypeMapping(typeVar, type, isMalleable(typeVar)));
+				map.put(typeVar, suitableTypeMapping(typeVar, type, isMalleable(typeVar)));
 			return previousMapping == null ? null : previousMapping.getType();
 		}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -453,7 +453,43 @@ public final class MatchingUtils {
 			inferTypeVariables(types[i], inferFroms[i], typeVarAssigns);
 		}
 	}
-	
+
+	/**
+	 * Tries to infer type vars contained in types from corresponding types from
+	 * inferFrom, putting them into the specified map.
+	 *
+	 * @param type
+	 * @param inferFrom
+	 * @param typeVarAssigns
+	 * @throws TypeInferenceException
+	 */
+	protected static void inferTypeVariables(Type type, Type inferFrom,
+		Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException
+	{
+		if (type instanceof TypeVariable) {
+			inferTypeVariables((TypeVariable<?>) type, inferFrom, typeVarAssigns);
+		}
+		else if (type instanceof ParameterizedType) {
+			inferTypeVariables((ParameterizedType) type, inferFrom, typeVarAssigns);
+		}
+		else if (type instanceof WildcardType) {
+			// TODO Do we need to specifically handle Wildcards? Or are they
+			// sufficiently handled by Types.satisfies below?
+
+		}
+		else if (type instanceof GenericArrayType) {
+			inferTypeVariables((GenericArrayType) type, inferFrom, typeVarAssigns);
+		}
+		else if (type instanceof Class) {
+			inferTypeVariables((Class<?>) type, inferFrom, typeVarAssigns);
+		}
+
+		// Check if the inferred types satisfy their bounds
+		if (!Types.typesSatisfyVariables(typeVarAssigns)) {
+			throw new TypeInferenceException();
+		}
+	}
+
 	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {
 		Type current = typeVarAssigns.putIfAbsent(type, inferFrom);
 		// If current is not null then we have already encountered that
@@ -500,7 +536,7 @@ public final class MatchingUtils {
 			}	
 		}
 	}
-	
+
 	private static void inferTypeVariables(ParameterizedType type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {
 	// Recursively follow parameterized types
 		if (!(inferFrom instanceof ParameterizedType)) {
@@ -538,7 +574,7 @@ public final class MatchingUtils {
 					typeVarAssigns);
 		}	
 	}
-	
+
 	private static void inferTypeVariables(Class<?> type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {
 		if( inferFrom instanceof TypeVariable<?>){
 			// If current type var is absent put it to the map. Otherwise,
@@ -557,7 +593,7 @@ public final class MatchingUtils {
 			}
 		}
 	}
-	
+
 	private static void inferTypeVariables(GenericArrayType type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {
 		if (inferFrom instanceof Class<?> && ((Class<?>) inferFrom).isArray()) {
 			Type componentType = type.getGenericComponentType();
@@ -566,42 +602,6 @@ public final class MatchingUtils {
 		}
 		else {
 			if (! Types.isAssignable(inferFrom, type, typeVarAssigns)) throw new TypeInferenceException();
-		}
-	}
-
-	/**
-	 * Tries to infer type vars contained in types from corresponding types from
-	 * inferFrom, putting them into the specified map.
-	 *
-	 * @param type
-	 * @param inferFrom
-	 * @param typeVarAssigns
-	 * @throws TypeInferenceException
-	 */
-	protected static void inferTypeVariables(Type type, Type inferFrom,
-		Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException
-	{
-		if (type instanceof TypeVariable) {
-			inferTypeVariables((TypeVariable<?>) type, inferFrom, typeVarAssigns);
-		}
-		else if (type instanceof ParameterizedType) {
-			inferTypeVariables((ParameterizedType) type, inferFrom, typeVarAssigns);
-		}
-		else if (type instanceof WildcardType) {
-			// TODO Do we need to specifically handle Wildcards? Or are they
-			// sufficiently handled by Types.satisfies below?
-
-		}
-		else if (type instanceof GenericArrayType) {
-			inferTypeVariables((GenericArrayType) type, inferFrom, typeVarAssigns);
-		}
-		else if (type instanceof Class) {
-			inferTypeVariables((Class<?>) type, inferFrom, typeVarAssigns);
-		}
-
-		// Check if the inferred types satisfy their bounds
-		if (!Types.typesSatisfyVariables(typeVarAssigns)) {
-			throw new TypeInferenceException();
 		}
 	}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -855,6 +855,9 @@ public final class MatchingUtils {
 				mappedType = otherType;
 				return;
 			}
+			if (otherType instanceof Any) {
+				return;
+			}
 			if (malleable) {
 				// TODO: consider the correct value of that boolean
 				Type superType = Types.greatestCommonSuperType(new Type[] { otherType,

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -402,6 +402,14 @@ public final class MatchingUtils {
 		 *
 		 */
 		private static final long serialVersionUID = 7147530827546663700L;
+		
+		public TypeInferenceException() {
+			super();
+		}
+		
+		public TypeInferenceException(String message) {
+			super(message);
+		}
 	}
 
 	/**

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -487,6 +487,7 @@ public final class MatchingUtils {
 		else if (type instanceof WildcardType) {
 			// TODO Do we need to specifically handle Wildcards? Or are they
 			// sufficiently handled by Types.satisfies below?
+			inferTypeVariables((WildcardType) type, inferFrom, typeVarAssigns);
 
 		}
 		else if (type instanceof GenericArrayType) {
@@ -585,6 +586,13 @@ public final class MatchingUtils {
 			inferTypeVariables(type.getActualTypeArguments(), paramInferFrom.getActualTypeArguments(),
 					typeVarAssigns);
 		}	
+	}
+	
+	private static void inferTypeVariables(WildcardType type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) {
+		Type[] upperBounds = type.getUpperBounds();
+		for (Type upperBound : upperBounds) {
+			if (!(upperBound instanceof TypeVariable<?>)) continue;
+		}
 	}
 
 	private static void inferTypeVariables(Class<?> type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -442,12 +442,12 @@ public final class MatchingUtils {
 	protected static void inferTypeVariables(Type[] types, Type[] inferFroms,
 		Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException
 	{
-		if (typeVarAssigns == null)
-			throw new IllegalArgumentException();
-		// TODO: is this the correct place to put this? We could get a marginal increase
-		// in Type Variable information if we put this farther into the loop.
-		if (types.length != inferFroms.length)
-			throw new TypeInferenceException();
+		// Ensure that the user has not passed a null map
+		if (typeVarAssigns == null) throw new IllegalArgumentException(
+			"Type Variable map is null, cannot store mappings of TypeVariables to Types!");
+
+		if (types.length != inferFroms.length) throw new TypeInferenceException(
+			"Could not infer type variables: Type arrays must be of the same size");
 
 		for (int i = 0; i < types.length; i++) {
 			inferTypeVariables(types[i], inferFroms[i], typeVarAssigns);

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -551,16 +551,8 @@ public final class MatchingUtils {
 	}
 
 	private static void inferTypeVariables(ParameterizedType type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) throws TypeInferenceException {
-	// Recursively follow parameterized types
-		if (!(inferFrom instanceof ParameterizedType)) {
-			Type mappedType = Types.mapVarToTypes(type, typeVarAssigns);
-			// Use isAssignable to attempt to infer the type variables present in type
-			if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
-				throw new TypeInferenceException(inferFrom +
-					" cannot be implicitly cast to " + mappedType +
-					", thus it is impossible to infer type variables for " + inferFrom);
-			}
-		} else {
+		// Recursively follow parameterized types
+		if (inferFrom instanceof ParameterizedType) {
 			// Finding the supertype here is really important. Suppose that we are
 			// inferring from a StrangeThing<Long> extends Thing<Double> and our
 			// Op requires a Thing<T>. We need to ensure that T gets
@@ -569,9 +561,18 @@ public final class MatchingUtils {
 				.getExactSuperType(inferFrom, Types.raw(type));
 			if (paramInferFrom == null) throw new TypeInferenceException();
 
-			inferTypeVariables(type.getActualTypeArguments(), paramInferFrom.getActualTypeArguments(),
-					typeVarAssigns);
-		}	
+			inferTypeVariables(type.getActualTypeArguments(), paramInferFrom
+				.getActualTypeArguments(), typeVarAssigns);
+		}
+		else {
+			Type mappedType = Types.mapVarToTypes(type, typeVarAssigns);
+			// Use isAssignable to attempt to infer the type variables present in type
+			if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
+				throw new TypeInferenceException(inferFrom +
+					" cannot be implicitly cast to " + mappedType +
+					", thus it is impossible to infer type variables for " + inferFrom);
+			}
+		}
 	}
 	
 	private static void inferTypeVariables(WildcardType type, Type inferFrom, Map<TypeVariable<?>, Type> typeVarAssigns) {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -871,31 +871,35 @@ public final class MatchingUtils {
 		private Type lowerBound;
 
 		public WildcardTypeMapping(TypeVariable<?> typeVar, WildcardType mappedType,
-			boolean malleable)
+			boolean malleable) throws TypeInferenceException
 		{
 			super(typeVar, mappedType, malleable);
 			Type[] upperBounds = mappedType.getUpperBounds();
 			if (upperBounds.length == 0) {
 				this.mappedType = Object.class;
 			}
-			else {
-				// HACK: while WildcardType API has the ability to support multiple
-				// lower (and upper) bounds, the Java language makes it impossible to specify
-				// multiple lower bounds (i.e. it is not possible to write ? extends
-				// Comparable<?> & String). Thus we assume that there is only one
+			else if (upperBounds.length == 1) {
 				this.mappedType = upperBounds[0];
 			}
-			
+			else {
+				throw new TypeInferenceException(mappedType + //
+					" is an impossible WildcardType. " + //
+					"The Java language specification currently prevents multiple upper bounds " + //
+					Arrays.toString(upperBounds)); //
+			}
+
 			Type[] lowerBounds = mappedType.getLowerBounds();
 			if (lowerBounds.length == 0) {
 				lowerBound = new Any();
 			}
-			else {
-				// HACK: while WildcardType API has the ability to support multiple
-				// lower bounds, the Java language makes it impossible to specify
-				// multiple lower bounds (i.e. it is not possible to write ? super
-				// Number & String). Thus we assume that there is only one.
+			else if (lowerBounds.length == 1) {
 				lowerBound = lowerBounds[0];
+			}
+			else {
+				throw new TypeInferenceException(mappedType + //
+					" is an impossible WildcardType. " + //
+					"The Java language specification currently prevents multiple lower bounds " + //
+					Arrays.toString(lowerBounds)); //
 			}
 		}	
 		

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -515,7 +515,10 @@ public final class MatchingUtils {
 				typeVarAssigns.put(type, inferFrom);
 				return;
 			}
-			throw new TypeInferenceException();
+			throw new TypeInferenceException(
+				"Cannot infer the type of TypeVariable " + type +
+					": this TypeVariable has already been mapped to " + current +
+					" and cannot be mapped to a " + inferFrom);
 		}
 
 		// Bounds could also contain type vars, hence possibly go into

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -301,29 +301,6 @@ public final class MatchingUtils {
 	}
 
 	/**
-	 * @param srcTypes
-	 *            the Type arguments for the source Type
-	 * @param destTypes
-	 *            the Type arguments for the destination Type
-	 * @param src
-	 *            the type for which assignment should be checked from
-	 * @param dest
-	 *            the parameterized type for which assignment should be checked to
-	 * @param safeAssignability
-	 *            used to determine if we want to check if the src->dest assignment
-	 *            would be safely assignable even though it would cause a compiler
-	 *            error if we explicitly tried to do this (useful pretty much only
-	 *            for Op matching)
-	 * @return whether and assignment of source to destination would be a legal java
-	 *         statement
-	 */
-	private static boolean checkGenericAssignability(Type[] srcTypes, Type[] destTypes, Type src, Type dest,
-			boolean safeAssignability) {
-		return checkGenericAssignability(srcTypes, destTypes, src, dest, new HashMap<TypeVariable<?>, Type>(),
-				safeAssignability);
-	}
-
-	/**
 	 * 
 	 * @param srcTypes
 	 *            the Type arguments for the source Type

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -554,16 +554,11 @@ public final class MatchingUtils {
 	// Recursively follow parameterized types
 		if (!(inferFrom instanceof ParameterizedType)) {
 			Type mappedType = Types.mapVarToTypes(type, typeVarAssigns);
-			if( inferFrom instanceof TypeVariable<?>){
-				// Use isAssignable to attempt to infer the type variables present in type using the BOUNDS of inferFrom
-				if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
-					throw new TypeInferenceException(inferFrom +
-						" cannot be implicitly cast to " + mappedType +
-						", thus it is impossible to infer type variables for " + inferFrom);
-				}
-			}
-			else if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
-				throw new TypeInferenceException();
+			// Use isAssignable to attempt to infer the type variables present in type
+			if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
+				throw new TypeInferenceException(inferFrom +
+					" cannot be implicitly cast to " + mappedType +
+					", thus it is impossible to infer type variables for " + inferFrom);
 			}
 		} else {
 			// Finding the supertype here is really important. Suppose that we are

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -404,12 +404,14 @@ public final class MatchingUtils {
 
 	/**
 	 * Map type vars in specified type list to types using the specified map. In
-	 * doing so, type vars mapping to other type vars will not be followed but just
-	 * repalced.
+	 * doing so, type vars mapping to other type vars will not be followed but
+	 * just replaced.
 	 *
 	 * @param typesToMap
 	 * @param typeAssigns
-	 * @return
+	 * @return a copy of {@code typesToMap} in which the {@link TypeVariable}s
+	 *         (that are present in {@code typeAssigns}) are mapped to the
+	 *         associated values within the {@code Map}.
 	 */
 	private static Type[] mapVarToTypes(Type[] typesToMap, Map<TypeVariable<?>, Type> typeAssigns) {
 		return Arrays.stream(typesToMap).map(type -> Types.unrollVariables(typeAssigns, type, false))

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -418,10 +418,6 @@ public final class MatchingUtils {
 				.toArray(Type[]::new);
 	}
 
-	private static <M> boolean containsNull(M[] arr) {
-		return !Arrays.stream(arr).noneMatch(m -> m == null);
-	}
-	
 	/**
 	 * Tries to infer type vars contained in types from corresponding types from
 	 * inferFrom, putting them into the specified map.

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -442,7 +442,9 @@ public final class MatchingUtils {
 
 	/**
 	 * Tries to infer type vars contained in types from corresponding types from
-	 * inferFrom, putting them into the specified map.
+	 * inferFrom, putting them into the specified map. <b>When a
+	 * {@link TypeInferenceException} is thrown, the caller should assume that
+	 * some of the mappings within {@code typeVarAssigns} are incorrect.</b>
 	 *
 	 * @param types - the types containing {@link TypeVariable}s
 	 * @param inferFroms - the types used to infer the {@link TypeVariable}s
@@ -468,7 +470,9 @@ public final class MatchingUtils {
 
 	/**
 	 * Tries to infer type vars contained in types from corresponding types from
-	 * inferFrom, putting them into the specified map.
+	 * inferFrom, putting them into the specified map. <b>When a
+	 * {@link TypeInferenceException} is thrown, the caller should assume that
+	 * some of the mappings within {@code typeVarAssigns} are incorrect.</b>
 	 *
 	 * @param type
 	 * @param inferFrom

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -534,7 +534,9 @@ public final class MatchingUtils {
 		if (typeData != null) {
 			typeData.refine(inferFrom, malleable);
 		}
-		typeMappings.put(type, new TypeMapping(type, inferFrom, malleable));
+		else {
+			typeMappings.put(type, new TypeMapping(type, inferFrom, malleable));
+		}
 
 		// Bounds could also contain type vars, hence possibly go into
 		// recursion
@@ -864,7 +866,8 @@ public final class MatchingUtils {
 
 		@Override
 		public Type get(Object key) {
-			return map.get(key).getType();
+			TypeMapping value = map.get(key);
+			return value == null ? null : value.getType();
 		}
 		
 		@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -485,6 +485,12 @@ public final class MatchingUtils {
 		for (int i = 0; i < types.length; i++) {
 			inferTypeVariables(types[i], inferFroms[i], typeMappings, malleable);
 		}
+		// Check if the inferred types satisfy their bounds
+		// TODO: can we do this in an efficient manner?
+		TypeVarAssigns typeVarAssigns = new TypeVarAssigns(typeMappings);
+		if (!Types.typesSatisfyVariables(typeVarAssigns)) {
+			throw new TypeInferenceException();
+		}
 	}
 	
 	/**
@@ -512,10 +518,7 @@ public final class MatchingUtils {
 			inferTypeVariables((ParameterizedType) type, inferFrom, typeMappings);
 		}
 		else if (type instanceof WildcardType) {
-			// TODO Do we need to specifically handle Wildcards? Or are they
-			// sufficiently handled by Types.satisfies below?
 			inferTypeVariables((WildcardType) type, inferFrom, typeMappings);
-
 		}
 		else if (type instanceof GenericArrayType) {
 			inferTypeVariables((GenericArrayType) type, inferFrom, typeMappings);
@@ -524,12 +527,6 @@ public final class MatchingUtils {
 			inferTypeVariables((Class<?>) type, inferFrom, typeMappings);
 		}
 
-		// Check if the inferred types satisfy their bounds
-		// TODO: can we do this in an efficient manner?
-		TypeVarAssigns typeVarAssigns = new TypeVarAssigns(typeMappings);
-		if (!Types.typesSatisfyVariables(typeVarAssigns)) {
-			throw new TypeInferenceException();
-		}
 	}
 
 	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) throws TypeInferenceException {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -60,9 +60,9 @@ public final class MatchingUtils {
 	}
 
 	/**
-	 * Checks for raw assignability. TODO This method is not yet fully implemented.
-	 * The correct behavior should be as follows. Suppose we have a generic typed
-	 * method like:
+	 * Checks for raw assignability. TODO This method is not yet fully
+	 * implemented. The correct behavior should be as follows. Suppose we have a
+	 * generic typed method like:
 	 *
 	 * <pre>
 	 *public static &lt;N&gt; List&lt;N&gt; foo(N in) {
@@ -103,9 +103,11 @@ public final class MatchingUtils {
 	 * @param froms
 	 * @param tos
 	 * @param typeBounds
-	 * @return
+	 * @return the index {@code i} such that {@code from[i]} cannot be assigned to
+	 *         {@code to[i]}, or {@code -1} iff {@code from[i]} can be assigned to
+	 *         {@code to[i]} for all {@code 0 <= i < from.length}.
 	 */
-	public static int checkGenericOutputsAssignability(Type[] froms, Type[] tos,
+	static int checkGenericOutputsAssignability(Type[] froms, Type[] tos,
 			HashMap<TypeVariable<?>, TypeVarInfo> typeBounds) {
 		for (int i = 0; i < froms.length; i++) {
 			Type from = froms[i];

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -424,7 +424,7 @@ public final class MatchingUtils {
 	/**
 	 * Exception indicating that type vars could not be inferred.
 	 */
-	static class TypeInferenceException extends Exception {
+	static class TypeInferenceException extends RuntimeException {
 		/**
 		 *
 		 */
@@ -466,14 +466,13 @@ public final class MatchingUtils {
 	 *          within {@code types}
 	 * @param typeMappings - the mapping of {@link TypeVariable}s to
 	 *          {@link Type}s
-	 * @throws TypeInferenceException
 	 */
-	static void inferTypeVariables(Type[] types, Type[] inferFroms, Map<TypeVariable<?>, TypeMapping> typeMappings) throws TypeInferenceException {
+	static void inferTypeVariables(Type[] types, Type[] inferFroms, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		inferTypeVariables(types, inferFroms, typeMappings, true);
 	}
 	
 	private static void inferTypeVariables(Type[] types, Type[] inferFroms,
-		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) throws TypeInferenceException
+		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) 
 	{
 		// Ensure that the user has not passed a null map
 		if (typeMappings == null) throw new IllegalArgumentException(
@@ -502,14 +501,13 @@ public final class MatchingUtils {
 	 * @param type
 	 * @param inferFrom
 	 * @param typeMappings
-	 * @throws TypeInferenceException
 	 */
-	static void inferTypeVariables(Type type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) throws TypeInferenceException {
+	static void inferTypeVariables(Type type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		inferTypeVariables(type, inferFrom, typeMappings, true);
 	}
 
 	private static void inferTypeVariables(Type type, Type inferFrom,
-		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) throws TypeInferenceException
+		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) 
 	{
 		if (type instanceof TypeVariable) {
 			inferTypeVariables((TypeVariable<?>) type, inferFrom, typeMappings, malleable);
@@ -529,7 +527,7 @@ public final class MatchingUtils {
 
 	}
 
-	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) throws TypeInferenceException {
+	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) {
 		TypeMapping typeData = typeMappings.get(type);
 		// If current is not null then we have already encountered that
 		// variable. If so, we require them to be exactly the same, and throw a
@@ -573,7 +571,7 @@ public final class MatchingUtils {
 		}
 	}
 
-	private static void inferTypeVariables(ParameterizedType type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) throws TypeInferenceException {
+	private static void inferTypeVariables(ParameterizedType type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		// Recursively follow parameterized types
 		if (inferFrom instanceof ParameterizedType) {
 			// Finding the supertype here is really important. Suppose that we are
@@ -619,7 +617,7 @@ public final class MatchingUtils {
 		}
 	}
 	
-	private static void inferTypeVariables(WildcardType type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) throws TypeInferenceException {
+	private static void inferTypeVariables(WildcardType type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		Type inferrableBound = getInferrableBound(type);
 		if (inferFrom instanceof WildcardType) {
 			// NB if both type and inferFrom are Wildcards, it doesn't really matter
@@ -646,7 +644,6 @@ public final class MatchingUtils {
 	
 	private static void resolveTypeInMap(TypeVariable<?> typeVar, Type newType,
 		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleability)
-		throws TypeInferenceException
 	{
 		if (typeMappings.containsKey(typeVar)) {
 			typeMappings.get(typeVar).refine(newType, malleability);
@@ -658,7 +655,7 @@ public final class MatchingUtils {
 	}
 	
 	private static TypeMapping suitableTypeMapping(TypeVariable<?> typeVar,
-		Type newType, boolean malleability) throws TypeInferenceException
+		Type newType, boolean malleability) 
 	{
 		if (newType instanceof WildcardType) {
 			return new WildcardTypeMapping(typeVar, (WildcardType) newType,
@@ -667,7 +664,7 @@ public final class MatchingUtils {
 		return new TypeMapping(typeVar, newType, malleability);
 	}
 
-	private static void inferTypeVariables(Class<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) throws TypeInferenceException {
+	private static void inferTypeVariables(Class<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		if( inferFrom instanceof TypeVariable<?>){
 			TypeVarAssigns typeVarAssigns = new TypeVarAssigns(typeMappings);
 			// If current type var is absent put it to the map. Otherwise,
@@ -689,7 +686,6 @@ public final class MatchingUtils {
 
 	private static void inferTypeVariables(GenericArrayType type, Type inferFrom,
 		Map<TypeVariable<?>, TypeMapping> typeMappings)
-		throws TypeInferenceException
 	{
 		if (inferFrom instanceof Class<?> && ((Class<?>) inferFrom).isArray()) {
 			Type componentType = type.getGenericComponentType();
@@ -863,10 +859,8 @@ public final class MatchingUtils {
 		 * @param otherType - the type that will be refined into {@link #mappedType}
 		 * @param newTypeMalleability - the malleability of {@code otherType},
 		 *          determined by the context from which {@code otherType} came.
-		 * @throws TypeInferenceException
 		 */
 		public void refine(Type otherType, boolean newTypeMalleability)
-			throws TypeInferenceException
 		{
 			malleable &= newTypeMalleability;
 			if (mappedType instanceof Any) {
@@ -976,11 +970,9 @@ public final class MatchingUtils {
 		 * @param otherType - the type that will be refined into {@link #mappedType}
 		 * @param newTypeMalleability - the malleability of {@code otherType},
 		 *          determined by the context from which {@code otherType} came.
-		 * @throws TypeInferenceException
 		 */
 		@Override
 		public void refine(Type otherType, boolean newTypeMalleability)
-			throws TypeInferenceException
 		{
 			if (otherType instanceof WildcardType) {
 				refineWildcard((WildcardType) otherType, newTypeMalleability);
@@ -997,7 +989,7 @@ public final class MatchingUtils {
 		}
 
 		private void refineWildcard(WildcardType otherType,
-			boolean newTypeMalleability) throws TypeInferenceException
+			boolean newTypeMalleability) 
 		{
 			if (otherType.getLowerBounds().length == 1) {
 				lowerBoundList.add(otherType.getLowerBounds()[0]);

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -236,7 +236,7 @@ public final class MatchingUtils {
 	 */
 	public static boolean checkGenericAssignability(Type src, ParameterizedType dest,
 			Map<TypeVariable<?>, Type> typeVarAssigns, boolean safeAssignability) {
-		// check raw assignability
+		// fail fast when raw types are not assignable
 		if (!Types.isAssignable(Types.raw(src), Types.raw(dest)))
 			return false;
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -360,8 +360,6 @@ public final class MatchingUtils {
 	 * NORMALLY MATCH UP but WE KNOW IT WILL BE SAFE TO ASSIGN. This method attempts
 	 * to tease those situations out as a last resort.
 	 * 
-	 * @param srcTypes
-	 *            - the array of Parameterized types of the potential match
 	 * @param destTypes
 	 *            - the array of Parameterized types of the OpInfo we called the
 	 *            matcher on (in the case of ops.run(), it is a Type array of the

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -7,7 +7,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,6 +141,50 @@ public class InferTypeVariablesTest {
 		WildcardType mappedWildcard = (WildcardType) mappedType;
 		expected.put(typeVarT, new MatchingUtils.WildcardTypeMapping(typeVarT,
 			mappedWildcard, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <T extends Number> void testInferWildcardAndClass()
+		throws TypeInferenceException
+	{
+		final Nil<List<? super T>> listT = new Nil<>() {};
+		final Nil<T> t = new Nil<>() {};
+		final Nil<List<? super Number>> listWildcard = new Nil<>() {};
+
+		Type[] types = new Type[] { listT.getType(), t.getType() };
+		Type[] inferFroms = new Type[] { listWildcard.getType(), Double.class };
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
+
+		// We expect T=Number
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
+			new HashMap<>();
+		TypeVariable<?> typeVarT = (TypeVariable<?>) t.getType();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <T extends Number> void testInferSuperWildcard()
+		throws TypeInferenceException
+	{
+		final Nil<List<? super T>> listT = new Nil<>() {};
+		final Nil<List<? super Number>> listWildcard = new Nil<>() {};
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(listT.getType(), listWildcard.getType(), typeAssigns);
+
+		// We expect T=Number
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
+			new HashMap<>();
+		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
 
 		assertEquals(expected, typeAssigns);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -1,0 +1,180 @@
+
+package org.scijava.ops.matcher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.scijava.ops.matcher.MatchingUtils.TypeInferenceException;
+import org.scijava.ops.matcher.MatchingUtils.TypeMapping;
+import org.scijava.ops.matcher.MatchingUtilsTest.StrangeThing;
+import org.scijava.ops.matcher.MatchingUtilsTest.Thing;
+import org.scijava.types.Nil;
+
+public class InferTypeVariablesTest {
+
+	@Test
+	public <I, O> void testSupertypeTypeInference()
+		throws TypeInferenceException
+	{
+		final Type t = new Nil<Function<Thing<I>, List<O>>>() {}.getType();
+		final Type[] tArgs = ((ParameterizedType) t).getActualTypeArguments();
+		final Type dest =
+			new Nil<Function<StrangeThing<Double, String>, List<Double>>>()
+			{}.getType();
+		final Type[] destArgs = ((ParameterizedType) dest).getActualTypeArguments();
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(tArgs, destArgs, typeAssigns);
+
+		// We expect I=String, O=Double
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
+			new HashMap<>();
+		TypeVariable<?> typeVarI = (TypeVariable<?>) ((ParameterizedType) tArgs[0])
+			.getActualTypeArguments()[0];
+		expected.put(typeVarI, new TypeMapping(typeVarI, String.class, false));
+		TypeVariable<?> typeVarO = (TypeVariable<?>) ((ParameterizedType) tArgs[1])
+			.getActualTypeArguments()[0];
+		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, false));
+
+		assertEquals(typeAssigns, expected);
+	}
+
+	@Test
+	public <T> void testWildcardTypeInference() throws TypeInferenceException {
+		final Type t = new Nil<T>() {}.getType();
+		final Type listWild = new Nil<List<? extends T>>() {}.getType();
+		final Type integer = new Nil<Integer>() {}.getType();
+		final Type listDouble = new Nil<List<Double>>() {}.getType();
+
+		final Type[] types = { listWild, t };
+		final Type[] inferFroms = { listDouble, integer };
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
+
+		// We expect T=Number
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
+			new HashMap<>();
+		TypeVariable<?> typeVar = (TypeVariable<?>) t;
+		expected.put(typeVar, new TypeMapping(typeVar, Number.class, true));
+
+		assertEquals(expected, typeAssigns);
+
+		final Type[] types2 = { t, t };
+		final Type listWildcardNumber = new Nil<List<? extends Number>>() {}
+			.getType();
+		final Type wildcardNumber = ((ParameterizedType) listWildcardNumber)
+			.getActualTypeArguments()[0];
+		final Type listWildcardDouble = new Nil<List<? extends Double>>() {}
+			.getType();
+		final Type wildcardDouble = ((ParameterizedType) listWildcardDouble)
+			.getActualTypeArguments()[0];
+
+		final Type[] inferFroms2 = { wildcardNumber, wildcardDouble };
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns2 =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(types2, inferFroms2, typeAssigns2);
+
+		// We expect T=Number
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected2 =
+			new HashMap<>();
+		TypeVariable<?> typeVar2 = (TypeVariable<?>) t;
+		expected2.put(typeVar2, new TypeMapping(typeVar, Number.class, true));
+
+		assertEquals(expected2, typeAssigns2);
+	}
+
+	@Test
+	public <T, U extends Comparable<Double>> void testInferFromTypeVar()
+		throws TypeInferenceException
+	{
+		final Type compT = new Nil<Comparable<T>>() {}.getType();
+		final Type u = new Nil<U>() {}.getType();
+
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(compT, u, typeAssigns);
+
+		// We expect T=Double
+		final Type t = new Nil<T>() {}.getType();
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
+			new HashMap<>();
+		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
+		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, false));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <T extends Number> void testInferTypeVarInconsistentMapping()
+		throws TypeInferenceException
+	{
+
+		final Type t = new Nil<T>() {}.getType();
+
+		final Type[] tArr = { t, t };
+		final Type[] badInferFrom = { Integer.class, Double.class };
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(tArr, badInferFrom, typeAssigns);
+
+		// We expect T=Number
+		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <T extends Number> void
+		testInferGenericArrayTypeFromExtendingWildcardType()
+			throws TypeInferenceException
+	{
+		final Type type = new Nil<List<T[]>>() {}.getType();
+		final Type inferFrom = new Nil<List<? extends Double[]>>() {}.getType();
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
+
+		// We expect T=Double
+		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <T extends Number> void
+		testInferGenericArrayTypeFromSuperWildcardType()
+			throws TypeInferenceException
+	{
+		final Type type = new Nil<List<T[]>>() {}.getType();
+		final Type inferFrom = new Nil<List<? super Double[]>>() {}.getType();
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
+
+		// We expect T=Double
+		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -44,8 +44,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.scijava.ops.matcher.MatchingUtils.TypeInferenceException;
+import org.scijava.ops.matcher.MatchingUtils.TypeMapping;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 
@@ -466,7 +466,6 @@ public class MatchingUtilsTest {
 	 * Function&lt;Double[], Double[]&gt; barFunc = new Bar&lt;&gt;();
 	 * </pre>
 	 *
-	 * @param <I>
 	 * @param <O>
 	 */
 	@Test
@@ -529,7 +528,7 @@ public class MatchingUtilsTest {
 			{}.getType();
 		final Type[] destArgs = ((ParameterizedType) dest).getActualTypeArguments();
 
-		final Map<TypeVariable<?>, Type> typeAssigns = new HashMap<>();
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
 		MatchingUtils.inferTypeVariables(tArgs, destArgs, typeAssigns);
 
 		// We expect I=String, O=Double
@@ -552,14 +551,15 @@ public class MatchingUtilsTest {
 		final Type[] types = {listWild, t};
 		final Type[] inferFroms = {listDouble, integer};
 		
-		final Map<TypeVariable<?>, Type> typeAssigns = new HashMap<>();
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
 		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
 		
 		// We expect T=Number
-		final Map<TypeVariable<?>, Type> expected = new HashMap<>();
-		expected.put((TypeVariable<?>) t, Number.class);
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		TypeVariable<?> typeVar = (TypeVariable<?>) t;
+		expected.put(typeVar, new TypeMapping(typeVar, Number.class, true));
 		
-		assertEquals(typeAssigns, expected);
+		assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -569,7 +569,7 @@ public class MatchingUtilsTest {
 		final Type compT = new Nil<Comparable<T>>() {}.getType();
 		final Type u = new Nil<U>() {}.getType();
 
-		final Map<TypeVariable<?>, Type> typeAssigns = new HashMap<>();
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
 		MatchingUtils.inferTypeVariables(compT, u, typeAssigns);
 
 		// We expect T=Double

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -580,6 +580,21 @@ public class MatchingUtilsTest {
 		assertEquals(expected, typeAssigns);
 	}
 
+	// TODO: Use JUnit5
+	@Test(expected = TypeInferenceException.class)
+	public <T extends Number> void testInferTypeVarInconsistentMapping()
+		throws TypeInferenceException
+	{
+
+		final Type t = new Nil<T>() {}.getType();
+
+		final Type[] tArr = { t, t };
+		final Type[] badInferFrom = { Integer.class, Double.class };
+
+		MatchingUtils.inferTypeVariables(tArr, badInferFrom, new HashMap<>());
+
+	}
+
 	class Thing<T> {}
 	
 	class StrangeThing<N extends Number, T> extends Thing<T> {}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.scijava.ops.matcher.MatchingUtils.TypeInferenceException;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
@@ -419,6 +420,58 @@ public class MatchingUtilsTest {
 
 		assertAll(Wildcards.class, true, y1);
 		assertAll(Wildcards.class, false, n1, n2, n3, n4);
+	}
+
+	/**
+	 * Suppose we have a
+	 *
+	 * <pre>
+	 * class Foo&lt;I extends Number&gt implements Function&lt;I[], Double&gt;
+	 * </pre>
+	 *
+	 * It is legal to write
+	 *
+	 * <pre>
+	 *
+	 * Function&lt;Double[], Double[]&gt; fooFunc = new Foo&lt;&gt;();
+	 * </pre>
+	 *
+	 * If we instead have a
+	 *
+	 * <pre>
+	 * class Bar implements Function&lt;O[], Double&gt;
+	 * </pre>
+	 *
+	 * where <code>O extends Number</code>, is <strong>not</strong> legal to write
+	 *
+	 * <pre>
+	 *
+	 * Function&lt;Double[], Double[]&gt; barFunc = new Bar&lt;&gt;();
+	 * </pre>
+	 *
+	 * @param <I>
+	 * @param <O>
+	 */
+	@Test
+	public <O extends Number> void testGenericArrayFunction() {
+		class Foo<I extends Number> implements Function<I[], Double> {
+			@Override
+			public Double apply(I[] t) {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		}
+
+		class Bar implements Function<O[], Double> {
+			@Override
+			public Double apply(O[] t) {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		}
+		Nil<Function<Double[], Double>> doubleFunction = new Nil<>() {};
+		assertAll(Foo.class, true, doubleFunction);
+		assertAll(Bar.class, false, doubleFunction);
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -41,6 +41,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
@@ -497,6 +498,18 @@ public class MatchingUtilsTest {
 		// List<? extends Double[]> list = new Foo<>() {...};
 		// assertAll must return true
 		assertAll(Foo.class, true, upperType, lowerType);
+	}
+
+	@Test
+	public <T extends Number> void testSuperWildcardToSuperWildcard() {
+		final Nil<List<? super T>> listT = new Nil<>() {};
+		final Nil<List<? super Number>> listWildcard = new Nil<>() {};
+
+		// unfortunately we cannot use assertAll since it is impossible to create a
+		// Class implementing List<? super T>
+		boolean success = MatchingUtils.checkGenericAssignability(listT.getType(),
+			(ParameterizedType) listWildcard.getType(), false);
+		Assert.assertTrue(success);
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -69,9 +69,9 @@ public class MatchingUtilsTest {
 		}
 		abstract class SingleBounded<I extends Number> implements Supplier<I> {
 		}
-		Nil<Supplier<E>> y1 = new Nil<Supplier<E>>() {
+		Nil<Supplier<E>> y1 = new Nil<>() {
 		};
-		Nil<Supplier<N>> y2 = new Nil<Supplier<N>>() {
+		Nil<Supplier<N>> y2 = new Nil<>() {
 		};
 		Nil<Double> n1 = new Nil<>() {
 		};
@@ -87,9 +87,9 @@ public class MatchingUtilsTest {
 	public void genericAssignabilitySingleVar() {
 		abstract class Single<I> implements Supplier<I> {
 		}
-		Nil<Supplier<Double>> y1 = new Nil<Supplier<Double>>() {
+		Nil<Supplier<Double>> y1 = new Nil<>() {
 		};
-		Nil<Supplier<Number>> y2 = new Nil<Supplier<Number>>() {
+		Nil<Supplier<Number>> y2 = new Nil<>() {
 		};
 		Nil<Double> n1 = new Nil<>() {
 		};
@@ -103,11 +103,11 @@ public class MatchingUtilsTest {
 		abstract class SingleBounded<I extends Number> implements Supplier<I> {
 		}
 
-		Nil<Supplier<Double>> y1 = new Nil<Supplier<Double>>() {
+		Nil<Supplier<Double>> y1 = new Nil<>() {
 		};
 		Nil<Double> n1 = new Nil<>() {
 		};
-		Nil<String> n2 = new Nil<String>() {
+		Nil<String> n2 = new Nil<>() {
 		};
 
 		assertAll(SingleBounded.class, true, y1);
@@ -121,13 +121,13 @@ public class MatchingUtilsTest {
 
 		Nil<Double> n1 = new Nil<>() {
 		};
-		Nil<String> n2 = new Nil<String>() {
+		Nil<String> n2 = new Nil<>() {
 		};
-		Nil<Supplier<Double>> n3 = new Nil<Supplier<Double>>() {
+		Nil<Supplier<Double>> n3 = new Nil<>() {
 		};
-		Nil<Supplier<List<String>>> n4 = new Nil<Supplier<List<String>>>() {
+		Nil<Supplier<List<String>>> n4 = new Nil<>() {
 		};
-		Nil<Supplier<List<Double>>> y1 = new Nil<Supplier<List<Double>>>() {
+		Nil<Supplier<List<Double>>> y1 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedUsedNested.class, true, y1);
@@ -161,7 +161,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<Double, List<Double>>> n4 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Double>>> n5 = new Nil<Function<List<String>, List<Double>>>() {
+		Nil<Function<List<String>, List<Double>>> n5 = new Nil<>() {
 		};
 		Nil<Function<List<Double>, List<String>>> n6 = new Nil<>() {
 		};
@@ -171,7 +171,7 @@ public class MatchingUtilsTest {
 
 		Nil<Function<Double, List<Double>>> n7 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Double>>> n8 = new Nil<Function<List<String>, List<Double>>>() {
+		Nil<Function<List<String>, List<Double>>> n8 = new Nil<>() {
 		};
 		Nil<Function<List<Double>, List<String>>> n9 = new Nil<>() {
 		};
@@ -200,7 +200,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<Double, Double>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<String>, String>> n2 = new Nil<Function<List<String>, String>>() {
+		Nil<Function<List<String>, String>> n2 = new Nil<>() {
 		};
 		Nil<Function<Iterable<Double>, Double>> n3 = new Nil<>() {
 		};
@@ -222,7 +222,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<Integer, List<Double>>> n7 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Double>>> n8 = new Nil<Function<List<String>, List<Double>>>() {
+		Nil<Function<List<String>, List<Double>>> n8 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedNestedWildcardAndOther.class, true, y3, y4, y5);
@@ -242,13 +242,13 @@ public class MatchingUtilsTest {
 				implements Function<I, List<I>> {
 		}
 
-		Nil<Function<List<String>, List<String>>> y1 = new Nil<Function<List<String>, List<String>>>() {
+		Nil<Function<List<String>, List<String>>> y1 = new Nil<>() {
 		};
 		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<Function<List<String>, List<Integer>>>() {
+		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Double>> n2 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> n2 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedNestedMultipleOccurence.class, true, y1, y2);
@@ -260,7 +260,7 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<Iterable<Double>, Iterable<Integer>>> n3 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Integer>> n4 = new Nil<Function<List<String>, Integer>>() {
+		Nil<Function<List<String>, Integer>> n4 = new Nil<>() {
 		};
 
 		assertAll(SingleVarBoundedNestedWildcardMultipleOccurence.class, true, y3, y4);
@@ -289,26 +289,26 @@ public class MatchingUtilsTest {
 		abstract class DoubleVarBounded<I extends List<String>, B extends Number> implements Function<I, B> {
 		}
 
-		Nil<Function<List<String>, List<String>>> y1 = new Nil<Function<List<String>, List<String>>>() {
+		Nil<Function<List<String>, List<String>>> y1 = new Nil<>() {
 		};
 		Nil<Function<Iterable<String>, Iterable<String>>> y2 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Integer>>> y3 = new Nil<Function<List<String>, List<Integer>>>() {
+		Nil<Function<List<String>, List<Integer>>> y3 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Double>> y4 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> y4 = new Nil<>() {
 		};
 
 		assertAll(DoubleVar.class, true, y1, y2, y3, y4);
 
-		Nil<Function<List<String>, Double>> y5 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> y5 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Float>> y6 = new Nil<Function<List<String>, Float>>() {
+		Nil<Function<List<String>, Float>> y6 = new Nil<>() {
 		};
 		Nil<Function<Iterable<String>, Double>> n1 = new Nil<>() {
 		};
 		Nil<Function<List<Double>, Integer>> n2 = new Nil<>() {
 		};
-		Nil<Function<List<String>, String>> n3 = new Nil<Function<List<String>, String>>() {
+		Nil<Function<List<String>, String>> n3 = new Nil<>() {
 		};
 
 		assertAll(DoubleVarBounded.class, true, y5, y6);
@@ -329,9 +329,9 @@ public class MatchingUtilsTest {
 		};
 		Nil<Function<Iterable<Integer>, Iterable<Integer>>> y3 = new Nil<>() {
 		};
-		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<Function<List<String>, List<Integer>>>() {
+		Nil<Function<List<String>, List<Integer>>> n1 = new Nil<>() {
 		};
-		Nil<Function<List<String>, Double>> n2 = new Nil<Function<List<String>, Double>>() {
+		Nil<Function<List<String>, Double>> n2 = new Nil<>() {
 		};
 		Nil<Function<List<Integer>, List<Double>>> n3 = new Nil<>() {
 		};
@@ -511,16 +511,11 @@ public class MatchingUtilsTest {
 
 	@Test
 	public <T extends Number> void testIsAssignableT() {
-		final Type t = new Nil<T>() {
-		}.getType();
-		final Type listT = new Nil<List<T>>() {
-		}.getType();
-		final Type listNumber = new Nil<List<Number>>() {
-		}.getType();
-		final Type listInteger = new Nil<List<Integer>>() {
-		}.getType();
-		final Type listExtendsNumber = new Nil<List<? extends Number>>() {
-		}.getType();
+		final Nil<T> t = new Nil<>() {};
+		final Nil<List<T>> listT = new Nil<>() {};
+		final Nil<List<Number>> listNumber = new Nil<>() {};
+		final Nil<List<Integer>> listInteger = new Nil<>() {};
+		final Nil<List<? extends Number>> listExtendsNumber = new Nil<>() {};
 
 		assertAll(List.class, true, listT, listNumber, listInteger, listExtendsNumber);
 		assertAll(List.class, false, t);

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -532,11 +532,13 @@ public class MatchingUtilsTest {
 		MatchingUtils.inferTypeVariables(tArgs, destArgs, typeAssigns);
 
 		// We expect I=String, O=Double
-		final Map<TypeVariable<?>, Type> expected = new HashMap<>();
-		expected.put((TypeVariable<?>) ((ParameterizedType) tArgs[0])
-			.getActualTypeArguments()[0], String.class);
-		expected.put((TypeVariable<?>) ((ParameterizedType) tArgs[1])
-			.getActualTypeArguments()[0], Double.class);
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		TypeVariable<?> typeVarI = (TypeVariable<?>) ((ParameterizedType) tArgs[0])
+			.getActualTypeArguments()[0];
+		expected.put(typeVarI, new TypeMapping(typeVarI, String.class, false));
+		TypeVariable<?> typeVarO = (TypeVariable<?>) ((ParameterizedType) tArgs[1])
+			.getActualTypeArguments()[0];
+		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, false));
 
 		assertEquals(typeAssigns, expected);
 	}
@@ -574,14 +576,14 @@ public class MatchingUtilsTest {
 
 		// We expect T=Double
 		final Type t = new Nil<T>() {}.getType();
-		final Map<TypeVariable<?>, Type> expected = new HashMap<>();
-		expected.put((TypeVariable<?>) t, Double.class);
+		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
+		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, false));
 
 		assertEquals(expected, typeAssigns);
 	}
 
-	// TODO: Use JUnit5
-	@Test(expected = TypeInferenceException.class)
+	@Test
 	public <T extends Number> void testInferTypeVarInconsistentMapping()
 		throws TypeInferenceException
 	{
@@ -591,10 +593,17 @@ public class MatchingUtilsTest {
 		final Type[] tArr = { t, t };
 		final Type[] badInferFrom = { Integer.class, Double.class };
 
-		MatchingUtils.inferTypeVariables(tArr, badInferFrom, new HashMap<>());
-
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
+		MatchingUtils.inferTypeVariables(tArr, badInferFrom, typeAssigns);
+		
+		// We expect T=Number
+		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
+		
+		assertEquals(expected, typeAssigns);
 	}
-
+	
 	class Thing<T> {}
 	
 	class StrangeThing<N extends Number, T> extends Thing<T> {}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -29,27 +29,19 @@
 
 package org.scijava.ops.matcher;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.junit.Test;
-import org.scijava.ops.matcher.MatchingUtils.TypeInferenceException;
-import org.scijava.ops.matcher.MatchingUtils.TypeMapping;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 
@@ -534,151 +526,6 @@ public class MatchingUtilsTest {
 		assertAll(List.class, false, t);
 	}
 	
-	@Test
-	public <I, O> void testSupertypeTypeInference()
-		throws TypeInferenceException
-	{
-		final Type t = new Nil<Function<Thing<I>, List<O>>>() {}.getType();
-		final Type[] tArgs = ((ParameterizedType) t).getActualTypeArguments();
-		final Type dest =
-			new Nil<Function<StrangeThing<Double, String>, List<Double>>>()
-			{}.getType();
-		final Type[] destArgs = ((ParameterizedType) dest).getActualTypeArguments();
-
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
-		MatchingUtils.inferTypeVariables(tArgs, destArgs, typeAssigns);
-
-		// We expect I=String, O=Double
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
-		TypeVariable<?> typeVarI = (TypeVariable<?>) ((ParameterizedType) tArgs[0])
-			.getActualTypeArguments()[0];
-		expected.put(typeVarI, new TypeMapping(typeVarI, String.class, false));
-		TypeVariable<?> typeVarO = (TypeVariable<?>) ((ParameterizedType) tArgs[1])
-			.getActualTypeArguments()[0];
-		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, false));
-
-		assertEquals(typeAssigns, expected);
-	}
-
-	@Test
-	public <T> void testWildcardTypeInference() throws TypeInferenceException {
-		final Type t = new Nil<T>() {}.getType();
-		final Type listWild = new Nil<List<? extends T>>() {}.getType();
-		final Type integer = new Nil<Integer>() {}.getType();
-		final Type listDouble = new Nil<List<Double>>() {}.getType();
-
-		final Type[] types = { listWild, t };
-		final Type[] inferFroms = { listDouble, integer };
-
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
-			new HashMap<>();
-		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
-
-		// We expect T=Number
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
-			new HashMap<>();
-		TypeVariable<?> typeVar = (TypeVariable<?>) t;
-		expected.put(typeVar, new TypeMapping(typeVar, Number.class, true));
-
-		assertEquals(expected, typeAssigns);
-
-		final Type[] types2 = { t, t };
-		final Type listWildcardNumber = new Nil<List<? extends Number>>() {}
-			.getType();
-		final Type wildcardNumber = ((ParameterizedType) listWildcardNumber)
-			.getActualTypeArguments()[0];
-		final Type listWildcardDouble = new Nil<List<? extends Double>>() {}
-			.getType();
-		final Type wildcardDouble = ((ParameterizedType) listWildcardDouble)
-			.getActualTypeArguments()[0];
-
-		final Type[] inferFroms2 = { wildcardNumber, wildcardDouble };
-
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns2 =
-			new HashMap<>();
-		MatchingUtils.inferTypeVariables(types2, inferFroms2, typeAssigns2);
-
-		// We expect T=Number
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected2 =
-			new HashMap<>();
-		TypeVariable<?> typeVar2 = (TypeVariable<?>) t;
-		expected2.put(typeVar2, new TypeMapping(typeVar, Number.class, true));
-
-		assertEquals(expected2, typeAssigns2);
-	}
-
-	@Test
-	public <T, U extends Comparable<Double>> void testInferFromTypeVar()
-		throws TypeInferenceException
-	{
-		final Type compT = new Nil<Comparable<T>>() {}.getType();
-		final Type u = new Nil<U>() {}.getType();
-
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
-		MatchingUtils.inferTypeVariables(compT, u, typeAssigns);
-
-		// We expect T=Double
-		final Type t = new Nil<T>() {}.getType();
-		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
-		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
-		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, false));
-
-		assertEquals(expected, typeAssigns);
-	}
-
-	@Test
-	public <T extends Number> void testInferTypeVarInconsistentMapping()
-		throws TypeInferenceException
-	{
-
-		final Type t = new Nil<T>() {}.getType();
-
-		final Type[] tArr = { t, t };
-		final Type[] badInferFrom = { Integer.class, Double.class };
-
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
-		MatchingUtils.inferTypeVariables(tArr, badInferFrom, typeAssigns);
-		
-		// We expect T=Number
-		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
-		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
-		
-		assertEquals(expected, typeAssigns);
-	}
-
-	@Test
-	public <T extends Number> void testInferGenericArrayTypeFromExtendingWildcardType() throws TypeInferenceException{
-		final Type type = new Nil<List<T[]>>() {}.getType();
-		final Type inferFrom = new Nil<List<? extends Double[]>>() {}.getType();
-
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
-		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
-
-		// We expect T=Double
-		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
-		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
-	
-		assertEquals(expected, typeAssigns);
-	}
-
-	@Test
-	public <T extends Number> void testInferGenericArrayTypeFromSuperWildcardType() throws TypeInferenceException{
-		final Type type = new Nil<List<T[]>>() {}.getType();
-		final Type inferFrom = new Nil<List<? super Double[]>>() {}.getType();
-
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns = new HashMap<>();
-		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
-
-		// We expect T=Double
-		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
-		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
-		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
-
-		assertEquals(expected, typeAssigns);
-	}
-
 	class Thing<T> {}
 	
 	class StrangeThing<N extends Number, T> extends Thing<T> {}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -561,7 +561,25 @@ public class MatchingUtilsTest {
 		
 		assertEquals(typeAssigns, expected);
 	}
-	
+
+	@Test
+	public <T, U extends Comparable<Double>> void testInferFromTypeVar()
+		throws TypeInferenceException
+	{
+		final Type compT = new Nil<Comparable<T>>() {}.getType();
+		final Type u = new Nil<U>() {}.getType();
+
+		final Map<TypeVariable<?>, Type> typeAssigns = new HashMap<>();
+		MatchingUtils.inferTypeVariables(compT, u, typeAssigns);
+
+		// We expect T=Double
+		final Type t = new Nil<T>() {}.getType();
+		final Map<TypeVariable<?>, Type> expected = new HashMap<>();
+		expected.put((TypeVariable<?>) t, Double.class);
+
+		assertEquals(expected, typeAssigns);
+	}
+
 	class Thing<T> {}
 	
 	class StrangeThing<N extends Number, T> extends Thing<T> {}

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -806,8 +806,13 @@ public final class Types {
 					for (int j = 0; j < typeVarsI.length; j++) {
 						typeVarsI[j] = castedTypes[j].getActualTypeArguments()[i];
 					}
-					resolvedTypeArgs[i] = wildcard(new Type[] { greatestCommonSuperType(typeVarsI, true) },
-							new Type[] {});
+					// If each of these types implements some recursive interface, e.g. Comparable,
+					// the best we can do is return an unbounded wildcard.
+					if (Arrays.equals(types, typeVarsI))
+						resolvedTypeArgs[i] = wildcard();
+					else
+						resolvedTypeArgs[i] = wildcard(new Type[] { greatestCommonSuperType(typeVarsI, true) },
+								new Type[] {});
 				}
 
 				// return supertype parameterized with the resolved type args

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -3416,6 +3416,11 @@ public final class Types {
 					wild)[0]) || containsTypeVariables(TypeUtils.getImplicitUpperBounds(
 						wild)[0]);
 			}
+			if (type instanceof GenericArrayType) {
+				// if this type contains type vars, they will be in the component type
+				final GenericArrayType genArrType = (GenericArrayType) type;
+				return containsTypeVariables(genArrType.getGenericComponentType());
+			}
 			return false;
 		}
 

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -2011,7 +2011,7 @@ public final class Types {
 			if (toType == null) {
 				throw new NullPointerException("Destination type is null");
 			}
-			return isAssignable(type, toType, null);
+			return isAssignable(type, toType, new HashMap<>());
 		}
 
 		/**

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -1286,9 +1286,16 @@ public final class Types {
 	 * @return
 	 */
 	public static Type[] mapVarToTypes(Type[] typesToMap, Map<TypeVariable<?>, Type> typeAssigns) {
-		return Arrays.stream(typesToMap).map(type -> Types.unrollVariables(typeAssigns, type, false))
-				.toArray(Type[]::new);
+		return Arrays.stream(typesToMap).map(type -> mapVarToTypes(type,
+			typeAssigns)).toArray(Type[]::new);
 	}
+
+	public static Type mapVarToTypes(Type typeToMap,
+		Map<TypeVariable<?>, Type> typeAssigns)
+	{
+		return Types.unrollVariables(typeAssigns, typeToMap, false);
+	}
+
 	/**
 	 * Converts the given string value to an enumeration constant of the specified
 	 * type.

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -3362,6 +3362,12 @@ public final class Types {
 						.getUpperBounds())).withLowerBounds(unrollBounds(typeArguments, wild
 							.getLowerBounds())).build();
 				}
+				if (type instanceof GenericArrayType) {
+					final GenericArrayType genArrType = (GenericArrayType) type;
+					final Type componentType = genArrType.getGenericComponentType();
+					final Type unrolledComponent = unrollVariables(typeArguments, componentType, followTypeVars);
+					return array(unrolledComponent);
+				}
 			}
 			return type;
 		}

--- a/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
@@ -1,5 +1,6 @@
 package org.scijava.types;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -157,10 +158,11 @@ public class GreatestCommonSupertypeTest {
 	}
 	
 	@Test
-	public void RecursiveThingTest() {
+	public void RecursiveClassTest() {
 		Type t1 = new Nil<StrangeThing>() {}.getType();
 		Type t2 = new Nil<WeirdThing>() {}.getType();
 		Type superType = Types.greatestCommonSuperType(new Type[] {t1, t2}, false);
-		assertTrue(superType.equals(Object.class));
+		Nil<RecursiveThing<?>> expected = new Nil<>() {};
+		assertTrue(superType.equals(expected.getType()));
 	}
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -163,6 +164,28 @@ public class GreatestCommonSupertypeTest {
 		Type t2 = new Nil<WeirdThing>() {}.getType();
 		Type superType = Types.greatestCommonSuperType(new Type[] {t1, t2}, false);
 		Nil<RecursiveThing<?>> expected = new Nil<>() {};
+		assertTrue(superType.equals(expected.getType()));
+	}
+
+	@Test
+	public <T extends Base> void typeVarTest() {
+		Type t1 = new Nil<T>() {}.getType();
+		Type t2 = new Nil<NThing>() {}.getType();
+		Type superType = Types.greatestCommonSuperType(new Type[] { t1, t2 },
+			false);
+		Nil<Base> expected = new Nil<>() {};
+		assertTrue(superType.equals(expected.getType()));
+	}
+
+	@Test
+	public void wildcardTypeTest() {
+		Type typeWithWildcard = new Nil<List<? extends NThing>>() {}.getType();
+		Type t1 = ((ParameterizedType) typeWithWildcard)
+			.getActualTypeArguments()[0];
+		Type t2 = new Nil<XThing>() {}.getType();
+		Type superType = Types.greatestCommonSuperType(new Type[] { t1, t2 },
+			false);
+		Nil<Base> expected = new Nil<>() {};
 		assertTrue(superType.equals(expected.getType()));
 	}
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/GreatestCommonSupertypeTest.java
@@ -38,6 +38,18 @@ public class GreatestCommonSupertypeTest {
 	static class YThing implements Thing {
 
 	}
+	
+	static abstract class RecursiveThing<T extends RecursiveThing<T>> {
+		
+	}
+	
+	static class StrangeThing extends RecursiveThing<StrangeThing> {
+		
+	}
+	
+	static class WeirdThing extends RecursiveThing<WeirdThing> {
+		
+	}
 
 	@Test
 	public void DoubleTest() {
@@ -142,5 +154,13 @@ public class GreatestCommonSupertypeTest {
 		assertTrue(superType.equals(new Nil<Base>() {}.getType()));
 		assertFalse(superType.equals(new Nil<Thing>() {}.getType()),
 			"Non-Object classes should take precedence over interfaces");
+	}
+	
+	@Test
+	public void RecursiveThingTest() {
+		Type t1 = new Nil<StrangeThing>() {}.getType();
+		Type t2 = new Nil<WeirdThing>() {}.getType();
+		Type superType = Types.greatestCommonSuperType(new Type[] {t1, t2}, false);
+		assertTrue(superType.equals(Object.class));
 	}
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
@@ -552,9 +552,9 @@ public class TypesTest {
 		assertTrue(Types.isAssignable(listNumber, listExtendsNumber));
 		assertTrue(Types.isAssignable(listInteger, listExtendsNumber));
 
-		assertFalse(Types.isAssignable(listNumber, listT));
-		assertFalse(Types.isAssignable(listInteger, listT));
-		assertFalse(Types.isAssignable(listExtendsNumber, listT));
+		assertTrue(Types.isAssignable(listNumber, listT));
+		assertTrue(Types.isAssignable(listInteger, listT));
+		assertTrue(Types.isAssignable(listExtendsNumber, listT));
 		assertFalse(Types.isAssignable(listExtendsNumber, listNumber));
 	}
 


### PR DESCRIPTION
This PR introduces changes that clean up `MatchingUtils` and add missing support

TODO: 
- [x] Add support for `WildcardType`s in `MatchingUtils.inferTypeVariables()`