### PR TITLE
Add assertCloseEnough

### DIFF
--- a/imagej/imagej-ops2/pom.xml
+++ b/imagej/imagej-ops2/pom.xml
@@ -343,13 +343,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
-			<artifactId>scijava-test-util</artifactId>
+			<artifactId>scijava-testutil</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>imagej-test-util</artifactId>
+			<artifactId>imagej-testutil</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/ShuffledViewTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/ShuffledViewTest.java
@@ -39,7 +39,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.view.Views;
 
 import org.junit.jupiter.api.Test;
-import org.scijava.test_util.AssertIterations;
+import org.scijava.testutil.AssertIterations;
 
 public class ShuffledViewTest extends ColocalisationTest {
 

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/icq/LiICQTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/coloc/icq/LiICQTest.java
@@ -37,7 +37,7 @@ import java.util.function.BiFunction;
 
 import net.imagej.ops2.coloc.ColocalisationTest;
 import net.imagej.ops2.coloc.pValue.PValueResult;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/FFTTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/FFTTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.concurrent.ExecutorService;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.FinalDimensions;
 import net.imglib2.IterableInterval;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/NonLinearFiltersTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/NonLinearFiltersTest.java
@@ -41,7 +41,7 @@ import net.imagej.ops2.filter.median.DefaultMedianFilter;
 import net.imagej.ops2.filter.min.DefaultMinFilter;
 import net.imagej.ops2.filter.sigma.DefaultSigmaFilter;
 import net.imagej.ops2.filter.variance.DefaultVarianceFilter;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.algorithm.neighborhood.RectangleShape.NeighborhoodsIterableInterval;
 import net.imglib2.img.Img;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/bilateral/DefaultBilateralTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/bilateral/DefaultBilateralTest.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.filter.bilateral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivative/PartialDerivativeFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivative/PartialDerivativeFilterTest.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.filter.derivative;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGaussTest.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.filter.derivativeGauss;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccess;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/dog/DoGTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/dog/DoGTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.dog.DifferenceOfGaussian;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/gauss/GaussTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/gauss/GaussTest.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.filter.gauss;
 import java.util.concurrent.ExecutorService;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.algorithm.gauss3.Gauss3;
 import net.imglib2.exception.IncompatibleTypeException;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/hessian/HessianFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/hessian/HessianFilterTest.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.filter.hessian;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.real.FloatType;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/sobel/SobelFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/sobel/SobelFilterTest.java
@@ -31,7 +31,7 @@ package net.imagej.ops2.filter.sobel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/tubeness/TubenessTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/tubeness/TubenessTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.junit.jupiter.api.Test;
 import org.scijava.types.Nil;
-import org.scijava.test_util.AssertIterations;
+import org.scijava.testutil.AssertIterations;
 import org.scijava.thread.ThreadService;
 
 import net.imagej.ops2.AbstractOpTest;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/IntegralImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/IntegralImgTest.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.image.integral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.IterableInterval;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/SquareIntegralImgTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/integral/SquareIntegralImgTest.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.image.integral;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/invert/InvertTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/invert/InvertTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.math.BigInteger;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imagej.types.UnboundedIntegerType;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
@@ -238,7 +238,7 @@ public class InvertTest extends AbstractOpTest {
 				new UnsignedShortType((short) 8008));
 	}
 
-	//TODO: resolve imagej-common dependency within imagej-test-util
+	//TODO: resolve imagej-common dependency within imagej-testutil
 //	@Test
 //	public void testUnboundedIntegerTypeInvert() {
 //		final Img<UnboundedIntegerType> inUnboundedIntegerType = TestImgGeneration.generateUnboundedIntegerTypeListTestImg(true, 5, 5);

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/image/normalize/NormalizeTest.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.image.normalize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.img.Img;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Iterator;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.ByteType;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/blackTopHat/BlackTopHatTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/blackTopHat/BlackTopHatTest.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.IterableInterval;
 import net.imglib2.algorithm.morphology.BlackTopHat;
 import net.imglib2.algorithm.neighborhood.DiamondShape;
@@ -48,7 +48,7 @@ import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.scijava.test_util.AssertIterations;
+import org.scijava.testutil.AssertIterations;
 import org.scijava.types.Nil;
 
 /**

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/thin/ThinningTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/morphology/thin/ThinningTest.java
@@ -39,7 +39,7 @@ import net.imglib2.type.numeric.real.FloatType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.scijava.test_util.AssertIterations;
+import org.scijava.testutil.AssertIterations;
 import org.scijava.types.Nil;
 
 /**

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/project/ProjectTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/project/ProjectTest.java
@@ -32,7 +32,7 @@ package net.imagej.ops2.project;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.UnsignedByteType;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidgesTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidgesTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.scijava.types.Nil;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
 import net.imglib2.roi.geom.real.DefaultWritablePolyline;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/slice/SliceTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/slice/SliceTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Iterator;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/DefaultMedianTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/DefaultMedianTest.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/stats/StatisticsTest.java
@@ -30,7 +30,7 @@
 package net.imagej.ops2.stats;
 
 import net.imagej.ops2.AbstractOpTest;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;

--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/threshold/apply/LocalThresholdTest.java
@@ -55,7 +55,7 @@ import net.imagej.ops2.threshold.localMean.LocalMeanThreshold;
 import net.imagej.ops2.threshold.localMedian.LocalMedianThreshold;
 import net.imagej.ops2.threshold.localNiblack.LocalNiblackThreshold;
 import net.imagej.ops2.threshold.localSauvola.LocalSauvolaThreshold;
-import net.imagej.test_util.TestImgGeneration;
+import net.imagej.testutil.TestImgGeneration;
 import net.imglib2.Cursor;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;

--- a/imagej/imagej-testutil/pom.xml
+++ b/imagej/imagej-testutil/pom.xml
@@ -10,15 +10,15 @@
 	</parent>
 
 	<groupId>net.imagej</groupId>
-	<artifactId>imagej-test-util</artifactId>
+	<artifactId>imagej-testutil</artifactId>
 
 	<name>ImageJ Test Util</name>
-	<description>ImageJ Test Util: a testing framework for reusable algorithms.</description>
+	<description>Shared test utilities for ImageJ projects.</description>
 	<url>None</url>
 	<inceptionYear>2020</inceptionYear>
 	<organization>
 		<name>ImageJ</name>
-		<url>http://imagej.net/</url>
+		<url>https://imagej.net/</url>
 	</organization>
 	<licenses>
 		<license>
@@ -31,12 +31,10 @@
 		<developer>
 			<id>ctrueden</id>
 			<name>Curtis Rueden</name>
-			<url>http://imagej.net/User:Rueden</url>
+			<url>https://imagej.net/User:Rueden</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
-				<role>developer</role>
-				<role>debugger</role>
 				<role>reviewer</role>
 				<role>support</role>
 				<role>maintainer</role>
@@ -58,23 +56,19 @@
 		</developer>
 	</developers>
 	<contributors>
-		<!-- TODO: Remove -->
+		<!--
+		NB: Need a least one element to override the parent.
+		See: https://issues.apache.org/jira/browse/MNG-5220
+		-->
 		<contributor>
-			<name>Christian Dietz</name>
-			<url>https://imagej.net/User:Dietzc</url>
-			<roles>
-				<role>founder</role>
-			</roles>
-			<properties>
-				<id>dietzc</id>
-			</properties>
+			<name>None</name>
 		</contributor>
 	</contributors>
 
 	<mailingLists>
 		<mailingList>
 			<name>Image.sc Forum</name>
-			<archive>https://forum.image.sc/</archive>
+			<archive>https://forum.image.sc/tag/imagej</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -86,7 +80,7 @@
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/imagej/imagej-test-util/issues</url>
+		<url>https://github.com/imagej/imagej-testutil/issues</url>
 	</issueManagement>
 	<ciManagement>
 		<system>Travis CI</system>
@@ -94,8 +88,8 @@
 	</ciManagement>
 
 	<properties>
-		<package-name>net.imagej.test_util</package-name>
-		<main-class>net.imagej.test_util.Main</main-class>
+		<package-name>net.imagej.testutil</package-name>
+		<main-class>net.imagej.testutil.Main</main-class>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>ImageJ developers.</license.copyrightOwners>
 
@@ -141,7 +135,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
-			<artifactId>scijava-test-util</artifactId>
+			<artifactId>scijava-testutil</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/imagej/imagej-testutil/pom.xml
+++ b/imagej/imagej-testutil/pom.xml
@@ -105,39 +105,16 @@
 	</repositories>
 
 	<dependencies>
-		<!-- ImageJ dependencies -->
+		<!-- SciJava dependencies -->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+		</dependency>
 
 		<!-- ImgLib2 dependencies -->
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-		</dependency>
-
-		<!-- SciJava dependencies -->
-		<dependency>
-			<!-- Do not remove - Maven incorrectly identifies it as an unused dependency!  -->
-			<groupId>org.scijava</groupId>
-			<artifactId>scripting-javascript</artifactId>
-		</dependency>
-
-		<!-- Third party dependencies -->
-		
-		<!-- Test scope dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>junit-benchmarks</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scijava-testutil</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/imagej/imagej-testutil/src/main/java/net/imagej/testutil/TestImgGeneration.java
+++ b/imagej/imagej-testutil/src/main/java/net/imagej/testutil/TestImgGeneration.java
@@ -1,4 +1,4 @@
-package net.imagej.test_util;
+package net.imagej.testutil;
 
 import java.math.BigInteger;
 import java.util.Random;

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
 
 	<modules>
 		<module>imagej/imagej-ops2</module>
-		<module>imagej/imagej-test-util</module>
+		<module>imagej/imagej-testutil</module>
 		<module>scijava/scijava-ops</module>
-		<module>scijava/scijava-test-util</module>
+		<module>scijava/scijava-testutil</module>
 		<module>scijava/scijava-types</module>
 	</modules>
 

--- a/scijava/scijava-ops/pom.xml
+++ b/scijava/scijava-ops/pom.xml
@@ -164,7 +164,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
-			<artifactId>scijava-test-util</artifactId>
+			<artifactId>scijava-testutil</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/scijava/scijava-testutil/pom.xml
+++ b/scijava/scijava-testutil/pom.xml
@@ -11,11 +11,11 @@
 		<relativePath>../..</relativePath>
 	</parent>
 
-	<artifactId>scijava-test-util</artifactId>
+	<artifactId>scijava-testutil</artifactId>
 
-	<name>SciJava Test-Util</name>
-	<description>SciJava Test Utils: a set of shared test utilities for Scijava projects.</description>
-	<url>https://github.com/scijava/scijava-test-util</url>
+	<name>SciJava Test Util</name>
+	<description>Shared test utilities for SciJava projects.</description>
+	<url>None</url>
 	<inceptionYear>2020</inceptionYear>
 	<organization>
 		<name>SciJava</name>
@@ -54,23 +54,19 @@
 		</developer>
 	</developers>
 	<contributors>
-		<!-- TODO: Remove -->
+		<!--
+		NB: Need a least one element to override the parent.
+		See: https://issues.apache.org/jira/browse/MNG-5220
+		-->
 		<contributor>
-			<name>Christian Dietz</name>
-			<url>https://imagej.net/User:Dietzc</url>
-			<roles>
-				<role>founder</role>
-			</roles>
-			<properties>
-				<id>dietzc</id>
-			</properties>
+			<name>None</name>
 		</contributor>
 	</contributors>
 
 	<mailingLists>
 		<mailingList>
 			<name>Image.sc Forum</name>
-			<archive>https://forum.image.sc/tags/scijava-test-util</archive>
+			<archive>https://forum.image.sc/tag/scijava</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -82,16 +78,16 @@
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/scijava/scijava-test-util/issues</url>
+		<url>https://github.com/scijava/scijava-testutil/issues</url>
 	</issueManagement>
 	<ciManagement>
 		<system>Travis CI</system>
-		<url>https://travis-ci.com/scijava/test-util</url>
+		<url>https://travis-ci.org/scijava/incubator</url>
 	</ciManagement>
 
 	<properties>
-		<main-class>org.scijava.test_util.Main</main-class>
-		<package-name>org.scijava.test_util</package-name>
+		<main-class>org.scijava.testutil.Main</main-class>
+		<package-name>org.scijava.testutil</package-name>
 
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>SciJava developers.</license.copyrightOwners>

--- a/scijava/scijava-testutil/pom.xml
+++ b/scijava/scijava-testutil/pom.xml
@@ -94,19 +94,27 @@
 	</properties>
 
 	<dependencies>
-		<!-- SciJava dependencies -->
-		<!-- TODO: do we need this? -->
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scijava-common</artifactId>
-		</dependency>
+		<!-- JUnit dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>compile</scope>
 		</dependency>
-
-		<!-- TOOD: can we delete this section? -->
-		<!-- Test scope dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 </project>
 

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertClose.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * SciJava Operations: a framework for reusable algorithms.
+ * %%
+ * Copyright (C) 2018 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.testutil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Assertions to be used when a relative delta should be used to compare the
+ * actual and expected values.
+ *
+ * @author Gabriel Selzer
+ * @see Assertions
+ */
+public class AssertClose {
+
+	/**
+	 * <em>Assert</em> that {@code expected} and {@code actual} are equal within
+	 * the non-negative delta {@code 10^epsilonExp}.
+	 * 
+	 * @param expected
+	 * @param actual
+	 * @param epsilonExp
+	 */
+	public static void asesrtCloseEnough(double expected, double actual,
+		int epsilonExp)
+	{
+		double numerator = Math.abs(expected);
+		double denominator = Math.pow(10., epsilonExp);
+		double epsilon = numerator / denominator;
+		assertEquals(expected, actual, epsilon);
+	}
+
+}

--- a/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertIterations.java
+++ b/scijava/scijava-testutil/src/main/java/org/scijava/testutil/AssertIterations.java
@@ -1,4 +1,4 @@
-package org.scijava.test_util;
+package org.scijava.testutil;
 
 import java.util.Iterator;
 

--- a/scijava/scijava-testutil/src/test/java/org/scijava/testutil/AppTest.java
+++ b/scijava/scijava-testutil/src/test/java/org/scijava/testutil/AppTest.java
@@ -1,4 +1,4 @@
-package org.scijava.test_util;
+package org.scijava.testutil;
 
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
This PR introduces `assertCloseEnough`, which allows users to specify a "relative" epsilon instead of an absolute one. This can be useful if a test class contains various assertions comparing numbers of vastly different magnitudes. This method gives testers the ability to provide assert a consistent number of decimal places instead of a consistent non-negative delta.

This PR also cleans up scijava-test-util:
* Updates the JUnit dependency to JUnit5
* Removes an autogenerated test
* Renames the package `org.scijava.test_util` to `org.scijava.testutil`.