### PR TITLE
inferTypeVariables: insert Anys in Map when applicable

### DIFF
--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -627,6 +627,8 @@ public final class MatchingUtils {
 					" cannot be implicitly cast to " + mappedType +
 					", thus it is impossible to infer type variables for " + inferFrom);
 			}
+			// for all remaining unmapped type vars, map to Any
+			mapTypeVarsToAny(type, typeMappings);
 		}
 		// -- edge cases -> do our best -- //
 		else if (superInferFrom == null) {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -550,7 +550,9 @@ public final class MatchingUtils {
 
 	}
 
-	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable) {
+	private static void inferTypeVariables(TypeVariable<?> type, Type inferFrom,
+		Map<TypeVariable<?>, TypeMapping> typeMappings, boolean malleable)
+	{
 		TypeMapping typeData = typeMappings.get(type);
 		// If current is not null then we have already encountered that
 		// variable. If so, we require them to be exactly the same, and throw a
@@ -560,106 +562,118 @@ public final class MatchingUtils {
 		}
 		else {
 			resolveTypeInMap(type, inferFrom, typeMappings, malleable);
-		}
-
-		// Bounds could also contain type vars, hence possibly go into
-		// recursion
-		for (Type bound : type.getBounds()) {
-			if (bound instanceof TypeVariable && typeMappings.get(bound) != null) {
-				// If the bound of the current var (let's call it A) to
-				// infer is also a var (let's call it B):
-				// If we already encountered B, we check if the current
-				// type to infer from is assignable to
-				// the already inferred type for B. In this case we do
-				// not require equality as one var is
-				// bounded by another and it is not the same. E.g.
-				// assume we want to infer the types of vars:
-				// - - - A extends Number, B extends A
-				// From types:
-				// - - - Number, Double
-				// First A is bound to Number, next B to Double. Then we
-				// check the bounds for B. We encounter A,
-				// for which we already inferred Number. Hence, it
-				// suffices to check whether Double can be assigned
-				// to Number, it does not have to be equal as it is just
-				// a transitive bound for B.
-				Type typeAssignForBound = typeMappings.get(bound).getType();
-				if (!Types.isAssignable(inferFrom, typeAssignForBound)) {
-					throw new TypeInferenceException();
+			// Bounds could also contain type vars, hence possibly go into
+			// recursion
+			for (Type bound : type.getBounds()) {
+				if (bound instanceof TypeVariable && typeMappings.get(bound) != null) {
+					// If the bound of the current var (let's call it A) to
+					// infer is also a var (let's call it B):
+					// If we already encountered B, we check if the current
+					// type to infer from is assignable to
+					// the already inferred type for B. In this case we do
+					// not require equality as one var is
+					// bounded by another and it is not the same. E.g.
+					// assume we want to infer the types of vars:
+					// - - - A extends Number, B extends A
+					// From types:
+					// - - - Number, Double
+					// First A is bound to Number, next B to Double. Then we
+					// check the bounds for B. We encounter A,
+					// for which we already inferred Number. Hence, it
+					// suffices to check whether Double can be assigned
+					// to Number, it does not have to be equal as it is just
+					// a transitive bound for B.
+					Type typeAssignForBound = typeMappings.get(bound).getType();
+					if (!Types.isAssignable(inferFrom, typeAssignForBound)) {
+						throw new TypeInferenceException();
+					}
 				}
-			} else {
-				// Else go into recursion as we encountered a new var.
-				inferTypeVariables( bound, inferFrom, typeMappings);
-			}	
+				else {
+					// Else go into recursion as we encountered a new var.
+					inferTypeVariables(bound, inferFrom, typeMappings);
+				}
+			}
+
 		}
 	}
 
-	private static void inferTypeVariables(ParameterizedType type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
-		// Recursively follow parameterized types
-		if (inferFrom instanceof ParameterizedType) {
-			// Finding the supertype here is really important. Suppose that we are
-			// inferring from a StrangeThing<Long> extends Thing<Double> and our
-			// Op requires a Thing<T>. We need to ensure that T gets
-			// resolved to a Double and NOT a Long.
-			ParameterizedType paramInferFrom = (ParameterizedType) Types
-				.getExactSuperType(inferFrom, Types.raw(type));
-			if (paramInferFrom == null) {
-				// this means that inferFrom is NOT a superType of type. There is,
-				// however, one more thing that we can try. It is possible for inferFrom
-				// to be a subType of type (this can often happen when
-				// checkGenericAssignability is working with Functions). In this case,
-				// it is possible that inferFrom has information about the typeVariables
-				// of type.
-				ParameterizedType superTypeOfType = (ParameterizedType) Types
-					.getExactSuperType(type, Types.raw(inferFrom));
-				if (superTypeOfType == null) {
-					throw new TypeInferenceException(inferFrom +
-						" cannot be implicitly cast to " + type +
-						", thus it is impossible to infer type variables for " + inferFrom);
-				}
-				inferTypeVariables(superTypeOfType.getActualTypeArguments(),
-					((ParameterizedType) inferFrom).getActualTypeArguments(),
-					typeMappings, false);
-			}
-			else {
-				inferTypeVariables(type.getActualTypeArguments(), paramInferFrom
-					.getActualTypeArguments(), typeMappings, false);
-			}
+	private static void inferTypeVariables(ParameterizedType type, Type inferFrom,
+		Map<TypeVariable<?>, TypeMapping> typeMappings)
+	{
+		if (inferFrom instanceof WildcardType) {
+			inferFrom = getInferrableBound((WildcardType) inferFrom);
 		}
-		else {
-			// getExactSuperType does not return Object as a superType for any
-			// interface, so we cover it here.
-			// TODO: clean
-			if (Object.class.equals(inferFrom)) {
-				mapTypeVarsToAny(type, typeMappings);
-				return;
-			}
-			if (inferFrom instanceof WildcardType) {
-				WildcardType inferFromWildcard = (WildcardType) inferFrom;
-				if (inferFromWildcard.getUpperBounds().length == 1) inferFrom = inferFromWildcard.getUpperBounds()[0];
-			}
+		if (inferFrom instanceof Any) {
+			Any any = (Any) inferFrom;
+			mapTypeVarsToAny(type, any, typeMappings);
+			return;
+		}
+		// Finding the supertype here is really important. Suppose that we are
+		// inferring from a StrangeThing<Long> extends Thing<Double> and our
+		// Op requires a Thing<T>. We need to ensure that T gets
+		// resolved to a Double and NOT a Long.
+		Type superInferFrom = Types.getExactSuperType(inferFrom, Types.raw(type));
+		if (superInferFrom instanceof ParameterizedType) {
+			ParameterizedType paramInferFrom = (ParameterizedType) superInferFrom;
+			inferTypeVariables(type.getActualTypeArguments(), paramInferFrom
+				.getActualTypeArguments(), typeMappings, false);
+		}
+		else if (superInferFrom instanceof Class) {
 			TypeVarAssigns typeVarAssigns = new TypeVarAssigns(typeMappings);
 			Type mappedType = Types.mapVarToTypes(type, typeVarAssigns);
 			// Use isAssignable to attempt to infer the type variables present in type
-			if (!Types.isAssignable(inferFrom, mappedType, typeVarAssigns)) {
+			if (!Types.isAssignable(superInferFrom, mappedType, typeVarAssigns)) {
 				throw new TypeInferenceException(inferFrom +
 					" cannot be implicitly cast to " + mappedType +
 					", thus it is impossible to infer type variables for " + inferFrom);
 			}
 		}
+		// -- edge cases -> do our best -- //
+		else if (superInferFrom == null) {
+			// edge case 1: if inferFrom is an Object, superInferFrom will be null
+			// when type is some interface.
+			if (Object.class.equals(inferFrom)) {
+				mapTypeVarsToAny(type, typeMappings);
+				return;
+			}
+			// edge case 2: if inferFrom is a superType of type, we can get (some of)
+			// the types of type by finding the exact superType of type w.r.t.
+			// inferFrom.
+			Type superTypeOfType = Types.getExactSuperType(type, Types.raw(
+				inferFrom));
+			if (superTypeOfType == null) {
+				throw new TypeInferenceException(inferFrom +
+					" cannot be implicitly cast to " + type +
+					", thus it is impossible to infer type variables for " + inferFrom);
+			}
+			inferTypeVariables(superTypeOfType, inferFrom, typeMappings, false);
+			mapTypeVarsToAny(type, typeMappings);
+		}
+		// TODO: elaborate
+		else throw new IllegalStateException(superInferFrom +
+			" is the supertype of " + inferFrom + " with respect to " + type +
+			", however this cannot be (since " + type +
+			" is a ParamterizedType)! (Only a ParameterizedType, Class, or null " +
+			"can be returned from Types.getExactSuperType when it is called with a ParameterizedType!)");
 	}
-	
+
 	private static void mapTypeVarsToAny(Type type,
 		Map<TypeVariable<?>, TypeMapping> typeMappings)
 	{
-		if(!Types.containsTypeVars(type)) return;
+		mapTypeVarsToAny(type, new Any(), typeMappings);
+	}
 
-		if(type instanceof TypeVariable) {
+	private static void mapTypeVarsToAny(Type type, Any any,
+		Map<TypeVariable<?>, TypeMapping> typeMappings)
+	{
+		if (!Types.containsTypeVars(type)) return;
+
+		if (type instanceof TypeVariable) {
 			if (typeMappings.containsKey(type)) return;
 			TypeVariable<?> typeVar = (TypeVariable<?>) type;
-			typeMappings.put(typeVar, suitableTypeMapping(typeVar, new Any(), true));
+			typeMappings.put(typeVar, suitableTypeMapping(typeVar, any, true));
 		}
-		else if(type instanceof ParameterizedType) {
+		else if (type instanceof ParameterizedType) {
 			ParameterizedType pType = (ParameterizedType) type;
 			Type[] typeParams = pType.getActualTypeArguments();
 			for (Type typeParam : typeParams) {

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderNoOutputTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderNoOutputTest.java
@@ -1,0 +1,53 @@
+
+package org.scijava.ops.core.builder;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.scijava.ops.AbstractTestEnvironment;
+import org.scijava.ops.OpField;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+import org.scijava.types.Nil;
+import org.scijava.types.TypeService;
+
+/**
+ * Ensures correct behavior in {@link OpBuilder} calls <b>where no output type
+ * or <code>Object</code> is given</b>.
+ *
+ * @author Gabriel Selzer
+ * @see OpBuilderTest
+ */
+@Plugin(type = OpCollection.class)
+public class OpBuilderNoOutputTest<T extends Number> extends
+	AbstractTestEnvironment
+{
+
+	public final String opName = "test.noOutput";
+
+	// private wrapper class
+	private static class WrappedList<E> extends ArrayList<E> {}
+
+	@OpField(names = opName)
+	@Parameter(key = "in", itemIO = ItemIO.INPUT)
+	@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+	public final Function<T, WrappedList<T>> func = in -> {
+
+		WrappedList<T> out = new WrappedList<>();
+		out.add(in);
+		return out;
+	};
+
+	@Test
+	public void testNoParameterizedTypeOutputGiven() {
+		Object output = ops.op(opName).input(5.).apply();
+		TypeService types = context.getService(TypeService.class);
+		Type expectedOutputType = new Nil<WrappedList<Double>>() {}.getType();
+		Assert.assertEquals(types.reify(output), expectedOutputType);
+	}
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/core/builder/OpBuilderTest.java
@@ -43,36 +43,47 @@ import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Inplaces;
 import org.scijava.ops.function.Producer;
 
-// @formatter:off
 /**
- * Tests {@link OpBuilder}.
- * 
- * For each arity, we test the following matches and run the following commands 
- * based on the information scenarios.
- * 
- * * Input TYPES are given (IT) 
- * 	1) The output is unspecified (OU): 
- * 		a) match: Function, Inplace
- * 		b) run: none
- * 	2) The output type is given (OT): 
- * 		a) match: Function, Computer
- * 		b) run: none
- *  
- * * Input VALUES are given (IV) (N.B. this case applies for Arity0):
- * 	1) The output is unspecified (OU): 
- * 		a) match: Function, Inplace
- * 		b) run: apply, mutate
- * 	2) The output type is given (OT): 
- * 		a) match: Function, Computer
- * 		b) run: apply
- * 	3) The output value is given (OV): 
- * 		a) match: Computer
- *  	b) run: compute
+ * Tests {@link OpBuilder}. For each arity, we test the following matches and
+ * run the following commands based on the information scenarios.
+ * <p>
+ * Input TYPES are given (IT):
+ * <p>
+ * <ol>
+ * <li>The output is unspecified (OU):
+ * <ol type="a">
+ * <li>match: Function, Inplace
+ * <li>run: none
+ * </ol>
+ * <li>The output type is given (OT):
+ * <ol type="a">
+ * <li>match: Function, Computer
+ * <li>run: none
+ * </ol>
+ * </ol>
+ * Input VALUES are given (IV) (N.B. this case applies for Arity0):
+ * <p>
+ * <ol>
+ * <li>The output is unspecified (OU):
+ * <ol type="a">
+ * <li>match: Function, Inplace
+ * <li>run: apply, mutate
+ * </ol>
+ * <li>The output type is given (OT):
+ * <ol type="a">
+ * <li>match: Function, Computer
+ * <li>run: apply
+ * </ol>
+ * <li>The output value is given (OV):
+ * <ol type="a">
+ * <li>match: Computer
+ * <li>run: compute
+ * </ol>
+ * </ol>
  * 
  * @author Curtis Rueden
  * @author Gabriel Selzer
  */
-// @formatter:on
 public class OpBuilderTest extends AbstractTestEnvironment {
 
 	final double[] halves = new double[10];

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -332,6 +332,25 @@ public class InferTypeVariablesTest {
 		assertEquals(expected, typeAssigns);
 	}
 	
+	@Test
+	public <O extends Number> void testInferOToAnyWithRawType()
+		throws TypeInferenceException
+	{
+		final Type type = new Nil<TypedBar<O>>() {}.getType();
+		final Type inferFrom = TypedBar.class;
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
+
+		// We expect O = Any
+		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
 	class Bar {
 		
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -7,16 +7,19 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.Test;
+import org.scijava.ops.function.Producer;
 import org.scijava.ops.matcher.MatchingUtils.TypeInferenceException;
 import org.scijava.ops.matcher.MatchingUtils.TypeMapping;
 import org.scijava.ops.matcher.MatchingUtilsTest.StrangeThing;
 import org.scijava.ops.matcher.MatchingUtilsTest.Thing;
+import org.scijava.types.Any;
 import org.scijava.types.Nil;
 
 public class InferTypeVariablesTest {
@@ -268,6 +271,25 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
 		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
+
+		assertEquals(expected, typeAssigns);
+	}
+
+	@Test
+	public <O extends Number> void testInferOToAny()
+		throws TypeInferenceException
+	{
+		final Type iterableO = new Nil<Iterable<O>>() {}.getType();
+		final Type object = Object.class;
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(iterableO, object, typeAssigns);
+
+		// We expect O = Any
+		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
 
 		assertEquals(expected, typeAssigns);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -293,4 +293,50 @@ public class InferTypeVariablesTest {
 
 		assertEquals(expected, typeAssigns);
 	}
+
+	@Test
+	public <O extends Number> void testInferOToAnyWithInterface()
+		throws TypeInferenceException
+	{
+		final Type type = new Nil<ArrayList<O>>() {}.getType();
+		final Type inferFrom = Cloneable.class;
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
+
+		// We expect O = Any
+		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
+
+		assertEquals(expected, typeAssigns);
+	}
+	
+	@Test
+	public <O extends Number> void testInferOToAnyWithClass()
+		throws TypeInferenceException
+	{
+		final Type type = new Nil<TypedBar<O>>() {}.getType();
+		final Type inferFrom = Bar.class;
+
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
+			new HashMap<>();
+		MatchingUtils.inferTypeVariables(type, inferFrom, typeAssigns);
+
+		// We expect O = Any
+		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
+		Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected = new HashMap<>();
+		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
+
+		assertEquals(expected, typeAssigns);
+	}
+	
+	class Bar {
+		
+	}
+	
+	class TypedBar<E> extends Bar {
+		E type;
+	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingUtilsTest.java
@@ -43,6 +43,7 @@ import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 
@@ -547,7 +548,19 @@ public class MatchingUtilsTest {
 		assertAll(List.class, true, listT, listNumber, listInteger, listExtendsNumber);
 		assertAll(List.class, false, t);
 	}
-	
+
+	@Test
+	public <T extends Number> void testIsAssignableOutputToObject() {
+		final Type fooSource = new Nil<Function<T, List<T>>>() {}.getType();
+		final Type fooFunc = new Nil<Function<Double, Object>>() {}.getType();
+
+		Assertions.assertFalse(MatchingUtils.checkGenericAssignability(fooSource,
+			(ParameterizedType) fooFunc, false));
+		Assertions.assertTrue(MatchingUtils.checkGenericAssignability(fooSource,
+			(ParameterizedType) fooFunc, true));
+
+	}
+
 	class Thing<T> {}
 	
 	class StrangeThing<N extends Number, T> extends Thing<T> {}

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/builder/OpBuilderTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/core/builder/OpBuilderTest.vm
@@ -43,36 +43,47 @@ import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Inplaces;
 import org.scijava.ops.function.Producer;
 
-// @formatter:off
 /**
- * Tests {@link OpBuilder}.
- * 
- * For each arity, we test the following matches and run the following commands 
- * based on the information scenarios.
- * 
- * * Input TYPES are given (IT) 
- * 	1) The output is unspecified (OU): 
- * 		a) match: Function, Inplace
- * 		b) run: none
- * 	2) The output type is given (OT): 
- * 		a) match: Function, Computer
- * 		b) run: none
- *  
- * * Input VALUES are given (IV) (N.B. this case applies for Arity0):
- * 	1) The output is unspecified (OU): 
- * 		a) match: Function, Inplace
- * 		b) run: apply, mutate
- * 	2) The output type is given (OT): 
- * 		a) match: Function, Computer
- * 		b) run: apply
- * 	3) The output value is given (OV): 
- * 		a) match: Computer
- *  	b) run: compute
+ * Tests {@link OpBuilder}. For each arity, we test the following matches and
+ * run the following commands based on the information scenarios.
+ * <p>
+ * Input TYPES are given (IT):
+ * <p>
+ * <ol>
+ * <li>The output is unspecified (OU):
+ * <ol type="a">
+ * <li>match: Function, Inplace
+ * <li>run: none
+ * </ol>
+ * <li>The output type is given (OT):
+ * <ol type="a">
+ * <li>match: Function, Computer
+ * <li>run: none
+ * </ol>
+ * </ol>
+ * Input VALUES are given (IV) (N.B. this case applies for Arity0):
+ * <p>
+ * <ol>
+ * <li>The output is unspecified (OU):
+ * <ol type="a">
+ * <li>match: Function, Inplace
+ * <li>run: apply, mutate
+ * </ol>
+ * <li>The output type is given (OT):
+ * <ol type="a">
+ * <li>match: Function, Computer
+ * <li>run: apply
+ * </ol>
+ * <li>The output value is given (OV):
+ * <ol type="a">
+ * <li>match: Computer
+ * <li>run: compute
+ * </ol>
+ * </ol>
  * 
  * @author Curtis Rueden
  * @author Gabriel Selzer
  */
-// @formatter:on
 public class OpBuilderTest extends AbstractTestEnvironment {
 
 	final double[] halves = new double[10];

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Any.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Any.java
@@ -1,6 +1,8 @@
 package org.scijava.types;
 
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This {@link Type} represents a Type that can be assigned to any other Type.
@@ -42,6 +44,50 @@ public class Any implements Type {
 
 	public Type[] getLowerBounds() {
 		return lowerBounds;
+	}
+
+	/**
+	 * This method returns true iff:
+	 * <ul>
+	 * <li>{@code obj} is an {@link Any}
+	 * <li>{@code obj.getUpperBounds} is equal to {@code upperBounds}
+	 * (disregarding the order of each array)
+	 * <li>{@code obj.getLowerBounds} is equal to {@code lowerBounds}
+	 * (disregarding the order of each array)
+	 * <p>
+	 * This is a rather strict definition of equality, however it is necessary to
+	 * preserve transitivity.
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Any) || obj == null) return false;
+		Any other = (Any) obj;
+
+		return equalBounds(upperBounds, other.getUpperBounds()) && equalBounds(
+			lowerBounds, other.getLowerBounds());
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 0;
+		for (Type t : upperBounds)
+			hash ^= t.hashCode();
+		for (Type t : lowerBounds)
+			hash ^= t.hashCode();
+		return hash;
+	}
+
+	private boolean equalBounds(Type[] ours, Type[] theirs) {
+		if (ours.length != theirs.length) return false;
+
+		List<Type> ourList = Arrays.asList(ours);
+		List<Type> theirList = Arrays.asList(theirs);
+
+		for (Type t : ourList) {
+			if (!theirList.contains(t)) return false;
+		}
+
+		return true;
 	}
 
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
@@ -558,6 +558,13 @@ public class TypesTest {
 		assertFalse(Types.isAssignable(listExtendsNumber, listNumber));
 	}
 
+	/** Tests {@link Types#isAssignable(Type, Type)} against {@link Object} */
+	@Test
+	public <T extends Number> void testIsAssignableObject() {
+		final Type iterableT = new Nil<Iterable<T>>() {}.getType();
+		assertTrue(Types.isAssignable(iterableT, Object.class));
+	}
+
 	/** Tests {@link Types#isInstance(Object, Class)}. */
 	@Test
 	public void testIsInstance() {


### PR DESCRIPTION
Closes scijava/scijava-ops#49

TODO:
* [x] Finish testing
  * [x] It would be nice to write an `Any.equals()` for testing purposes, however we must decide the semantics. When should two `Any`s be considered equal? Are there cases when other `Object`s (that are not `Any`s) should be considered equal?
  * [x] For which other `Type`s can this scenario occur? `Object` is special in that [`Types.getExactSuperType`](https://github.com/scijava/incubator/blob/762f117775b69cda61e6257595126e51b0c25073/scijava/scijava-types/src/main/java/org/scijava/types/Types.java#L4156) will return `null` (**not** `Object`) for a call `Types.getExactSuperType(i, Object.class)` for any interface `i` (since `Object` is not a supertype of `i`).

* [x] Clean `inferTypeVariables(ParameterizedType type, ...)`