### PR TITLE
OpMethod support

### DIFF
--- a/scijava/scijava-ops/pom.xml
+++ b/scijava/scijava-ops/pom.xml
@@ -127,19 +127,20 @@
 			<artifactId>scijava-types</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<!-- Third-party dependencies -->
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
-		
 		<dependency>
 			<groupId>io.leangen.geantyref</groupId>
 			<artifactId>geantyref</artifactId>
 			<version>${geantyref.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.javassist</groupId>
+			<artifactId>javassist</artifactId>
+		</dependency>
 		<!-- Test scope dependencies -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/scijava/scijava-ops/src/main/java/module-info.java
+++ b/scijava/scijava-ops/src/main/java/module-info.java
@@ -22,4 +22,5 @@ module org.scijava.ops {
 
 	requires org.scijava;
 	requires org.scijava.types;
+	requires javassist;
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/MethodParameterOpDependencyMember.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/MethodParameterOpDependencyMember.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+
+/**
+ * @author Marcel Wiedenmann
+ */
+public class MethodParameterOpDependencyMember<T> extends
+	AnnotatedOpDependencyMember<T>
+{
+
+	public MethodParameterOpDependencyMember(Parameter methodParameter,
+		final Type parameterType, OpDependency annotation)
+	{
+		// NB: "Real" parameter name may or may not be available during runtime,
+		// that is, the keys of instances of this class will likely be of the form:
+		// arg0, arg1, etc.
+		super(methodParameter.getName(), parameterType, annotation);
+	}
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependencies.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependencies.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OpDependencies {
+
+	OpDependency[] value();
+
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependency.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependency.java
@@ -7,9 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /** Annotates a helper op as a field that should be auto injected.*/
-@Repeatable(OpDependencies.class)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.FIELD, ElementType.PARAMETER})
 public @interface OpDependency {
 	
 	/** The name of the Op to inject. */

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependency.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpDependency.java
@@ -1,13 +1,15 @@
 package org.scijava.ops;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /** Annotates a helper op as a field that should be auto injected.*/
+@Repeatable(OpDependencies.class)
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface OpDependency {
 	
 	/** The name of the Op to inject. */

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpMethod.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpMethod.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.scijava.Priority;
+
+/**
+ * @author Marcel Wiedenmann
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OpMethod {
+
+	String names();
+
+	double priority() default Priority.NORMAL;
+
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/OpMethod.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/OpMethod.java
@@ -46,6 +46,8 @@ public @interface OpMethod {
 
 	String names();
 
+	Class<?> type();
+
 	double priority() default Priority.NORMAL;
 
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -30,6 +30,7 @@
 package org.scijava.ops.impl;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -56,6 +57,7 @@ import org.scijava.ops.OpDependencyMember;
 import org.scijava.ops.OpEnvironment;
 import org.scijava.ops.OpField;
 import org.scijava.ops.OpInfo;
+import org.scijava.ops.OpMethod;
 import org.scijava.ops.OpUtils;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.core.OpCollection;
@@ -68,6 +70,7 @@ import org.scijava.ops.matcher.OpClassInfo;
 import org.scijava.ops.matcher.OpFieldInfo;
 import org.scijava.ops.matcher.OpMatcher;
 import org.scijava.ops.matcher.OpMatchingException;
+import org.scijava.ops.matcher.OpMethodInfo;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.util.OpWrapper;
 import org.scijava.param.FunctionalMethodType;
@@ -528,7 +531,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 		// Add Ops contained in an OpCollection
 		for (final PluginInfo<OpCollection> pluginInfo : pluginService.getPluginsOfType(OpCollection.class)) {
 			try {
-				Class<? extends OpCollection> c = pluginInfo.loadClass();
+				final Class<? extends OpCollection> c = pluginInfo.loadClass();
 				final List<Field> fields = ClassUtils.getAnnotatedFields(c, OpField.class);
 				Object instance = null;
 				for (Field field : fields) {
@@ -538,6 +541,11 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 					}
 					OpInfo opInfo = new OpFieldInfo(isStatic ? null : instance, field);
 					addToOpIndex(opInfo, field.getAnnotation(OpField.class).names());
+				}
+				final List<Method> methods = ClassUtils.getAnnotatedMethods(c, OpMethod.class);
+				for (final Method method: methods) {
+					OpInfo opInfo = new OpMethodInfo(method);
+					addToOpIndex(opInfo, method.getAnnotation(OpMethod.class).names());
 				}
 			} catch (InstantiableException | InstantiationException | IllegalAccessException exc) {
 				log.error("Can't load class from plugin info: " + pluginInfo.toString(), exc);

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -506,6 +506,22 @@ public final class MatchingUtils {
 	 * @param inferFrom
 	 * @param typeMappings
 	 */
+	static void inferTypeVariablesWithTypeMappings(Type type[], Type[] inferFrom,
+		Map<TypeVariable<?>, TypeMapping> typeMappings)
+	{
+		inferTypeVariables(type, inferFrom, typeMappings, true);
+	}
+	
+	/**
+	 * Tries to infer type vars contained in types from corresponding types from
+	 * inferFrom, putting them into the specified map. <b>When a
+	 * {@link TypeInferenceException} is thrown, the caller should assume that
+	 * some of the mappings within {@code typeMappings} are incorrect.</b>
+	 *
+	 * @param type
+	 * @param inferFrom
+	 * @param typeMappings
+	 */
 	static void inferTypeVariables(Type type, Type inferFrom, Map<TypeVariable<?>, TypeMapping> typeMappings) {
 		inferTypeVariables(type, inferFrom, typeMappings, true);
 	}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -354,7 +354,7 @@ public final class MatchingUtils {
 			// Try to infer type variables contained in the type arguments of
 			// sry
 			inferTypeVariables(srcTypes, destTypes, typeVarAssigns);
-		} catch (TypeInferenceException e) {
+		} catch (IllegalArgumentException e) {
 			// types can't be inferred
 			// TODO: Consider the situations in which it is okay that the type
 			// variables cannot be inferred. For example, if we have a

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/MatchingUtils.java
@@ -243,7 +243,10 @@ public final class MatchingUtils {
 		ParameterizedType dest, Map<TypeVariable<?>, Type> typeVarAssigns,
 		boolean safeAssignability)
 	{
-		if (typeVarAssigns != null && !typeVarAssigns.isEmpty()) {
+		if (typeVarAssigns == null) {
+			typeVarAssigns = new HashMap<>();
+		}
+		else if (!typeVarAssigns.isEmpty()) {
 			throw new IllegalArgumentException(
 				"Expected empty typeVarAssigns but contained " + typeVarAssigns.size() +
 					" entries");
@@ -260,12 +263,8 @@ public final class MatchingUtils {
 		// assignability check.
 		if (srcTypes.length == 0) return Types.isAssignable(src, dest);
 		// if there are type parameters, do a more complicated assignability check.
-		Map<TypeVariable<?>, TypeMapping> typeMappings = new HashMap<>();
 		boolean result = checkGenericAssignability(srcTypes, destTypes, src, dest,
-			typeMappings, safeAssignability);
-		if (typeVarAssigns != null) {
-			typeVarAssigns.putAll(new TypeVarAssigns(typeMappings));
-		}
+			typeVarAssigns, safeAssignability);
 		return result;
 	}
 
@@ -334,7 +333,7 @@ public final class MatchingUtils {
 	 * @param src the type for which assignment should be checked from
 	 * @param dest the parameterized type for which assignment should be checked
 	 *          to
-	 * @param typeMappings the map of {@link TypeVariable}s to
+	 * @param typeVarAssigns the map of {@link TypeVariable}s to
 	 *          {@link TypeMapping}s that would occur in this scenario
 	 * @param safeAssignability used to determine if we want to check if the
 	 *          src->dest assignment would be safely assignable even though it
@@ -344,19 +343,17 @@ public final class MatchingUtils {
 	 *         java statement
 	 */
 	private static boolean checkGenericAssignability(Type[] srcTypes, Type[] destTypes, Type src, Type dest,
-			Map<TypeVariable<?>, TypeMapping> typeMappings, boolean safeAssignability) {
+			Map<TypeVariable<?>, Type> typeVarAssigns, boolean safeAssignability) {
 		// if the number of type arguments does not match, the types can't be
 		// assignable
 		if (srcTypes.length != destTypes.length) {
 			return false;
 		}
 		
-		TypeVarAssigns typeVarAssigns = new TypeVarAssigns(typeMappings);
-
 		try {
 			// Try to infer type variables contained in the type arguments of
 			// sry
-			inferTypeVariables(srcTypes, destTypes, typeMappings);
+			inferTypeVariables(srcTypes, destTypes, typeVarAssigns);
 		} catch (TypeInferenceException e) {
 			// types can't be inferred
 			// TODO: Consider the situations in which it is okay that the type
@@ -464,11 +461,18 @@ public final class MatchingUtils {
 	 * @param types - the types containing {@link TypeVariable}s
 	 * @param inferFroms - the types used to infer the {@link TypeVariable}s
 	 *          within {@code types}
-	 * @param typeMappings - the mapping of {@link TypeVariable}s to
+	 * @param typeVarAssigns - the mapping of {@link TypeVariable}s to
 	 *          {@link Type}s
 	 */
-	static void inferTypeVariables(Type[] types, Type[] inferFroms, Map<TypeVariable<?>, TypeMapping> typeMappings) {
-		inferTypeVariables(types, inferFroms, typeMappings, true);
+	public static void inferTypeVariables(Type[] types, Type[] inferFroms, Map<TypeVariable<?>, Type> typeVarAssigns) {
+		Map<TypeVariable<?>, TypeMapping> typeMappings = new HashMap<>();
+		try {
+			inferTypeVariables(types, inferFroms, typeMappings, true);
+			typeVarAssigns.putAll(new TypeVarAssigns(typeMappings));
+		}
+		catch (TypeInferenceException e) {
+			throw new IllegalArgumentException(e);
+		}
 	}
 	
 	private static void inferTypeVariables(Type[] types, Type[] inferFroms,

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
@@ -35,6 +35,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -290,14 +291,14 @@ public class OpMethodInfo implements OpInfo {
 		List<Member<?>> members = struct().members().stream() //
 			.filter(member -> !(!member.isInput() && member.isOutput())) //
 			.collect(Collectors.toList());
-		for (int i = 0; i < members.size(); i++) {
-			Member<?> member = members.get(i);
-			String castClassName = Types.raw(member.getType()).getName();
-			if (Types.raw(member.getType()).isArray()) castClassName = Types.raw(
-				member.getType()).getSimpleName();
+		Parameter[] mParams = m.getParameters();
+		for (int i = 0; i < mParams.length; i++) {
+			Class<?> paramRawType = Types.raw(mParams[i].getParameterizedType());
+			String castClassName = paramRawType.getName();
+			if (paramRawType.isArray()) castClassName = paramRawType.getSimpleName();
 			sb.append("(" + castClassName + ") ");
-			if (member instanceof OpDependencyMember) sb.append("dep" +
-				numDependencies++);
+			if (mParams[i].getAnnotation(OpDependency.class) != null) sb.append(
+				"dep" + numDependencies++);
 			else sb.append("in" + numInputs++);
 			if (numDependencies + numInputs < members.size()) sb.append(", ");
 		}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
@@ -224,8 +224,18 @@ public class OpMethodInfo implements OpInfo {
     List<String> nameElements = new ArrayList<>();
     nameElements.add(m.getDeclaringClass().getSimpleName());
     nameElements.add(m.getName());
-    for(Class<?> c : m.getParameterTypes())
-    	nameElements.add(c.getSimpleName());
+    for(Class<?> c : m.getParameterTypes()) {
+			// TODO: if c is an array, simpleName will include brackets (which is
+			// illegal in a class name). To differentiate Object[] from Object, we map
+			// Object[] to ObjectArr. This is not truly extensible, since someone
+			// could create an ObjectArr class which might conflict, so it would be
+			// best to find a better solution.
+    	String simpleName = c.getSimpleName();
+    	if (c.isArray()) {
+    		simpleName = c.getComponentType() + "Arr";
+    	}
+    	nameElements.add(simpleName);
+    }
     nameElements.add(m.getReturnType().getSimpleName());
     String className = packageName + "." + String.join("_", nameElements);
     CtClass cc = pool.makeClass(className);
@@ -278,6 +288,8 @@ public class OpMethodInfo implements OpInfo {
 		for(int i = 0; i < members.size(); i++) {
 			Member<?> member = members.get(i);
 			String castClassName = Types.raw(member.getType()).getName();
+			if (Types.raw(member.getType()).isArray())
+				castClassName = Types.raw(member.getType()).getSimpleName();
 			sb.append("(" + castClassName + ") ");
 			if (member instanceof OpDependencyMember)
 				sb.append("dep" + numDependencies++);

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
@@ -1,0 +1,171 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2014 - 2016 Board of Regents of the University of
+ * Wisconsin-Madison and University of Konstanz.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops.matcher;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.scijava.Priority;
+import org.scijava.ops.OpInfo;
+import org.scijava.ops.OpMethod;
+import org.scijava.ops.OpUtils;
+import org.scijava.param.ParameterStructs;
+import org.scijava.param.ValidityException;
+import org.scijava.param.ValidityProblem;
+import org.scijava.struct.Struct;
+import org.scijava.struct.StructInstance;
+
+/**
+ * @author Marcel Wiedenmann
+ */
+public class OpMethodInfo implements OpInfo {
+
+	private final Method method;
+	private Struct struct;
+	private final ValidityException validityException;
+	private Object instance;
+
+	public OpMethodInfo(final Method method) {
+		final List<ValidityProblem> problems = new ArrayList<>();
+		// Reject all non public methods
+		if (!Modifier.isPublic(method.getModifiers())) {
+			problems.add(new ValidityProblem("Method to parse: " + method +
+				" must be public."));
+		}
+		if (Modifier.isStatic(method.getModifiers())) {
+			// TODO: We can't properly infer the generic types of static methods at
+			// the moment. This might be a Java limitation.
+			problems.add(new ValidityProblem("Method to parse: " + method +
+				" must not be static."));
+		}
+		this.method = method;
+		try {
+			struct = ParameterStructs.structOf(method.getDeclaringClass(), method);
+			instance = method.getDeclaringClass().getDeclaredConstructor()
+				.newInstance();
+		}
+		catch (final ValidityException e) {
+			problems.addAll(e.problems());
+		}
+		catch (NoSuchMethodException | InstantiationException
+				| IllegalAccessException | InvocationTargetException e)
+		{
+			problems.add(new ValidityProblem("Could not instantiate method's class.",
+				e));
+		}
+		validityException = problems.isEmpty() ? null : new ValidityException(
+			problems);
+	}
+
+	// -- OpInfo methods --
+
+	@Override
+	public Type opType() {
+		return method.getGenericReturnType();
+	}
+
+	@Override
+	public Struct struct() {
+		return struct;
+	}
+
+	@Override
+	public double priority() {
+		final OpMethod opMethod = method.getAnnotation(OpMethod.class);
+		return opMethod == null ? Priority.NORMAL : opMethod.priority();
+	}
+
+	@Override
+	public String implementationName() {
+		// TODO: This includes all of the modifiers etc. of the method which are not
+		// necessary to identify it. Use something custom? We need to be careful
+		// because of method overloading, so just using the name is not sufficient.
+		return method.toGenericString();
+	}
+
+	@Override
+	public StructInstance<?> createOpInstance(
+		final List<? extends Object> dependencies)
+	{
+		try {
+			method.setAccessible(true);
+			return struct.createInstance(method.invoke(instance, dependencies
+				.toArray()));
+		}
+		catch (final IllegalAccessException | IllegalArgumentException
+				| InvocationTargetException ex)
+		{
+			throw new IllegalStateException("Failed to invoke Op method: " + method +
+				". Provided Op dependencies were: " + Objects.toString(dependencies),
+				ex);
+		}
+	}
+
+	@Override
+	public boolean isValid() {
+		return validityException == null;
+	}
+
+	@Override
+	public ValidityException getValidityException() {
+		return validityException;
+	}
+
+	// -- Object methods --
+
+	@Override
+	public boolean equals(final Object o) {
+		if (!(o instanceof OpMethodInfo)) return false;
+		final OpInfo that = (OpInfo) o;
+		return struct().equals(that.struct());
+	}
+
+	@Override
+	public int hashCode() {
+		return struct().hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return OpUtils.opString(this);
+	}
+
+	@Override
+	public AnnotatedElement getAnnotationBearer() {
+		return method;
+	}
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpMethodInfo.java
@@ -55,6 +55,7 @@ import org.scijava.struct.StructInstance;
 public class OpMethodInfo implements OpInfo {
 
 	private final Method method;
+//	private final Type opType;
 	private Struct struct;
 	private final ValidityException validityException;
 	private Object instance;
@@ -66,12 +67,13 @@ public class OpMethodInfo implements OpInfo {
 			problems.add(new ValidityProblem("Method to parse: " + method +
 				" must be public."));
 		}
-		if (Modifier.isStatic(method.getModifiers())) {
-			// TODO: We can't properly infer the generic types of static methods at
-			// the moment. This might be a Java limitation.
-			problems.add(new ValidityProblem("Method to parse: " + method +
-				" must not be static."));
-		}
+		// TODO: This might no longer be a concern.
+//		if (Modifier.isStatic(method.getModifiers())) {
+//			// TODO: We can't properly infer the generic types of static methods at
+//			// the moment. This might be a Java limitation.
+//			problems.add(new ValidityProblem("Method to parse: " + method +
+//				" must not be static."));
+//		}
 		this.method = method;
 		try {
 			struct = ParameterStructs.structOf(method.getDeclaringClass(), method);

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/Parameter.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/Parameter.java
@@ -51,7 +51,7 @@ import org.scijava.struct.MemberInstance;
  * @author Curtis Rueden
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.TYPE })
+@Target({ ElementType.FIELD, ElementType.TYPE, ElementType.METHOD })
 @Repeatable(Parameters.class)
 public @interface Parameter {
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
@@ -1,8 +1,6 @@
 
 package org.scijava.param;
 
-import com.google.common.collect.Streams;
-
 import io.leangen.geantyref.AnnotationFormatException;
 import io.leangen.geantyref.TypeFactory;
 
@@ -37,8 +35,8 @@ import org.scijava.struct.ItemIO;
 import org.scijava.struct.Member;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
-import org.scijava.util.ClassUtils;
 import org.scijava.types.Types;
+import org.scijava.util.ClassUtils;
 
 /**
  * Utility functions for working with {@link org.scijava.param} classes.
@@ -202,12 +200,7 @@ public final class ParameterStructs {
 			final ArrayList<Member<?>> items = new ArrayList<>();
 			final ArrayList<ValidityProblem> problems = new ArrayList<>();
 			final Set<String> names = new HashSet<>();
-			final Type methodReturnType = Types.methodReturnType(method, c);
-			final java.lang.reflect.Parameter[] methodParameters = method.getParameters();
-			final Type[] methodParamTypes = Types.methodParamTypes(method, c);
-			final Annotation[][] paramAnnotations = method.getParameterAnnotations();
 			final OpMethod methodAnnotation = method.getAnnotation(OpMethod.class);
-//			final Type[] opInputs = getOpInputs(methodParamTypes, paramAnnotations);
 			
 			// Determine functional type
 			Type functionalType;
@@ -220,8 +213,6 @@ public final class ParameterStructs {
 				functionalType = Types.parameterizeRaw(methodAnnotation.type());
 			}
 			
-			final java.lang.reflect.Parameter[] opParams = getOpParams(methodParameters);
-
 			// Parse method level @Parameter annotations.
 			parseFunctionalParameters(items, names, problems, method, functionalType, true);
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/Parameters.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/Parameters.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  * @author Curtis Rueden
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.TYPE })
+@Target({ ElementType.FIELD, ElementType.TYPE, ElementType.METHOD })
 public @interface Parameters {
 	Parameter[] value();
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodDependencyPositionTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodDependencyPositionTest.java
@@ -1,0 +1,90 @@
+
+package org.scijava.ops;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Computers;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = OpCollection.class)
+public class OpMethodDependencyPositionTest extends AbstractTestEnvironment {
+
+	@OpField(names = "test.stringToLong")
+	public final Function<String, Long> parser = in -> Long.parseLong(in);
+
+	@OpMethod(names = "test.dependencyBeforeOutput",
+		type = Computers.Arity1.class)
+	public static void OpMethodFoo(List<String> in, @OpDependency(
+		name = "test.stringToLong") Function<String, Long> op, List<Long> out)
+	{
+		out.clear();
+		for (String s : in)
+			out.add(op.apply(s));
+	}
+
+	@Test
+	public void testOpDependencyBeforeOutput() {
+		List<String> in = new ArrayList<>();
+		in.add("1");
+		List<Long> out = new ArrayList<>();
+		ops.op("test.dependencyBeforeOutput").input(in).output(out).compute();
+		List<Long> expected = Arrays.asList(1l);
+		assertIterationsEqual(expected, out);
+	}
+
+	@OpMethod(names = "test.dependencyAfterOutput", type = Computers.Arity1.class)
+	public static void OpMethodFoo(List<String> in, List<Long> out, @OpDependency(
+		name = "test.stringToLong") Function<String, Long> op)
+	{
+		out.clear();
+		for (String s : in)
+			out.add(op.apply(s));
+	}
+
+	@Test
+	public void testOpDependencyAfterOutput() {
+		List<String> in = new ArrayList<>();
+		in.add("1");
+		List<Long> out = new ArrayList<>();
+		ops.op("test.dependencyAfterOutput").input(in).output(out).compute();
+		List<Long> expected = Arrays.asList(1l);
+		assertIterationsEqual(expected, out);
+	}
+
+	@OpField(names = "test.squareList")
+	public final Computers.Arity1<List<Long>, List<Long>> squareOp = (in,
+		out) -> {
+		out.clear();
+		for (Long l : in)
+			out.add(l * l);
+	};
+
+	@OpMethod(names = "test.dependencyBeforeAndAfterOutput",
+		type = Computers.Arity1.class)
+	public static void OpMethodBar(List<String> in, @OpDependency(
+		name = "test.stringToLong") Function<String, Long> op1, List<Long> out,
+		@OpDependency(
+			name = "test.squareList") Computers.Arity1<List<Long>, List<Long>> op2)
+	{
+		List<Long> temp = new ArrayList<>();
+		for (String s : in)
+			temp.add(op1.apply(s));
+		out.clear();
+		op2.compute(temp, out);
+	}
+
+	@Test
+	public void testOpDependencyBeforeAndAfterOutput() {
+		List<String> in = new ArrayList<>();
+		in.add("2");
+		List<Long> out = new ArrayList<>();
+		ops.op("test.dependencyBeforeAndAfterOutput").input(in).output(out).compute();
+		List<Long> expected = Arrays.asList(4l);
+		assertIterationsEqual(expected, out);
+	}
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -1502,4 +1502,1370 @@ public class OpMethodTest extends AbstractTestEnvironment {
 		ops.op("test.addDoubles16_16").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate16();
 		assertTrue(outputExpected(io, 16));
 	}
+
+	// -- Dependent Functions -- //
+
+	@Test
+	public void testDependentMethodFunction1() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 1), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction2() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 2), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction3() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 3), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction4() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 4), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction5() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 5), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction6() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 6), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction7() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 7), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction8() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 8), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction9() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 9), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction10() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 10), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction11() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 11), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction12() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 12), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction13() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 13), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction14() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 14), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction15() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 15), out, 0);
+	}
+
+	@Test
+	public void testDependentMethodFunction16() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 16), out, 0);
+	}
+
+	// -- Dependent Computers -- //
+
+	@Test
+	public void testDependentMethodComputer1() {
+		String in = "1";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in)
+			.output(out).compute();
+		assertEquals(expected(1, 1), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer2() {
+		String in = "2";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in)
+			.output(out).compute();
+		assertEquals(expected(2, 2), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer3() {
+		String in = "3";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in)
+			.output(out).compute();
+		assertEquals(expected(3, 3), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer4() {
+		String in = "4";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(4, 4), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer5() {
+		String in = "5";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(5, 5), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer6() {
+		String in = "6";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(6, 6), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer7() {
+		String in = "7";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(7, 7), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer8() {
+		String in = "8";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(8, 8), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer9() {
+		String in = "9";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(9, 9), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer10() {
+		String in = "10";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(10, 10), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer11() {
+		String in = "11";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(11, 11), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer12() {
+		String in = "12";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(12, 12), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer13() {
+		String in = "13";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(13, 13), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer14() {
+		String in = "14";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(14, 14), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer15() {
+		String in = "15";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(15, 15), out);
+	}
+
+	@Test
+	public void testDependentMethodComputer16() {
+		String in = "16";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(16, 16), out);
+	}
+
+	// -- Dependent Inplaces -- //
+
+	@Test
+	public void testDependentMethodInplace1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles1").input(io).mutate();
+		assertTrue(outputExpected(io, 1));
+	}
+
+	@Test
+	public void testDependentMethodInplace2_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles2_1").input(io, in).mutate1();
+		assertTrue(outputExpected(io, 2));
+	}
+
+	@Test
+	public void testDependentMethodInplace2_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles2_2").input(in, io).mutate2();
+		assertTrue(outputExpected(io, 2));
+	}
+
+	@Test
+	public void testDependentMethodInplace3_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles3_1").input(io, in, in).mutate1();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testDependentMethodInplace3_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles3_2").input(in, io, in).mutate2();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testDependentMethodInplace3_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles3_3").input(in, in, io).mutate3();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testDependentMethodInplace4_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles4_1").input(io, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testDependentMethodInplace4_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles4_2").input(in, io, in, in).mutate2();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testDependentMethodInplace4_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles4_3").input(in, in, io, in).mutate3();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testDependentMethodInplace4_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles4_4").input(in, in, in, io).mutate4();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testDependentMethodInplace5_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles5_1").input(io, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testDependentMethodInplace5_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles5_2").input(in, io, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testDependentMethodInplace5_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles5_3").input(in, in, io, in, in).mutate3();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testDependentMethodInplace5_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles5_4").input(in, in, in, io, in).mutate4();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testDependentMethodInplace5_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles5_5").input(in, in, in, in, io).mutate5();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_1").input(io, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_2").input(in, io, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_3").input(in, in, io, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_4").input(in, in, in, io, in, in).mutate4();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_5").input(in, in, in, in, io, in).mutate5();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace6_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles6_6").input(in, in, in, in, in, io).mutate6();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_1").input(io, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_2").input(in, io, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_3").input(in, in, io, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_4").input(in, in, in, io, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_5").input(in, in, in, in, io, in, in).mutate5();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_6").input(in, in, in, in, in, io, in).mutate6();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace7_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles7_7").input(in, in, in, in, in, in, io).mutate7();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_1").input(io, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_2").input(in, io, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_3").input(in, in, io, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_4").input(in, in, in, io, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_5").input(in, in, in, in, io, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_6").input(in, in, in, in, in, io, in, in).mutate6();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_7").input(in, in, in, in, in, in, io, in).mutate7();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace8_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles8_8").input(in, in, in, in, in, in, in, io).mutate8();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_1").input(io, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_2").input(in, io, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_3").input(in, in, io, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_4").input(in, in, in, io, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_5").input(in, in, in, in, io, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_6").input(in, in, in, in, in, io, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_7").input(in, in, in, in, in, in, io, in, in).mutate7();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_8").input(in, in, in, in, in, in, in, io, in).mutate8();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace9_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles9_9").input(in, in, in, in, in, in, in, in, io).mutate9();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_1").input(io, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_2").input(in, io, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_3").input(in, in, io, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_4").input(in, in, in, io, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_5").input(in, in, in, in, io, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_6").input(in, in, in, in, in, io, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_7").input(in, in, in, in, in, in, io, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_8").input(in, in, in, in, in, in, in, io, in, in).mutate8();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_9").input(in, in, in, in, in, in, in, in, io, in).mutate9();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace10_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles10_10").input(in, in, in, in, in, in, in, in, in, io).mutate10();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_1").input(io, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_2").input(in, io, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_3").input(in, in, io, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_4").input(in, in, in, io, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_5").input(in, in, in, in, io, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_6").input(in, in, in, in, in, io, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_7").input(in, in, in, in, in, in, io, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_8").input(in, in, in, in, in, in, in, io, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_9").input(in, in, in, in, in, in, in, in, io, in, in).mutate9();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_10").input(in, in, in, in, in, in, in, in, in, io, in).mutate10();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace11_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles11_11").input(in, in, in, in, in, in, in, in, in, in, io).mutate11();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_1").input(io, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_2").input(in, io, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_3").input(in, in, io, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_4").input(in, in, in, io, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_5").input(in, in, in, in, io, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_6").input(in, in, in, in, in, io, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_7").input(in, in, in, in, in, in, io, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_8").input(in, in, in, in, in, in, in, io, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_9").input(in, in, in, in, in, in, in, in, io, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_10").input(in, in, in, in, in, in, in, in, in, io, in, in).mutate10();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_11").input(in, in, in, in, in, in, in, in, in, in, io, in).mutate11();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace12_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles12_12").input(in, in, in, in, in, in, in, in, in, in, in, io).mutate12();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in).mutate11();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in).mutate12();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace13_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles13_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io).mutate13();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate12();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate13();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace14_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles14_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate14();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate12();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate13();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate14();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace15_15() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles15_15").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate15();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate12();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate13();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate14();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_15() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_15").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate15();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testDependentMethodInplace16_16() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles16_16").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate16();
+		assertTrue(outputExpected(io, 16));
+	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -78,7 +78,7 @@ public class OpMethodTest extends AbstractTestEnvironment {
 	@Parameter(key = "numericString")
 	// Refers to the output parameter of the function.
 	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
-	public Integer createParseIntegerOp(String in) {
+	public static Integer createParseIntegerOp(String in) {
 		return Integer.parseInt(in);
 	}
 

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -72,28 +72,23 @@ public class OpMethodTest extends AbstractTestEnvironment {
 		assertEquals(Integer.parseInt(numericString1) * Integer.parseInt(numericString2), (int) multipliedNumericStrings);
 	}
 
-	@OpMethod(names = "test.parseInteger")
+	@OpMethod(names = "test.parseInteger", type = Function.class)
 	// Refers to the input parameter of the function that's returned by this
 	// factory method.
 	@Parameter(key = "numericString")
 	// Refers to the output parameter of the function.
 	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
-	public Function<String, Integer> createParseIntegerOp() {
-		return Integer::parseInt;
+	public Integer createParseIntegerOp(String in) {
+		return Integer.parseInt(in);
 	}
 
-	@OpMethod(names = "test.multiplyNumericStrings")
+	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
 	@Parameter(key = "numericString1")
 	@Parameter(key = "numericString2")
 	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
-	// Refers to the first parameter of this factory method ("parseIntegerOp").
-	// Will be automatically provided by the matching system. Can be used by the
-	// returned lambda/Op as if it was an @OpDependency-annotated field in a
-	// regular Op class.
-	@OpDependency(name = "test.parseInteger")
-	public BiFunction<String, String, Integer> createMultiplyNumericStringsOp(
-		final Function<String, Integer> parseIntegerOp)
+	public static Integer createMultiplyNumericStringsOp( final String in1, final String in2, 
+		@OpDependency (name = "test.parseInteger") Function<String, Integer> parseIntegerOp)
 	{
-		return (i1, i2) -> parseIntegerOp.apply(i1) * parseIntegerOp.apply(i2);
+		return parseIntegerOp.apply(in1) * parseIntegerOp.apply(in2);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -36,11 +36,15 @@ import java.util.function.Function;
 
 import org.junit.Test;
 import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Producer;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
 
 /**
+ * Tests the construction of {@link OpMethod}s.
+ * 
+ * @author Gabriel Selzer
  * @author Marcel Wiedenmann
  */
 @Plugin(type = OpCollection.class)
@@ -90,5 +94,13 @@ public class OpMethodTest extends AbstractTestEnvironment {
 		@OpDependency (name = "test.parseInteger") Function<String, Integer> parseIntegerOp)
 	{
 		return parseIntegerOp.apply(in1) * parseIntegerOp.apply(in2);
+	}
+	
+	@Test
+	public void testOpMethodProducer() {
+		final Producer<Integer> op = ops.op("test.multiplyNumericStrings").input()
+			.outType(Integer.class).producer();
+		final Integer expected = Integer.valueOf(1);
+		assertEquals(expected, op.create());
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * SciJava Operations: a framework for reusable algorithms.
+ * %%
+ * Copyright (C) 2018 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+/**
+ * @author Marcel Wiedenmann
+ */
+@Plugin(type = OpCollection.class)
+public class OpMethodTest extends AbstractTestEnvironment {
+
+	@Test
+	public void testParseIntegerOp() {
+		// Will match a lambda created and returned by createParseIntegerOp() below.
+		final Function<String, Integer> parseIntegerOp = ops.op("test.parseInteger")
+			.inType(String.class).outType(Integer.class).function();
+
+		final String numericString = "42";
+		final Integer parsedInteger = parseIntegerOp.apply(numericString);
+		assertEquals(Integer.parseInt(numericString), (int) parsedInteger);
+	}
+
+	@Test
+	public void testMultiplyNumericStringsOpMethod() {
+		// Will match a lambda created and returned by
+		// createMultiplyNumericStringsOp(..), which itself captured a lambda
+		// created and returned by createParseIntegerOp().
+		final BiFunction<String, String, Integer> multiplyNumericStringsOp = ops.op(
+			"test.multiplyNumericStrings").inType(String.class, String.class).outType(
+				Integer.class).function();
+
+		final String numericString1 = "3";
+		final String numericString2 = "18";
+		final Integer multipliedNumericStrings = multiplyNumericStringsOp.apply(numericString1, numericString2);
+		assertEquals(Integer.parseInt(numericString1) * Integer.parseInt(numericString2), (int) multipliedNumericStrings);
+	}
+
+	@OpMethod(names = "test.parseInteger")
+	// Refers to the input parameter of the function that's returned by this
+	// factory method.
+	@Parameter(key = "numericString")
+	// Refers to the output parameter of the function.
+	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
+	public Function<String, Integer> createParseIntegerOp() {
+		return Integer::parseInt;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings")
+	@Parameter(key = "numericString1")
+	@Parameter(key = "numericString2")
+	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+	// Refers to the first parameter of this factory method ("parseIntegerOp").
+	// Will be automatically provided by the matching system. Can be used by the
+	// returned lambda/Op as if it was an @OpDependency-annotated field in a
+	// regular Op class.
+	@OpDependency(name = "test.parseInteger")
+	public BiFunction<String, String, Integer> createMultiplyNumericStringsOp(
+		final Function<String, Integer> parseIntegerOp)
+	{
+		return (i1, i2) -> parseIntegerOp.apply(i1) * parseIntegerOp.apply(i2);
+	}
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -30,16 +30,23 @@
 package org.scijava.ops;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.junit.Test;
 import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Computers;
+import org.scijava.ops.function.Inplaces;
 import org.scijava.ops.function.Producer;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
+import org.scijava.types.Nil;
 
 /**
  * Tests the construction of {@link OpMethod}s.
@@ -50,57 +57,1449 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = OpCollection.class)
 public class OpMethodTest extends AbstractTestEnvironment {
 
-	@Test
-	public void testParseIntegerOp() {
-		// Will match a lambda created and returned by createParseIntegerOp() below.
-		final Function<String, Integer> parseIntegerOp = ops.op("test.parseInteger")
-			.inType(String.class).outType(Integer.class).function();
+//	@Test
+//	public void testParseIntegerOp() {
+//		// Will match a lambda created and returned by createParseIntegerOp() below.
+//		final Function<String, Integer> parseIntegerOp = ops.op("test.parseInteger")
+//			.inType(String.class).outType(Integer.class).function();
+//
+//		final String numericString = "42";
+//		final Integer parsedInteger = parseIntegerOp.apply(numericString);
+//		assertEquals(Integer.parseInt(numericString), (int) parsedInteger);
+//	}
+//
+//	@Test
+//	public void testMultiplyNumericStringsOpMethod() {
+//		// Will match a lambda created and returned by
+//		// createMultiplyNumericStringsOp(..), which itself captured a lambda
+//		// created and returned by createParseIntegerOp().
+//		final BiFunction<String, String, Integer> multiplyNumericStringsOp = ops.op(
+//			"test.multiplyNumericStrings").inType(String.class, String.class).outType(
+//				Integer.class).function();
+//
+//		final String numericString1 = "3";
+//		final String numericString2 = "18";
+//		final Integer multipliedNumericStrings = multiplyNumericStringsOp.apply(
+//			numericString1, numericString2);
+//		assertEquals(Integer.parseInt(numericString1) * Integer.parseInt(
+//			numericString2), (int) multipliedNumericStrings);
+//	}
+//
+//	@OpMethod(names = "test.parseInteger", type = Function.class)
+//	// Refers to the input parameter of the function that's returned by this
+//	// factory method.
+//	@Parameter(key = "numericString")
+//	// Refers to the output parameter of the function.
+//	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
+//	public static Integer createParseIntegerOp(String in) {
+//		return Integer.parseInt(in);
+//	}
+//
+//	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
+//	@Parameter(key = "numericString1")
+//	@Parameter(key = "numericString2")
+//	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+//	public static Integer createMultiplyNumericStringsOp(final String in1,
+//		final String in2, @OpDependency(
+//			name = "test.parseInteger") Function<String, Integer> parseIntegerOp)
+//	{
+//		return parseIntegerOp.apply(in1) * parseIntegerOp.apply(in2);
+//	}
+	// -- Functions -- //
 
-		final String numericString = "42";
-		final Integer parsedInteger = parseIntegerOp.apply(numericString);
-		assertEquals(Integer.parseInt(numericString), (int) parsedInteger);
-	}
-
-	@Test
-	public void testMultiplyNumericStringsOpMethod() {
-		// Will match a lambda created and returned by
-		// createMultiplyNumericStringsOp(..), which itself captured a lambda
-		// created and returned by createParseIntegerOp().
-		final BiFunction<String, String, Integer> multiplyNumericStringsOp = ops.op(
-			"test.multiplyNumericStrings").inType(String.class, String.class).outType(
-				Integer.class).function();
-
-		final String numericString1 = "3";
-		final String numericString2 = "18";
-		final Integer multipliedNumericStrings = multiplyNumericStringsOp.apply(numericString1, numericString2);
-		assertEquals(Integer.parseInt(numericString1) * Integer.parseInt(numericString2), (int) multipliedNumericStrings);
-	}
-
-	@OpMethod(names = "test.parseInteger", type = Function.class)
-	// Refers to the input parameter of the function that's returned by this
-	// factory method.
-	@Parameter(key = "numericString")
-	// Refers to the output parameter of the function.
-	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
-	public static Integer createParseIntegerOp(String in) {
-		return Integer.parseInt(in);
-	}
-
-	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
-	@Parameter(key = "numericString1")
-	@Parameter(key = "numericString2")
-	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
-	public static Integer createMultiplyNumericStringsOp( final String in1, final String in2, 
-		@OpDependency (name = "test.parseInteger") Function<String, Integer> parseIntegerOp)
-	{
-		return parseIntegerOp.apply(in1) * parseIntegerOp.apply(in2);
-	}
-	
 	@Test
 	public void testOpMethodProducer() {
-		final Producer<Integer> op = ops.op("test.multiplyNumericStrings").input()
-			.outType(Integer.class).producer();
+		final Integer out = ops.op("test.multiplyNumericStrings").input()
+			.outType(Integer.class).create();
 		final Integer expected = Integer.valueOf(1);
-		assertEquals(expected, op.create());
+		assertEquals(expected, out);
+	}
+
+	@Test
+	public void testOpMethodFunction1() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 1), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction2() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 2), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction3() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 3), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction4() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 4), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction5() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 5), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction6() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 6), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction7() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 7), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction8() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 8), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction9() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 9), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction10() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 10), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction11() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 11), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction12() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 12), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction13() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 13), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction14() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 14), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction15() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 15), out, 0);
+	}
+
+	@Test
+	public void testOpMethodFunction16() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, 16), out, 0);
+	}
+
+	// -- Computers -- //
+
+	public List<Double> expected(double expected, int size) {
+		List<Double> list = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			list.add(expected);
+		}
+		return list;
+	}
+
+	@Test
+	public void testOpMethodComputer0() {
+		String in = "0";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input()
+			.output(out).compute();
+		assertEquals(expected(0, 0), out);
+	}
+
+	@Test
+	public void testOpMethodComputer1() {
+		String in = "1";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in)
+			.output(out).compute();
+		assertEquals(expected(1, 1), out);
+	}
+
+	@Test
+	public void testOpMethodComputer2() {
+		String in = "2";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in)
+			.output(out).compute();
+		assertEquals(expected(2, 2), out);
+	}
+
+	@Test
+	public void testOpMethodComputer3() {
+		String in = "3";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in)
+			.output(out).compute();
+		assertEquals(expected(3, 3), out);
+	}
+
+	@Test
+	public void testOpMethodComputer4() {
+		String in = "4";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(4, 4), out);
+	}
+
+	@Test
+	public void testOpMethodComputer5() {
+		String in = "5";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(5, 5), out);
+	}
+
+	@Test
+	public void testOpMethodComputer6() {
+		String in = "6";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(6, 6), out);
+	}
+
+	@Test
+	public void testOpMethodComputer7() {
+		String in = "7";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(7, 7), out);
+	}
+
+	@Test
+	public void testOpMethodComputer8() {
+		String in = "8";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(8, 8), out);
+	}
+
+	@Test
+	public void testOpMethodComputer9() {
+		String in = "9";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(9, 9), out);
+	}
+
+	@Test
+	public void testOpMethodComputer10() {
+		String in = "10";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(10, 10), out);
+	}
+
+	@Test
+	public void testOpMethodComputer11() {
+		String in = "11";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(11, 11), out);
+	}
+
+	@Test
+	public void testOpMethodComputer12() {
+		String in = "12";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(12, 12), out);
+	}
+
+	@Test
+	public void testOpMethodComputer13() {
+		String in = "13";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(13, 13), out);
+	}
+
+	@Test
+	public void testOpMethodComputer14() {
+		String in = "14";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(14, 14), out);
+	}
+
+	@Test
+	public void testOpMethodComputer15() {
+		String in = "15";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(15, 15), out);
+	}
+
+	@Test
+	public void testOpMethodComputer16() {
+		String in = "16";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in)
+			.output(out).compute();
+		assertEquals(expected(16, 16), out);
+	}
+
+	// -- Inplaces -- //
+
+	private boolean outputExpected(double[] array, int multiplier) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] != (i + 1) * multiplier) return false;
+		}
+		return true;
+	}
+
+	@Test
+	public void testOpMethodInplace1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles1").input(io).mutate();
+		assertTrue(outputExpected(io, 1));
+	}
+
+	@Test
+	public void testOpMethodInplace2_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles2_1").input(io, in).mutate1();
+		assertTrue(outputExpected(io, 2));
+	}
+
+	@Test
+	public void testOpMethodInplace2_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles2_2").input(in, io).mutate2();
+		assertTrue(outputExpected(io, 2));
+	}
+
+	@Test
+	public void testOpMethodInplace3_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles3_1").input(io, in, in).mutate1();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testOpMethodInplace3_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles3_2").input(in, io, in).mutate2();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testOpMethodInplace3_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles3_3").input(in, in, io).mutate3();
+		assertTrue(outputExpected(io, 3));
+	}
+
+	@Test
+	public void testOpMethodInplace4_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles4_1").input(io, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testOpMethodInplace4_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles4_2").input(in, io, in, in).mutate2();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testOpMethodInplace4_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles4_3").input(in, in, io, in).mutate3();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testOpMethodInplace4_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles4_4").input(in, in, in, io).mutate4();
+		assertTrue(outputExpected(io, 4));
+	}
+
+	@Test
+	public void testOpMethodInplace5_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles5_1").input(io, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testOpMethodInplace5_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles5_2").input(in, io, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testOpMethodInplace5_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles5_3").input(in, in, io, in, in).mutate3();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testOpMethodInplace5_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles5_4").input(in, in, in, io, in).mutate4();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testOpMethodInplace5_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles5_5").input(in, in, in, in, io).mutate5();
+		assertTrue(outputExpected(io, 5));
+	}
+
+	@Test
+	public void testOpMethodInplace6_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_1").input(io, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace6_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_2").input(in, io, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace6_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_3").input(in, in, io, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace6_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_4").input(in, in, in, io, in, in).mutate4();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace6_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_5").input(in, in, in, in, io, in).mutate5();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace6_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles6_6").input(in, in, in, in, in, io).mutate6();
+		assertTrue(outputExpected(io, 6));
+	}
+
+	@Test
+	public void testOpMethodInplace7_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_1").input(io, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_2").input(in, io, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_3").input(in, in, io, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_4").input(in, in, in, io, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_5").input(in, in, in, in, io, in, in).mutate5();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_6").input(in, in, in, in, in, io, in).mutate6();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace7_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles7_7").input(in, in, in, in, in, in, io).mutate7();
+		assertTrue(outputExpected(io, 7));
+	}
+
+	@Test
+	public void testOpMethodInplace8_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_1").input(io, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_2").input(in, io, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_3").input(in, in, io, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_4").input(in, in, in, io, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_5").input(in, in, in, in, io, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_6").input(in, in, in, in, in, io, in, in).mutate6();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_7").input(in, in, in, in, in, in, io, in).mutate7();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace8_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles8_8").input(in, in, in, in, in, in, in, io).mutate8();
+		assertTrue(outputExpected(io, 8));
+	}
+
+	@Test
+	public void testOpMethodInplace9_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_1").input(io, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_2").input(in, io, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_3").input(in, in, io, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_4").input(in, in, in, io, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_5").input(in, in, in, in, io, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_6").input(in, in, in, in, in, io, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_7").input(in, in, in, in, in, in, io, in, in).mutate7();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_8").input(in, in, in, in, in, in, in, io, in).mutate8();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace9_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles9_9").input(in, in, in, in, in, in, in, in, io).mutate9();
+		assertTrue(outputExpected(io, 9));
+	}
+
+	@Test
+	public void testOpMethodInplace10_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_1").input(io, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_2").input(in, io, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_3").input(in, in, io, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_4").input(in, in, in, io, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_5").input(in, in, in, in, io, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_6").input(in, in, in, in, in, io, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_7").input(in, in, in, in, in, in, io, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_8").input(in, in, in, in, in, in, in, io, in, in).mutate8();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_9").input(in, in, in, in, in, in, in, in, io, in).mutate9();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace10_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles10_10").input(in, in, in, in, in, in, in, in, in, io).mutate10();
+		assertTrue(outputExpected(io, 10));
+	}
+
+	@Test
+	public void testOpMethodInplace11_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_1").input(io, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_2").input(in, io, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_3").input(in, in, io, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_4").input(in, in, in, io, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_5").input(in, in, in, in, io, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_6").input(in, in, in, in, in, io, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_7").input(in, in, in, in, in, in, io, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_8").input(in, in, in, in, in, in, in, io, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_9").input(in, in, in, in, in, in, in, in, io, in, in).mutate9();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_10").input(in, in, in, in, in, in, in, in, in, io, in).mutate10();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace11_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles11_11").input(in, in, in, in, in, in, in, in, in, in, io).mutate11();
+		assertTrue(outputExpected(io, 11));
+	}
+
+	@Test
+	public void testOpMethodInplace12_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_1").input(io, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_2").input(in, io, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_3").input(in, in, io, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_4").input(in, in, in, io, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_5").input(in, in, in, in, io, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_6").input(in, in, in, in, in, io, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_7").input(in, in, in, in, in, in, io, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_8").input(in, in, in, in, in, in, in, io, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_9").input(in, in, in, in, in, in, in, in, io, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_10").input(in, in, in, in, in, in, in, in, in, io, in, in).mutate10();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_11").input(in, in, in, in, in, in, in, in, in, in, io, in).mutate11();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace12_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles12_12").input(in, in, in, in, in, in, in, in, in, in, in, io).mutate12();
+		assertTrue(outputExpected(io, 12));
+	}
+
+	@Test
+	public void testOpMethodInplace13_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in).mutate11();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in).mutate12();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace13_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles13_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io).mutate13();
+		assertTrue(outputExpected(io, 13));
+	}
+
+	@Test
+	public void testOpMethodInplace14_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate12();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate13();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace14_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles14_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate14();
+		assertTrue(outputExpected(io, 14));
+	}
+
+	@Test
+	public void testOpMethodInplace15_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate12();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate13();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate14();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace15_15() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles15_15").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate15();
+		assertTrue(outputExpected(io, 15));
+	}
+
+	@Test
+	public void testOpMethodInplace16_1() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_1").input(io, in, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate1();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_2() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_2").input(in, io, in, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate2();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_3() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_3").input(in, in, io, in, in, in, in, in, in, in, in, in, in, in, in, in).mutate3();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_4() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_4").input(in, in, in, io, in, in, in, in, in, in, in, in, in, in, in, in).mutate4();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_5() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_5").input(in, in, in, in, io, in, in, in, in, in, in, in, in, in, in, in).mutate5();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_6() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_6").input(in, in, in, in, in, io, in, in, in, in, in, in, in, in, in, in).mutate6();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_7() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_7").input(in, in, in, in, in, in, io, in, in, in, in, in, in, in, in, in).mutate7();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_8() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_8").input(in, in, in, in, in, in, in, io, in, in, in, in, in, in, in, in).mutate8();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_9() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_9").input(in, in, in, in, in, in, in, in, io, in, in, in, in, in, in, in).mutate9();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_10() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_10").input(in, in, in, in, in, in, in, in, in, io, in, in, in, in, in, in).mutate10();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_11() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_11").input(in, in, in, in, in, in, in, in, in, in, io, in, in, in, in, in).mutate11();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_12() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_12").input(in, in, in, in, in, in, in, in, in, in, in, io, in, in, in, in).mutate12();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_13() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_13").input(in, in, in, in, in, in, in, in, in, in, in, in, io, in, in, in).mutate13();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_14() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_14").input(in, in, in, in, in, in, in, in, in, in, in, in, in, io, in, in).mutate14();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_15() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_15").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, io, in).mutate15();
+		assertTrue(outputExpected(io, 16));
+	}
+
+	@Test
+	public void testOpMethodInplace16_16() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles16_16").input(in, in, in, in, in, in, in, in, in, in, in, in, in, in, in, io).mutate16();
+		assertTrue(outputExpected(io, 16));
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
@@ -1,6 +1,42 @@
+/*
+ * #%L
+ * SciJava Operations: a framework for reusable algorithms.
+ * %%
+ * Copyright (C) 2016 - 2019 SciJava Ops developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
 package org.scijava.ops;
 
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Computers;
+import org.scijava.ops.function.Functions;
+import org.scijava.ops.function.Inplaces;
 import org.scijava.ops.function.Producer;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
@@ -8,7 +44,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = OpCollection.class)
 public class OpMethodTestOps {
-	
+
 	// -- Functions -- //
 	@OpMethod(names = "test.multiplyNumericStrings", type = Producer.class)
 	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
@@ -16,4 +52,2701 @@ public class OpMethodTestOps {
 		return Integer.valueOf(1);
 	}
 
+	@OpMethod(names = "test.multiplyNumericStrings", type = Function.class)
+	public static Integer multiplyNumericStringsFunction1(String in1)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
+	public static Integer multiplyNumericStringsFunction2(String in1, String in2)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity3.class)
+	public static Integer multiplyNumericStringsFunction3(String in1, String in2, String in3)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity4.class)
+	public static Integer multiplyNumericStringsFunction4(String in1, String in2, String in3, String in4)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity5.class)
+	public static Integer multiplyNumericStringsFunction5(String in1, String in2, String in3, String in4, String in5)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity6.class)
+	public static Integer multiplyNumericStringsFunction6(String in1, String in2, String in3, String in4, String in5, String in6)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity7.class)
+	public static Integer multiplyNumericStringsFunction7(String in1, String in2, String in3, String in4, String in5, String in6, String in7)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity8.class)
+	public static Integer multiplyNumericStringsFunction8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity9.class)
+	public static Integer multiplyNumericStringsFunction9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity10.class)
+	public static Integer multiplyNumericStringsFunction10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity11.class)
+	public static Integer multiplyNumericStringsFunction11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity12.class)
+	public static Integer multiplyNumericStringsFunction12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+		out *= Integer.parseInt(in12);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity13.class)
+	public static Integer multiplyNumericStringsFunction13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+		out *= Integer.parseInt(in12);
+		out *= Integer.parseInt(in13);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity14.class)
+	public static Integer multiplyNumericStringsFunction14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+		out *= Integer.parseInt(in12);
+		out *= Integer.parseInt(in13);
+		out *= Integer.parseInt(in14);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity15.class)
+	public static Integer multiplyNumericStringsFunction15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+		out *= Integer.parseInt(in12);
+		out *= Integer.parseInt(in13);
+		out *= Integer.parseInt(in14);
+		out *= Integer.parseInt(in15);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity16.class)
+	public static Integer multiplyNumericStringsFunction16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16)
+	{
+		Integer out = Integer.valueOf(1);
+		
+		out *= Integer.parseInt(in1);
+		out *= Integer.parseInt(in2);
+		out *= Integer.parseInt(in3);
+		out *= Integer.parseInt(in4);
+		out *= Integer.parseInt(in5);
+		out *= Integer.parseInt(in6);
+		out *= Integer.parseInt(in7);
+		out *= Integer.parseInt(in8);
+		out *= Integer.parseInt(in9);
+		out *= Integer.parseInt(in10);
+		out *= Integer.parseInt(in11);
+		out *= Integer.parseInt(in12);
+		out *= Integer.parseInt(in13);
+		out *= Integer.parseInt(in14);
+		out *= Integer.parseInt(in15);
+		out *= Integer.parseInt(in16);
+
+		return out;
+	}
+
+	// -- Computers -- //
+	
+	@OpMethod(names = "test.doubleList", type = Computers.Arity0.class)
+	public static void doublesToListArity1(List<Double> output) {
+		output.clear();
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity1.class)
+	public static void doublesToList1(String in1, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity2.class)
+	public static void doublesToList2(String in1, String in2, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity3.class)
+	public static void doublesToList3(String in1, String in2, String in3, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity4.class)
+	public static void doublesToList4(String in1, String in2, String in3, String in4, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity5.class)
+	public static void doublesToList5(String in1, String in2, String in3, String in4, String in5, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity6.class)
+	public static void doublesToList6(String in1, String in2, String in3, String in4, String in5, String in6, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity7.class)
+	public static void doublesToList7(String in1, String in2, String in3, String in4, String in5, String in6, String in7, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity8.class)
+	public static void doublesToList8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity9.class)
+	public static void doublesToList9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity10.class)
+	public static void doublesToList10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity11.class)
+	public static void doublesToList11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity12.class)
+	public static void doublesToList12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+		output.add(Double.parseDouble(in12));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity13.class)
+	public static void doublesToList13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+		output.add(Double.parseDouble(in12));
+		output.add(Double.parseDouble(in13));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity14.class)
+	public static void doublesToList14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+		output.add(Double.parseDouble(in12));
+		output.add(Double.parseDouble(in13));
+		output.add(Double.parseDouble(in14));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity15.class)
+	public static void doublesToList15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+		output.add(Double.parseDouble(in12));
+		output.add(Double.parseDouble(in13));
+		output.add(Double.parseDouble(in14));
+		output.add(Double.parseDouble(in15));
+	}
+
+	@OpMethod(names = "test.doubleList", type = Computers.Arity16.class)
+	public static void doublesToList16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16, List<Double> output) {
+		output.clear();
+		
+		output.add(Double.parseDouble(in1));
+		output.add(Double.parseDouble(in2));
+		output.add(Double.parseDouble(in3));
+		output.add(Double.parseDouble(in4));
+		output.add(Double.parseDouble(in5));
+		output.add(Double.parseDouble(in6));
+		output.add(Double.parseDouble(in7));
+		output.add(Double.parseDouble(in8));
+		output.add(Double.parseDouble(in9));
+		output.add(Double.parseDouble(in10));
+		output.add(Double.parseDouble(in11));
+		output.add(Double.parseDouble(in12));
+		output.add(Double.parseDouble(in13));
+		output.add(Double.parseDouble(in14));
+		output.add(Double.parseDouble(in15));
+		output.add(Double.parseDouble(in16));
+	}
+
+	// -- Inplaces -- //
+
+
+	@OpMethod(names = "test.addDoubles1", type = Inplaces.Arity1.class)
+	public static void addDoubles1(double[] io) {
+		for (int i = 0; i < io.length; i++) {
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles2_1", type = Inplaces.Arity2_1.class)
+	public static void addDoubles2_1(double[] io, double[] in2) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles2_2", type = Inplaces.Arity2_2.class)
+	public static void addDoubles2_2(double[] in1, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles3_1", type = Inplaces.Arity3_1.class)
+	public static void addDoubles3_1(double[] io, double[] in2, double[] in3) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles3_2", type = Inplaces.Arity3_2.class)
+	public static void addDoubles3_2(double[] in1, double[] io, double[] in3) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles3_3", type = Inplaces.Arity3_3.class)
+	public static void addDoubles3_3(double[] in1, double[] in2, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles4_1", type = Inplaces.Arity4_1.class)
+	public static void addDoubles4_1(double[] io, double[] in2, double[] in3, double[] in4) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles4_2", type = Inplaces.Arity4_2.class)
+	public static void addDoubles4_2(double[] in1, double[] io, double[] in3, double[] in4) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles4_3", type = Inplaces.Arity4_3.class)
+	public static void addDoubles4_3(double[] in1, double[] in2, double[] io, double[] in4) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles4_4", type = Inplaces.Arity4_4.class)
+	public static void addDoubles4_4(double[] in1, double[] in2, double[] in3, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles5_1", type = Inplaces.Arity5_1.class)
+	public static void addDoubles5_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles5_2", type = Inplaces.Arity5_2.class)
+	public static void addDoubles5_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles5_3", type = Inplaces.Arity5_3.class)
+	public static void addDoubles5_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles5_4", type = Inplaces.Arity5_4.class)
+	public static void addDoubles5_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles5_5", type = Inplaces.Arity5_5.class)
+	public static void addDoubles5_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_1", type = Inplaces.Arity6_1.class)
+	public static void addDoubles6_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_2", type = Inplaces.Arity6_2.class)
+	public static void addDoubles6_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_3", type = Inplaces.Arity6_3.class)
+	public static void addDoubles6_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_4", type = Inplaces.Arity6_4.class)
+	public static void addDoubles6_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_5", type = Inplaces.Arity6_5.class)
+	public static void addDoubles6_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles6_6", type = Inplaces.Arity6_6.class)
+	public static void addDoubles6_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_1", type = Inplaces.Arity7_1.class)
+	public static void addDoubles7_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_2", type = Inplaces.Arity7_2.class)
+	public static void addDoubles7_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_3", type = Inplaces.Arity7_3.class)
+	public static void addDoubles7_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_4", type = Inplaces.Arity7_4.class)
+	public static void addDoubles7_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_5", type = Inplaces.Arity7_5.class)
+	public static void addDoubles7_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_6", type = Inplaces.Arity7_6.class)
+	public static void addDoubles7_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles7_7", type = Inplaces.Arity7_7.class)
+	public static void addDoubles7_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_1", type = Inplaces.Arity8_1.class)
+	public static void addDoubles8_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_2", type = Inplaces.Arity8_2.class)
+	public static void addDoubles8_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_3", type = Inplaces.Arity8_3.class)
+	public static void addDoubles8_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_4", type = Inplaces.Arity8_4.class)
+	public static void addDoubles8_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_5", type = Inplaces.Arity8_5.class)
+	public static void addDoubles8_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_6", type = Inplaces.Arity8_6.class)
+	public static void addDoubles8_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_7", type = Inplaces.Arity8_7.class)
+	public static void addDoubles8_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles8_8", type = Inplaces.Arity8_8.class)
+	public static void addDoubles8_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_1", type = Inplaces.Arity9_1.class)
+	public static void addDoubles9_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_2", type = Inplaces.Arity9_2.class)
+	public static void addDoubles9_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_3", type = Inplaces.Arity9_3.class)
+	public static void addDoubles9_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_4", type = Inplaces.Arity9_4.class)
+	public static void addDoubles9_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_5", type = Inplaces.Arity9_5.class)
+	public static void addDoubles9_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_6", type = Inplaces.Arity9_6.class)
+	public static void addDoubles9_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_7", type = Inplaces.Arity9_7.class)
+	public static void addDoubles9_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_8", type = Inplaces.Arity9_8.class)
+	public static void addDoubles9_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles9_9", type = Inplaces.Arity9_9.class)
+	public static void addDoubles9_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_1", type = Inplaces.Arity10_1.class)
+	public static void addDoubles10_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_2", type = Inplaces.Arity10_2.class)
+	public static void addDoubles10_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_3", type = Inplaces.Arity10_3.class)
+	public static void addDoubles10_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_4", type = Inplaces.Arity10_4.class)
+	public static void addDoubles10_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_5", type = Inplaces.Arity10_5.class)
+	public static void addDoubles10_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_6", type = Inplaces.Arity10_6.class)
+	public static void addDoubles10_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_7", type = Inplaces.Arity10_7.class)
+	public static void addDoubles10_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_8", type = Inplaces.Arity10_8.class)
+	public static void addDoubles10_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_9", type = Inplaces.Arity10_9.class)
+	public static void addDoubles10_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles10_10", type = Inplaces.Arity10_10.class)
+	public static void addDoubles10_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_1", type = Inplaces.Arity11_1.class)
+	public static void addDoubles11_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_2", type = Inplaces.Arity11_2.class)
+	public static void addDoubles11_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_3", type = Inplaces.Arity11_3.class)
+	public static void addDoubles11_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_4", type = Inplaces.Arity11_4.class)
+	public static void addDoubles11_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_5", type = Inplaces.Arity11_5.class)
+	public static void addDoubles11_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_6", type = Inplaces.Arity11_6.class)
+	public static void addDoubles11_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_7", type = Inplaces.Arity11_7.class)
+	public static void addDoubles11_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_8", type = Inplaces.Arity11_8.class)
+	public static void addDoubles11_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_9", type = Inplaces.Arity11_9.class)
+	public static void addDoubles11_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_10", type = Inplaces.Arity11_10.class)
+	public static void addDoubles11_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles11_11", type = Inplaces.Arity11_11.class)
+	public static void addDoubles11_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_1", type = Inplaces.Arity12_1.class)
+	public static void addDoubles12_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_2", type = Inplaces.Arity12_2.class)
+	public static void addDoubles12_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_3", type = Inplaces.Arity12_3.class)
+	public static void addDoubles12_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_4", type = Inplaces.Arity12_4.class)
+	public static void addDoubles12_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_5", type = Inplaces.Arity12_5.class)
+	public static void addDoubles12_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_6", type = Inplaces.Arity12_6.class)
+	public static void addDoubles12_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_7", type = Inplaces.Arity12_7.class)
+	public static void addDoubles12_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_8", type = Inplaces.Arity12_8.class)
+	public static void addDoubles12_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_9", type = Inplaces.Arity12_9.class)
+	public static void addDoubles12_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_10", type = Inplaces.Arity12_10.class)
+	public static void addDoubles12_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_11", type = Inplaces.Arity12_11.class)
+	public static void addDoubles12_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles12_12", type = Inplaces.Arity12_12.class)
+	public static void addDoubles12_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_1", type = Inplaces.Arity13_1.class)
+	public static void addDoubles13_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_2", type = Inplaces.Arity13_2.class)
+	public static void addDoubles13_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_3", type = Inplaces.Arity13_3.class)
+	public static void addDoubles13_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_4", type = Inplaces.Arity13_4.class)
+	public static void addDoubles13_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_5", type = Inplaces.Arity13_5.class)
+	public static void addDoubles13_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_6", type = Inplaces.Arity13_6.class)
+	public static void addDoubles13_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_7", type = Inplaces.Arity13_7.class)
+	public static void addDoubles13_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_8", type = Inplaces.Arity13_8.class)
+	public static void addDoubles13_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_9", type = Inplaces.Arity13_9.class)
+	public static void addDoubles13_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_10", type = Inplaces.Arity13_10.class)
+	public static void addDoubles13_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_11", type = Inplaces.Arity13_11.class)
+	public static void addDoubles13_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_12", type = Inplaces.Arity13_12.class)
+	public static void addDoubles13_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles13_13", type = Inplaces.Arity13_13.class)
+	public static void addDoubles13_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_1", type = Inplaces.Arity14_1.class)
+	public static void addDoubles14_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_2", type = Inplaces.Arity14_2.class)
+	public static void addDoubles14_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_3", type = Inplaces.Arity14_3.class)
+	public static void addDoubles14_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_4", type = Inplaces.Arity14_4.class)
+	public static void addDoubles14_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_5", type = Inplaces.Arity14_5.class)
+	public static void addDoubles14_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_6", type = Inplaces.Arity14_6.class)
+	public static void addDoubles14_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_7", type = Inplaces.Arity14_7.class)
+	public static void addDoubles14_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_8", type = Inplaces.Arity14_8.class)
+	public static void addDoubles14_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_9", type = Inplaces.Arity14_9.class)
+	public static void addDoubles14_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_10", type = Inplaces.Arity14_10.class)
+	public static void addDoubles14_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_11", type = Inplaces.Arity14_11.class)
+	public static void addDoubles14_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_12", type = Inplaces.Arity14_12.class)
+	public static void addDoubles14_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_13", type = Inplaces.Arity14_13.class)
+	public static void addDoubles14_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles14_14", type = Inplaces.Arity14_14.class)
+	public static void addDoubles14_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_1", type = Inplaces.Arity15_1.class)
+	public static void addDoubles15_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_2", type = Inplaces.Arity15_2.class)
+	public static void addDoubles15_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_3", type = Inplaces.Arity15_3.class)
+	public static void addDoubles15_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_4", type = Inplaces.Arity15_4.class)
+	public static void addDoubles15_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_5", type = Inplaces.Arity15_5.class)
+	public static void addDoubles15_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_6", type = Inplaces.Arity15_6.class)
+	public static void addDoubles15_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_7", type = Inplaces.Arity15_7.class)
+	public static void addDoubles15_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_8", type = Inplaces.Arity15_8.class)
+	public static void addDoubles15_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_9", type = Inplaces.Arity15_9.class)
+	public static void addDoubles15_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_10", type = Inplaces.Arity15_10.class)
+	public static void addDoubles15_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_11", type = Inplaces.Arity15_11.class)
+	public static void addDoubles15_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_12", type = Inplaces.Arity15_12.class)
+	public static void addDoubles15_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_13", type = Inplaces.Arity15_13.class)
+	public static void addDoubles15_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_14", type = Inplaces.Arity15_14.class)
+	public static void addDoubles15_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in15[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles15_15", type = Inplaces.Arity15_15.class)
+	public static void addDoubles15_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_1", type = Inplaces.Arity16_1.class)
+	public static void addDoubles16_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_2", type = Inplaces.Arity16_2.class)
+	public static void addDoubles16_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_3", type = Inplaces.Arity16_3.class)
+	public static void addDoubles16_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_4", type = Inplaces.Arity16_4.class)
+	public static void addDoubles16_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_5", type = Inplaces.Arity16_5.class)
+	public static void addDoubles16_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_6", type = Inplaces.Arity16_6.class)
+	public static void addDoubles16_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_7", type = Inplaces.Arity16_7.class)
+	public static void addDoubles16_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_8", type = Inplaces.Arity16_8.class)
+	public static void addDoubles16_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_9", type = Inplaces.Arity16_9.class)
+	public static void addDoubles16_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_10", type = Inplaces.Arity16_10.class)
+	public static void addDoubles16_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_11", type = Inplaces.Arity16_11.class)
+	public static void addDoubles16_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_12", type = Inplaces.Arity16_12.class)
+	public static void addDoubles16_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_13", type = Inplaces.Arity16_13.class)
+	public static void addDoubles16_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_14", type = Inplaces.Arity16_14.class)
+	public static void addDoubles16_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in15[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_15", type = Inplaces.Arity16_15.class)
+	public static void addDoubles16_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io, double[] in16) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in16[i];
+		}
+	}
+
+	@OpMethod(names = "test.addDoubles16_16", type = Inplaces.Arity16_16.class)
+	public static void addDoubles16_16(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] io) {
+		for (int i = 0; i < io.length; i++) {
+			io[i] += in1[i];
+			io[i] += in2[i];
+			io[i] += in3[i];
+			io[i] += in4[i];
+			io[i] += in5[i];
+			io[i] += in6[i];
+			io[i] += in7[i];
+			io[i] += in8[i];
+			io[i] += in9[i];
+			io[i] += in10[i];
+			io[i] += in11[i];
+			io[i] += in12[i];
+			io[i] += in13[i];
+			io[i] += in14[i];
+			io[i] += in15[i];
+		}
+	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
@@ -1,0 +1,19 @@
+package org.scijava.ops;
+
+import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Producer;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+@Plugin(type = OpCollection.class)
+public class OpMethodTestOps {
+	
+	// -- Functions -- //
+	@OpMethod(names = "test.multiplyNumericStrings", type = Producer.class)
+	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+	public static Integer multiplyNumericStringsProducer() {
+		return Integer.valueOf(1);
+	}
+
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
@@ -53,522 +53,186 @@ public class OpMethodTestOps {
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Function.class)
-	public static Integer multiplyNumericStringsFunction1(String in1)
+	public static Integer multiplyNumericStringsFunction1(String in)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-
-		return out;
+		return multiplyNumericStringsFunction1(in, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
 	public static Integer multiplyNumericStringsFunction2(String in1, String in2)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-
-		return out;
+		return multiplyNumericStringsFunction2(in1, in2, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity3.class)
 	public static Integer multiplyNumericStringsFunction3(String in1, String in2, String in3)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-
-		return out;
+		return multiplyNumericStringsFunction3(in1, in2, in3, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity4.class)
 	public static Integer multiplyNumericStringsFunction4(String in1, String in2, String in3, String in4)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-
-		return out;
+		return multiplyNumericStringsFunction4(in1, in2, in3, in4, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity5.class)
 	public static Integer multiplyNumericStringsFunction5(String in1, String in2, String in3, String in4, String in5)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-
-		return out;
+		return multiplyNumericStringsFunction5(in1, in2, in3, in4, in5, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity6.class)
 	public static Integer multiplyNumericStringsFunction6(String in1, String in2, String in3, String in4, String in5, String in6)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-
-		return out;
+		return multiplyNumericStringsFunction6(in1, in2, in3, in4, in5, in6, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity7.class)
 	public static Integer multiplyNumericStringsFunction7(String in1, String in2, String in3, String in4, String in5, String in6, String in7)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-
-		return out;
+		return multiplyNumericStringsFunction7(in1, in2, in3, in4, in5, in6, in7, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity8.class)
 	public static Integer multiplyNumericStringsFunction8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-
-		return out;
+		return multiplyNumericStringsFunction8(in1, in2, in3, in4, in5, in6, in7, in8, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity9.class)
 	public static Integer multiplyNumericStringsFunction9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-
-		return out;
+		return multiplyNumericStringsFunction9(in1, in2, in3, in4, in5, in6, in7, in8, in9, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity10.class)
 	public static Integer multiplyNumericStringsFunction10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-
-		return out;
+		return multiplyNumericStringsFunction10(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity11.class)
 	public static Integer multiplyNumericStringsFunction11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-
-		return out;
+		return multiplyNumericStringsFunction11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity12.class)
 	public static Integer multiplyNumericStringsFunction12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-		out *= Integer.parseInt(in12);
-
-		return out;
+		return multiplyNumericStringsFunction12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity13.class)
 	public static Integer multiplyNumericStringsFunction13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-		out *= Integer.parseInt(in12);
-		out *= Integer.parseInt(in13);
-
-		return out;
+		return multiplyNumericStringsFunction13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity14.class)
 	public static Integer multiplyNumericStringsFunction14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-		out *= Integer.parseInt(in12);
-		out *= Integer.parseInt(in13);
-		out *= Integer.parseInt(in14);
-
-		return out;
+		return multiplyNumericStringsFunction14(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity15.class)
 	public static Integer multiplyNumericStringsFunction15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-		out *= Integer.parseInt(in12);
-		out *= Integer.parseInt(in13);
-		out *= Integer.parseInt(in14);
-		out *= Integer.parseInt(in15);
-
-		return out;
+		return multiplyNumericStringsFunction15(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, parseInt);
 	}
 
 	@OpMethod(names = "test.multiplyNumericStrings", type = Functions.Arity16.class)
 	public static Integer multiplyNumericStringsFunction16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16)
 	{
-		Integer out = Integer.valueOf(1);
-		
-		out *= Integer.parseInt(in1);
-		out *= Integer.parseInt(in2);
-		out *= Integer.parseInt(in3);
-		out *= Integer.parseInt(in4);
-		out *= Integer.parseInt(in5);
-		out *= Integer.parseInt(in6);
-		out *= Integer.parseInt(in7);
-		out *= Integer.parseInt(in8);
-		out *= Integer.parseInt(in9);
-		out *= Integer.parseInt(in10);
-		out *= Integer.parseInt(in11);
-		out *= Integer.parseInt(in12);
-		out *= Integer.parseInt(in13);
-		out *= Integer.parseInt(in14);
-		out *= Integer.parseInt(in15);
-		out *= Integer.parseInt(in16);
-
-		return out;
+		return multiplyNumericStringsFunction16(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, parseInt);
 	}
 
 	// -- Computers -- //
 	
 	@OpMethod(names = "test.doubleList", type = Computers.Arity0.class)
-	public static void doublesToListArity1(List<Double> output) {
+	public static void doublesToList0(List<Double> output) {
 		output.clear();
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity1.class)
-	public static void doublesToList1(String in1, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
+	public static void doublesToList1(String in, List<Double> output) {
+		doublesToListWithOp1(in, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity2.class)
 	public static void doublesToList2(String in1, String in2, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
+		doublesToListWithOp2(in1, in2, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity3.class)
 	public static void doublesToList3(String in1, String in2, String in3, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
+		doublesToListWithOp3(in1, in2, in3, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity4.class)
 	public static void doublesToList4(String in1, String in2, String in3, String in4, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
+		doublesToListWithOp4(in1, in2, in3, in4, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity5.class)
 	public static void doublesToList5(String in1, String in2, String in3, String in4, String in5, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
+		doublesToListWithOp5(in1, in2, in3, in4, in5, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity6.class)
 	public static void doublesToList6(String in1, String in2, String in3, String in4, String in5, String in6, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
+		doublesToListWithOp6(in1, in2, in3, in4, in5, in6, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity7.class)
 	public static void doublesToList7(String in1, String in2, String in3, String in4, String in5, String in6, String in7, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
+		doublesToListWithOp7(in1, in2, in3, in4, in5, in6, in7, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity8.class)
 	public static void doublesToList8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
+		doublesToListWithOp8(in1, in2, in3, in4, in5, in6, in7, in8, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity9.class)
 	public static void doublesToList9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
+		doublesToListWithOp9(in1, in2, in3, in4, in5, in6, in7, in8, in9, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity10.class)
 	public static void doublesToList10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
+		doublesToListWithOp10(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity11.class)
 	public static void doublesToList11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
+		doublesToListWithOp11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity12.class)
 	public static void doublesToList12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
-		output.add(Double.parseDouble(in12));
+		doublesToListWithOp12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity13.class)
 	public static void doublesToList13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
-		output.add(Double.parseDouble(in12));
-		output.add(Double.parseDouble(in13));
+		doublesToListWithOp13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity14.class)
 	public static void doublesToList14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
-		output.add(Double.parseDouble(in12));
-		output.add(Double.parseDouble(in13));
-		output.add(Double.parseDouble(in14));
+		doublesToListWithOp14(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity15.class)
 	public static void doublesToList15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
-		output.add(Double.parseDouble(in12));
-		output.add(Double.parseDouble(in13));
-		output.add(Double.parseDouble(in14));
-		output.add(Double.parseDouble(in15));
+		doublesToListWithOp15(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, output, appendDouble);
 	}
 
 	@OpMethod(names = "test.doubleList", type = Computers.Arity16.class)
 	public static void doublesToList16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16, List<Double> output) {
-		output.clear();
-		
-		output.add(Double.parseDouble(in1));
-		output.add(Double.parseDouble(in2));
-		output.add(Double.parseDouble(in3));
-		output.add(Double.parseDouble(in4));
-		output.add(Double.parseDouble(in5));
-		output.add(Double.parseDouble(in6));
-		output.add(Double.parseDouble(in7));
-		output.add(Double.parseDouble(in8));
-		output.add(Double.parseDouble(in9));
-		output.add(Double.parseDouble(in10));
-		output.add(Double.parseDouble(in11));
-		output.add(Double.parseDouble(in12));
-		output.add(Double.parseDouble(in13));
-		output.add(Double.parseDouble(in14));
-		output.add(Double.parseDouble(in15));
-		output.add(Double.parseDouble(in16));
+		doublesToListWithOp16(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, output, appendDouble);
 	}
 
 	// -- Inplaces -- //
@@ -576,2177 +240,3169 @@ public class OpMethodTestOps {
 
 	@OpMethod(names = "test.addDoubles1", type = Inplaces.Arity1.class)
 	public static void addDoubles1(double[] io) {
-		for (int i = 0; i < io.length; i++) {
-		}
+		dependentAddDoubles1(io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles2_1", type = Inplaces.Arity2_1.class)
 	public static void addDoubles2_1(double[] io, double[] in2) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-		}
+		dependentAddDoubles2_1(io, in2, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles2_2", type = Inplaces.Arity2_2.class)
 	public static void addDoubles2_2(double[] in1, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-		}
+		dependentAddDoubles2_2(in1, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles3_1", type = Inplaces.Arity3_1.class)
 	public static void addDoubles3_1(double[] io, double[] in2, double[] in3) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-		}
+		dependentAddDoubles3_1(io, in2, in3, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles3_2", type = Inplaces.Arity3_2.class)
 	public static void addDoubles3_2(double[] in1, double[] io, double[] in3) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-		}
+		dependentAddDoubles3_2(in1, io, in3, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles3_3", type = Inplaces.Arity3_3.class)
 	public static void addDoubles3_3(double[] in1, double[] in2, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-		}
+		dependentAddDoubles3_3(in1, in2, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles4_1", type = Inplaces.Arity4_1.class)
 	public static void addDoubles4_1(double[] io, double[] in2, double[] in3, double[] in4) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-		}
+		dependentAddDoubles4_1(io, in2, in3, in4, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles4_2", type = Inplaces.Arity4_2.class)
 	public static void addDoubles4_2(double[] in1, double[] io, double[] in3, double[] in4) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-		}
+		dependentAddDoubles4_2(in1, io, in3, in4, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles4_3", type = Inplaces.Arity4_3.class)
 	public static void addDoubles4_3(double[] in1, double[] in2, double[] io, double[] in4) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-		}
+		dependentAddDoubles4_3(in1, in2, io, in4, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles4_4", type = Inplaces.Arity4_4.class)
 	public static void addDoubles4_4(double[] in1, double[] in2, double[] in3, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-		}
+		dependentAddDoubles4_4(in1, in2, in3, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles5_1", type = Inplaces.Arity5_1.class)
 	public static void addDoubles5_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-		}
+		dependentAddDoubles5_1(io, in2, in3, in4, in5, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles5_2", type = Inplaces.Arity5_2.class)
 	public static void addDoubles5_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-		}
+		dependentAddDoubles5_2(in1, io, in3, in4, in5, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles5_3", type = Inplaces.Arity5_3.class)
 	public static void addDoubles5_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-		}
+		dependentAddDoubles5_3(in1, in2, io, in4, in5, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles5_4", type = Inplaces.Arity5_4.class)
 	public static void addDoubles5_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-		}
+		dependentAddDoubles5_4(in1, in2, in3, io, in5, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles5_5", type = Inplaces.Arity5_5.class)
 	public static void addDoubles5_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-		}
+		dependentAddDoubles5_5(in1, in2, in3, in4, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_1", type = Inplaces.Arity6_1.class)
 	public static void addDoubles6_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles6_1(io, in2, in3, in4, in5, in6, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_2", type = Inplaces.Arity6_2.class)
 	public static void addDoubles6_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles6_2(in1, io, in3, in4, in5, in6, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_3", type = Inplaces.Arity6_3.class)
 	public static void addDoubles6_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles6_3(in1, in2, io, in4, in5, in6, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_4", type = Inplaces.Arity6_4.class)
 	public static void addDoubles6_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles6_4(in1, in2, in3, io, in5, in6, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_5", type = Inplaces.Arity6_5.class)
 	public static void addDoubles6_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles6_5(in1, in2, in3, in4, io, in6, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles6_6", type = Inplaces.Arity6_6.class)
 	public static void addDoubles6_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-		}
+		dependentAddDoubles6_6(in1, in2, in3, in4, in5, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_1", type = Inplaces.Arity7_1.class)
 	public static void addDoubles7_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_1(io, in2, in3, in4, in5, in6, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_2", type = Inplaces.Arity7_2.class)
 	public static void addDoubles7_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_2(in1, io, in3, in4, in5, in6, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_3", type = Inplaces.Arity7_3.class)
 	public static void addDoubles7_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_3(in1, in2, io, in4, in5, in6, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_4", type = Inplaces.Arity7_4.class)
 	public static void addDoubles7_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_4(in1, in2, in3, io, in5, in6, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_5", type = Inplaces.Arity7_5.class)
 	public static void addDoubles7_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_5(in1, in2, in3, in4, io, in6, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_6", type = Inplaces.Arity7_6.class)
 	public static void addDoubles7_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles7_6(in1, in2, in3, in4, in5, io, in7, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles7_7", type = Inplaces.Arity7_7.class)
 	public static void addDoubles7_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-		}
+		dependentAddDoubles7_7(in1, in2, in3, in4, in5, in6, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_1", type = Inplaces.Arity8_1.class)
 	public static void addDoubles8_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_1(io, in2, in3, in4, in5, in6, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_2", type = Inplaces.Arity8_2.class)
 	public static void addDoubles8_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_2(in1, io, in3, in4, in5, in6, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_3", type = Inplaces.Arity8_3.class)
 	public static void addDoubles8_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_3(in1, in2, io, in4, in5, in6, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_4", type = Inplaces.Arity8_4.class)
 	public static void addDoubles8_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_4(in1, in2, in3, io, in5, in6, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_5", type = Inplaces.Arity8_5.class)
 	public static void addDoubles8_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_5(in1, in2, in3, in4, io, in6, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_6", type = Inplaces.Arity8_6.class)
 	public static void addDoubles8_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_6(in1, in2, in3, in4, in5, io, in7, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_7", type = Inplaces.Arity8_7.class)
 	public static void addDoubles8_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles8_7(in1, in2, in3, in4, in5, in6, io, in8, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles8_8", type = Inplaces.Arity8_8.class)
 	public static void addDoubles8_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-		}
+		dependentAddDoubles8_8(in1, in2, in3, in4, in5, in6, in7, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_1", type = Inplaces.Arity9_1.class)
 	public static void addDoubles9_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_1(io, in2, in3, in4, in5, in6, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_2", type = Inplaces.Arity9_2.class)
 	public static void addDoubles9_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_2(in1, io, in3, in4, in5, in6, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_3", type = Inplaces.Arity9_3.class)
 	public static void addDoubles9_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_3(in1, in2, io, in4, in5, in6, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_4", type = Inplaces.Arity9_4.class)
 	public static void addDoubles9_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_4(in1, in2, in3, io, in5, in6, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_5", type = Inplaces.Arity9_5.class)
 	public static void addDoubles9_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_5(in1, in2, in3, in4, io, in6, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_6", type = Inplaces.Arity9_6.class)
 	public static void addDoubles9_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_6(in1, in2, in3, in4, in5, io, in7, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_7", type = Inplaces.Arity9_7.class)
 	public static void addDoubles9_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_7(in1, in2, in3, in4, in5, in6, io, in8, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_8", type = Inplaces.Arity9_8.class)
 	public static void addDoubles9_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles9_8(in1, in2, in3, in4, in5, in6, in7, io, in9, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles9_9", type = Inplaces.Arity9_9.class)
 	public static void addDoubles9_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-		}
+		dependentAddDoubles9_9(in1, in2, in3, in4, in5, in6, in7, in8, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_1", type = Inplaces.Arity10_1.class)
 	public static void addDoubles10_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_2", type = Inplaces.Arity10_2.class)
 	public static void addDoubles10_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_3", type = Inplaces.Arity10_3.class)
 	public static void addDoubles10_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_4", type = Inplaces.Arity10_4.class)
 	public static void addDoubles10_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_5", type = Inplaces.Arity10_5.class)
 	public static void addDoubles10_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_6", type = Inplaces.Arity10_6.class)
 	public static void addDoubles10_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_7", type = Inplaces.Arity10_7.class)
 	public static void addDoubles10_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_8", type = Inplaces.Arity10_8.class)
 	public static void addDoubles10_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_9", type = Inplaces.Arity10_9.class)
 	public static void addDoubles10_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles10_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles10_10", type = Inplaces.Arity10_10.class)
 	public static void addDoubles10_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-		}
+		dependentAddDoubles10_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_1", type = Inplaces.Arity11_1.class)
 	public static void addDoubles11_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_2", type = Inplaces.Arity11_2.class)
 	public static void addDoubles11_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_3", type = Inplaces.Arity11_3.class)
 	public static void addDoubles11_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_4", type = Inplaces.Arity11_4.class)
 	public static void addDoubles11_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_5", type = Inplaces.Arity11_5.class)
 	public static void addDoubles11_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_6", type = Inplaces.Arity11_6.class)
 	public static void addDoubles11_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_7", type = Inplaces.Arity11_7.class)
 	public static void addDoubles11_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_8", type = Inplaces.Arity11_8.class)
 	public static void addDoubles11_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_9", type = Inplaces.Arity11_9.class)
 	public static void addDoubles11_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_10", type = Inplaces.Arity11_10.class)
 	public static void addDoubles11_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles11_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles11_11", type = Inplaces.Arity11_11.class)
 	public static void addDoubles11_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-		}
+		dependentAddDoubles11_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_1", type = Inplaces.Arity12_1.class)
 	public static void addDoubles12_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_2", type = Inplaces.Arity12_2.class)
 	public static void addDoubles12_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_3", type = Inplaces.Arity12_3.class)
 	public static void addDoubles12_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_4", type = Inplaces.Arity12_4.class)
 	public static void addDoubles12_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_5", type = Inplaces.Arity12_5.class)
 	public static void addDoubles12_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_6", type = Inplaces.Arity12_6.class)
 	public static void addDoubles12_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_7", type = Inplaces.Arity12_7.class)
 	public static void addDoubles12_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_8", type = Inplaces.Arity12_8.class)
 	public static void addDoubles12_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_9", type = Inplaces.Arity12_9.class)
 	public static void addDoubles12_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_10", type = Inplaces.Arity12_10.class)
 	public static void addDoubles12_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_11", type = Inplaces.Arity12_11.class)
 	public static void addDoubles12_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles12_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles12_12", type = Inplaces.Arity12_12.class)
 	public static void addDoubles12_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-		}
+		dependentAddDoubles12_12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_1", type = Inplaces.Arity13_1.class)
 	public static void addDoubles13_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_2", type = Inplaces.Arity13_2.class)
 	public static void addDoubles13_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_3", type = Inplaces.Arity13_3.class)
 	public static void addDoubles13_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_4", type = Inplaces.Arity13_4.class)
 	public static void addDoubles13_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_5", type = Inplaces.Arity13_5.class)
 	public static void addDoubles13_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_6", type = Inplaces.Arity13_6.class)
 	public static void addDoubles13_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_7", type = Inplaces.Arity13_7.class)
 	public static void addDoubles13_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_8", type = Inplaces.Arity13_8.class)
 	public static void addDoubles13_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_9", type = Inplaces.Arity13_9.class)
 	public static void addDoubles13_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_10", type = Inplaces.Arity13_10.class)
 	public static void addDoubles13_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_11", type = Inplaces.Arity13_11.class)
 	public static void addDoubles13_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_12", type = Inplaces.Arity13_12.class)
 	public static void addDoubles13_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles13_12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles13_13", type = Inplaces.Arity13_13.class)
 	public static void addDoubles13_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-		}
+		dependentAddDoubles13_13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_1", type = Inplaces.Arity14_1.class)
 	public static void addDoubles14_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_2", type = Inplaces.Arity14_2.class)
 	public static void addDoubles14_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_3", type = Inplaces.Arity14_3.class)
 	public static void addDoubles14_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_4", type = Inplaces.Arity14_4.class)
 	public static void addDoubles14_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_5", type = Inplaces.Arity14_5.class)
 	public static void addDoubles14_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_6", type = Inplaces.Arity14_6.class)
 	public static void addDoubles14_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_7", type = Inplaces.Arity14_7.class)
 	public static void addDoubles14_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_8", type = Inplaces.Arity14_8.class)
 	public static void addDoubles14_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_9", type = Inplaces.Arity14_9.class)
 	public static void addDoubles14_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_10", type = Inplaces.Arity14_10.class)
 	public static void addDoubles14_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_11", type = Inplaces.Arity14_11.class)
 	public static void addDoubles14_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_12", type = Inplaces.Arity14_12.class)
 	public static void addDoubles14_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_13", type = Inplaces.Arity14_13.class)
 	public static void addDoubles14_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles14_13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles14_14", type = Inplaces.Arity14_14.class)
 	public static void addDoubles14_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-		}
+		dependentAddDoubles14_14(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_1", type = Inplaces.Arity15_1.class)
 	public static void addDoubles15_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_2", type = Inplaces.Arity15_2.class)
 	public static void addDoubles15_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_3", type = Inplaces.Arity15_3.class)
 	public static void addDoubles15_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_4", type = Inplaces.Arity15_4.class)
 	public static void addDoubles15_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_5", type = Inplaces.Arity15_5.class)
 	public static void addDoubles15_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_6", type = Inplaces.Arity15_6.class)
 	public static void addDoubles15_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_7", type = Inplaces.Arity15_7.class)
 	public static void addDoubles15_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_8", type = Inplaces.Arity15_8.class)
 	public static void addDoubles15_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_9", type = Inplaces.Arity15_9.class)
 	public static void addDoubles15_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_10", type = Inplaces.Arity15_10.class)
 	public static void addDoubles15_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_11", type = Inplaces.Arity15_11.class)
 	public static void addDoubles15_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_12", type = Inplaces.Arity15_12.class)
 	public static void addDoubles15_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_13", type = Inplaces.Arity15_13.class)
 	public static void addDoubles15_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_14", type = Inplaces.Arity15_14.class)
 	public static void addDoubles15_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in15[i];
-		}
+		dependentAddDoubles15_14(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io, in15, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles15_15", type = Inplaces.Arity15_15.class)
 	public static void addDoubles15_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-		}
+		dependentAddDoubles15_15(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, io, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_1", type = Inplaces.Arity16_1.class)
 	public static void addDoubles16_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_1(io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_2", type = Inplaces.Arity16_2.class)
 	public static void addDoubles16_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_2(in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_3", type = Inplaces.Arity16_3.class)
 	public static void addDoubles16_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_3(in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_4", type = Inplaces.Arity16_4.class)
 	public static void addDoubles16_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_4(in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_5", type = Inplaces.Arity16_5.class)
 	public static void addDoubles16_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_5(in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_6", type = Inplaces.Arity16_6.class)
 	public static void addDoubles16_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_6(in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_7", type = Inplaces.Arity16_7.class)
 	public static void addDoubles16_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_7(in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_8", type = Inplaces.Arity16_8.class)
 	public static void addDoubles16_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_8(in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_9", type = Inplaces.Arity16_9.class)
 	public static void addDoubles16_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_9(in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_10", type = Inplaces.Arity16_10.class)
 	public static void addDoubles16_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_10(in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_11", type = Inplaces.Arity16_11.class)
 	public static void addDoubles16_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_11(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_12", type = Inplaces.Arity16_12.class)
 	public static void addDoubles16_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_12(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_13", type = Inplaces.Arity16_13.class)
 	public static void addDoubles16_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_13(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_14", type = Inplaces.Arity16_14.class)
 	public static void addDoubles16_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in15[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_14(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io, in15, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_15", type = Inplaces.Arity16_15.class)
 	public static void addDoubles16_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io, double[] in16) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
-			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in16[i];
-		}
+		dependentAddDoubles16_15(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, io, in16, addArrays);
 	}
 
 	@OpMethod(names = "test.addDoubles16_16", type = Inplaces.Arity16_16.class)
 	public static void addDoubles16_16(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] io) {
-		for (int i = 0; i < io.length; i++) {
-			io[i] += in1[i];
+		dependentAddDoubles16_16(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, io, addArrays);
+	}
+
+	// -- Helper Op -- //
+
+	@OpField(names = "test.parseInt")
+	public static final Function<String, Integer> parseInt = in -> Integer
+		.parseInt(in);
+
+	@OpField(names = "test.appendDouble")
+	public static final Inplaces.Arity2_1<List<Double>, String> appendDouble = (
+		list, element) -> list.add(Double.parseDouble(element));
+
+	@OpField(names = "test.addArrays")
+	public static final Inplaces.Arity2_1<double[], double[]> addArrays = (io,
+		in2) -> {
+		for (int i = 0; i < io.length; i++)
 			io[i] += in2[i];
-			io[i] += in3[i];
-			io[i] += in4[i];
-			io[i] += in5[i];
-			io[i] += in6[i];
-			io[i] += in7[i];
-			io[i] += in8[i];
-			io[i] += in9[i];
-			io[i] += in10[i];
-			io[i] += in11[i];
-			io[i] += in12[i];
-			io[i] += in13[i];
-			io[i] += in14[i];
-			io[i] += in15[i];
-		}
+	};
+
+	// -- Dependent Functions -- //
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Function.class)
+	public static Integer multiplyNumericStringsFunction1(String in,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = BiFunction.class)
+	public static Integer multiplyNumericStringsFunction2(String in1, String in2,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity3.class)
+	public static Integer multiplyNumericStringsFunction3(String in1, String in2, String in3,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity4.class)
+	public static Integer multiplyNumericStringsFunction4(String in1, String in2, String in3, String in4,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity5.class)
+	public static Integer multiplyNumericStringsFunction5(String in1, String in2, String in3, String in4, String in5,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity6.class)
+	public static Integer multiplyNumericStringsFunction6(String in1, String in2, String in3, String in4, String in5, String in6,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity7.class)
+	public static Integer multiplyNumericStringsFunction7(String in1, String in2, String in3, String in4, String in5, String in6, String in7,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity8.class)
+	public static Integer multiplyNumericStringsFunction8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity9.class)
+	public static Integer multiplyNumericStringsFunction9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity10.class)
+	public static Integer multiplyNumericStringsFunction10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity11.class)
+	public static Integer multiplyNumericStringsFunction11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity12.class)
+	public static Integer multiplyNumericStringsFunction12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+		out *= op.apply(in12);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity13.class)
+	public static Integer multiplyNumericStringsFunction13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+		out *= op.apply(in12);
+		out *= op.apply(in13);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity14.class)
+	public static Integer multiplyNumericStringsFunction14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+		out *= op.apply(in12);
+		out *= op.apply(in13);
+		out *= op.apply(in14);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity15.class)
+	public static Integer multiplyNumericStringsFunction15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+		out *= op.apply(in12);
+		out *= op.apply(in13);
+		out *= op.apply(in14);
+		out *= op.apply(in15);
+
+		return out;
+	}
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = Functions.Arity16.class)
+	public static Integer multiplyNumericStringsFunction16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16,
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+		out *= op.apply(in1);
+		out *= op.apply(in2);
+		out *= op.apply(in3);
+		out *= op.apply(in4);
+		out *= op.apply(in5);
+		out *= op.apply(in6);
+		out *= op.apply(in7);
+		out *= op.apply(in8);
+		out *= op.apply(in9);
+		out *= op.apply(in10);
+		out *= op.apply(in11);
+		out *= op.apply(in12);
+		out *= op.apply(in13);
+		out *= op.apply(in14);
+		out *= op.apply(in15);
+		out *= op.apply(in16);
+
+		return out;
+	}
+
+	// -- Dependent Computers -- //
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity1.class)
+	public static void doublesToListWithOp1(String in,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity2.class)
+	public static void doublesToListWithOp2(String in1, String in2,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity3.class)
+	public static void doublesToListWithOp3(String in1, String in2, String in3,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity4.class)
+	public static void doublesToListWithOp4(String in1, String in2, String in3, String in4,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity5.class)
+	public static void doublesToListWithOp5(String in1, String in2, String in3, String in4, String in5,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity6.class)
+	public static void doublesToListWithOp6(String in1, String in2, String in3, String in4, String in5, String in6,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity7.class)
+	public static void doublesToListWithOp7(String in1, String in2, String in3, String in4, String in5, String in6, String in7,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity8.class)
+	public static void doublesToListWithOp8(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity9.class)
+	public static void doublesToListWithOp9(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity10.class)
+	public static void doublesToListWithOp10(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity11.class)
+	public static void doublesToListWithOp11(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity12.class)
+	public static void doublesToListWithOp12(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+		op.mutate(output, in12);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity13.class)
+	public static void doublesToListWithOp13(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+		op.mutate(output, in12);
+		op.mutate(output, in13);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity14.class)
+	public static void doublesToListWithOp14(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+		op.mutate(output, in12);
+		op.mutate(output, in13);
+		op.mutate(output, in14);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity15.class)
+	public static void doublesToListWithOp15(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+		op.mutate(output, in12);
+		op.mutate(output, in13);
+		op.mutate(output, in14);
+		op.mutate(output, in15);
+	}
+
+	@OpMethod(names = "test.dependentDoubleList", type = Computers.Arity16.class)
+	public static void doublesToListWithOp16(String in1, String in2, String in3, String in4, String in5, String in6, String in7, String in8, String in9, String in10, String in11, String in12, String in13, String in14, String in15, String in16,
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+		op.mutate(output, in1);
+		op.mutate(output, in2);
+		op.mutate(output, in3);
+		op.mutate(output, in4);
+		op.mutate(output, in5);
+		op.mutate(output, in6);
+		op.mutate(output, in7);
+		op.mutate(output, in8);
+		op.mutate(output, in9);
+		op.mutate(output, in10);
+		op.mutate(output, in11);
+		op.mutate(output, in12);
+		op.mutate(output, in13);
+		op.mutate(output, in14);
+		op.mutate(output, in15);
+		op.mutate(output, in16);
+	}
+
+	// -- Dependent Inplaces -- //
+
+
+	@OpMethod(names = "test.dependentAddDoubles1", type = Inplaces.Arity1.class)
+	public static void dependentAddDoubles1(double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles2_1", type = Inplaces.Arity2_1.class)
+	public static void dependentAddDoubles2_1(double[] io, double[] in2, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles2_2", type = Inplaces.Arity2_2.class)
+	public static void dependentAddDoubles2_2(double[] in1, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles3_1", type = Inplaces.Arity3_1.class)
+	public static void dependentAddDoubles3_1(double[] io, double[] in2, double[] in3, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles3_2", type = Inplaces.Arity3_2.class)
+	public static void dependentAddDoubles3_2(double[] in1, double[] io, double[] in3, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles3_3", type = Inplaces.Arity3_3.class)
+	public static void dependentAddDoubles3_3(double[] in1, double[] in2, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles4_1", type = Inplaces.Arity4_1.class)
+	public static void dependentAddDoubles4_1(double[] io, double[] in2, double[] in3, double[] in4, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles4_2", type = Inplaces.Arity4_2.class)
+	public static void dependentAddDoubles4_2(double[] in1, double[] io, double[] in3, double[] in4, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles4_3", type = Inplaces.Arity4_3.class)
+	public static void dependentAddDoubles4_3(double[] in1, double[] in2, double[] io, double[] in4, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles4_4", type = Inplaces.Arity4_4.class)
+	public static void dependentAddDoubles4_4(double[] in1, double[] in2, double[] in3, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles5_1", type = Inplaces.Arity5_1.class)
+	public static void dependentAddDoubles5_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles5_2", type = Inplaces.Arity5_2.class)
+	public static void dependentAddDoubles5_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles5_3", type = Inplaces.Arity5_3.class)
+	public static void dependentAddDoubles5_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles5_4", type = Inplaces.Arity5_4.class)
+	public static void dependentAddDoubles5_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles5_5", type = Inplaces.Arity5_5.class)
+	public static void dependentAddDoubles5_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_1", type = Inplaces.Arity6_1.class)
+	public static void dependentAddDoubles6_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_2", type = Inplaces.Arity6_2.class)
+	public static void dependentAddDoubles6_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_3", type = Inplaces.Arity6_3.class)
+	public static void dependentAddDoubles6_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_4", type = Inplaces.Arity6_4.class)
+	public static void dependentAddDoubles6_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_5", type = Inplaces.Arity6_5.class)
+	public static void dependentAddDoubles6_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles6_6", type = Inplaces.Arity6_6.class)
+	public static void dependentAddDoubles6_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_1", type = Inplaces.Arity7_1.class)
+	public static void dependentAddDoubles7_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_2", type = Inplaces.Arity7_2.class)
+	public static void dependentAddDoubles7_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_3", type = Inplaces.Arity7_3.class)
+	public static void dependentAddDoubles7_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_4", type = Inplaces.Arity7_4.class)
+	public static void dependentAddDoubles7_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_5", type = Inplaces.Arity7_5.class)
+	public static void dependentAddDoubles7_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_6", type = Inplaces.Arity7_6.class)
+	public static void dependentAddDoubles7_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles7_7", type = Inplaces.Arity7_7.class)
+	public static void dependentAddDoubles7_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_1", type = Inplaces.Arity8_1.class)
+	public static void dependentAddDoubles8_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_2", type = Inplaces.Arity8_2.class)
+	public static void dependentAddDoubles8_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_3", type = Inplaces.Arity8_3.class)
+	public static void dependentAddDoubles8_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_4", type = Inplaces.Arity8_4.class)
+	public static void dependentAddDoubles8_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_5", type = Inplaces.Arity8_5.class)
+	public static void dependentAddDoubles8_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_6", type = Inplaces.Arity8_6.class)
+	public static void dependentAddDoubles8_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_7", type = Inplaces.Arity8_7.class)
+	public static void dependentAddDoubles8_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles8_8", type = Inplaces.Arity8_8.class)
+	public static void dependentAddDoubles8_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_1", type = Inplaces.Arity9_1.class)
+	public static void dependentAddDoubles9_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_2", type = Inplaces.Arity9_2.class)
+	public static void dependentAddDoubles9_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_3", type = Inplaces.Arity9_3.class)
+	public static void dependentAddDoubles9_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_4", type = Inplaces.Arity9_4.class)
+	public static void dependentAddDoubles9_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_5", type = Inplaces.Arity9_5.class)
+	public static void dependentAddDoubles9_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_6", type = Inplaces.Arity9_6.class)
+	public static void dependentAddDoubles9_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_7", type = Inplaces.Arity9_7.class)
+	public static void dependentAddDoubles9_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_8", type = Inplaces.Arity9_8.class)
+	public static void dependentAddDoubles9_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles9_9", type = Inplaces.Arity9_9.class)
+	public static void dependentAddDoubles9_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_1", type = Inplaces.Arity10_1.class)
+	public static void dependentAddDoubles10_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_2", type = Inplaces.Arity10_2.class)
+	public static void dependentAddDoubles10_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_3", type = Inplaces.Arity10_3.class)
+	public static void dependentAddDoubles10_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_4", type = Inplaces.Arity10_4.class)
+	public static void dependentAddDoubles10_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_5", type = Inplaces.Arity10_5.class)
+	public static void dependentAddDoubles10_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_6", type = Inplaces.Arity10_6.class)
+	public static void dependentAddDoubles10_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_7", type = Inplaces.Arity10_7.class)
+	public static void dependentAddDoubles10_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_8", type = Inplaces.Arity10_8.class)
+	public static void dependentAddDoubles10_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_9", type = Inplaces.Arity10_9.class)
+	public static void dependentAddDoubles10_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles10_10", type = Inplaces.Arity10_10.class)
+	public static void dependentAddDoubles10_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_1", type = Inplaces.Arity11_1.class)
+	public static void dependentAddDoubles11_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_2", type = Inplaces.Arity11_2.class)
+	public static void dependentAddDoubles11_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_3", type = Inplaces.Arity11_3.class)
+	public static void dependentAddDoubles11_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_4", type = Inplaces.Arity11_4.class)
+	public static void dependentAddDoubles11_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_5", type = Inplaces.Arity11_5.class)
+	public static void dependentAddDoubles11_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_6", type = Inplaces.Arity11_6.class)
+	public static void dependentAddDoubles11_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_7", type = Inplaces.Arity11_7.class)
+	public static void dependentAddDoubles11_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_8", type = Inplaces.Arity11_8.class)
+	public static void dependentAddDoubles11_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_9", type = Inplaces.Arity11_9.class)
+	public static void dependentAddDoubles11_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_10", type = Inplaces.Arity11_10.class)
+	public static void dependentAddDoubles11_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles11_11", type = Inplaces.Arity11_11.class)
+	public static void dependentAddDoubles11_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_1", type = Inplaces.Arity12_1.class)
+	public static void dependentAddDoubles12_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_2", type = Inplaces.Arity12_2.class)
+	public static void dependentAddDoubles12_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_3", type = Inplaces.Arity12_3.class)
+	public static void dependentAddDoubles12_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_4", type = Inplaces.Arity12_4.class)
+	public static void dependentAddDoubles12_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_5", type = Inplaces.Arity12_5.class)
+	public static void dependentAddDoubles12_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_6", type = Inplaces.Arity12_6.class)
+	public static void dependentAddDoubles12_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_7", type = Inplaces.Arity12_7.class)
+	public static void dependentAddDoubles12_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_8", type = Inplaces.Arity12_8.class)
+	public static void dependentAddDoubles12_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_9", type = Inplaces.Arity12_9.class)
+	public static void dependentAddDoubles12_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_10", type = Inplaces.Arity12_10.class)
+	public static void dependentAddDoubles12_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_11", type = Inplaces.Arity12_11.class)
+	public static void dependentAddDoubles12_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles12_12", type = Inplaces.Arity12_12.class)
+	public static void dependentAddDoubles12_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_1", type = Inplaces.Arity13_1.class)
+	public static void dependentAddDoubles13_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_2", type = Inplaces.Arity13_2.class)
+	public static void dependentAddDoubles13_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_3", type = Inplaces.Arity13_3.class)
+	public static void dependentAddDoubles13_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_4", type = Inplaces.Arity13_4.class)
+	public static void dependentAddDoubles13_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_5", type = Inplaces.Arity13_5.class)
+	public static void dependentAddDoubles13_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_6", type = Inplaces.Arity13_6.class)
+	public static void dependentAddDoubles13_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_7", type = Inplaces.Arity13_7.class)
+	public static void dependentAddDoubles13_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_8", type = Inplaces.Arity13_8.class)
+	public static void dependentAddDoubles13_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_9", type = Inplaces.Arity13_9.class)
+	public static void dependentAddDoubles13_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_10", type = Inplaces.Arity13_10.class)
+	public static void dependentAddDoubles13_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_11", type = Inplaces.Arity13_11.class)
+	public static void dependentAddDoubles13_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_12", type = Inplaces.Arity13_12.class)
+	public static void dependentAddDoubles13_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles13_13", type = Inplaces.Arity13_13.class)
+	public static void dependentAddDoubles13_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_1", type = Inplaces.Arity14_1.class)
+	public static void dependentAddDoubles14_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_2", type = Inplaces.Arity14_2.class)
+	public static void dependentAddDoubles14_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_3", type = Inplaces.Arity14_3.class)
+	public static void dependentAddDoubles14_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_4", type = Inplaces.Arity14_4.class)
+	public static void dependentAddDoubles14_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_5", type = Inplaces.Arity14_5.class)
+	public static void dependentAddDoubles14_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_6", type = Inplaces.Arity14_6.class)
+	public static void dependentAddDoubles14_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_7", type = Inplaces.Arity14_7.class)
+	public static void dependentAddDoubles14_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_8", type = Inplaces.Arity14_8.class)
+	public static void dependentAddDoubles14_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_9", type = Inplaces.Arity14_9.class)
+	public static void dependentAddDoubles14_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_10", type = Inplaces.Arity14_10.class)
+	public static void dependentAddDoubles14_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_11", type = Inplaces.Arity14_11.class)
+	public static void dependentAddDoubles14_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_12", type = Inplaces.Arity14_12.class)
+	public static void dependentAddDoubles14_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_13", type = Inplaces.Arity14_13.class)
+	public static void dependentAddDoubles14_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles14_14", type = Inplaces.Arity14_14.class)
+	public static void dependentAddDoubles14_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_1", type = Inplaces.Arity15_1.class)
+	public static void dependentAddDoubles15_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_2", type = Inplaces.Arity15_2.class)
+	public static void dependentAddDoubles15_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_3", type = Inplaces.Arity15_3.class)
+	public static void dependentAddDoubles15_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_4", type = Inplaces.Arity15_4.class)
+	public static void dependentAddDoubles15_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_5", type = Inplaces.Arity15_5.class)
+	public static void dependentAddDoubles15_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_6", type = Inplaces.Arity15_6.class)
+	public static void dependentAddDoubles15_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_7", type = Inplaces.Arity15_7.class)
+	public static void dependentAddDoubles15_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_8", type = Inplaces.Arity15_8.class)
+	public static void dependentAddDoubles15_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_9", type = Inplaces.Arity15_9.class)
+	public static void dependentAddDoubles15_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_10", type = Inplaces.Arity15_10.class)
+	public static void dependentAddDoubles15_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_11", type = Inplaces.Arity15_11.class)
+	public static void dependentAddDoubles15_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_12", type = Inplaces.Arity15_12.class)
+	public static void dependentAddDoubles15_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_13", type = Inplaces.Arity15_13.class)
+	public static void dependentAddDoubles15_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_14", type = Inplaces.Arity15_14.class)
+	public static void dependentAddDoubles15_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in15);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles15_15", type = Inplaces.Arity15_15.class)
+	public static void dependentAddDoubles15_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_1", type = Inplaces.Arity16_1.class)
+	public static void dependentAddDoubles16_1(double[] io, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_2", type = Inplaces.Arity16_2.class)
+	public static void dependentAddDoubles16_2(double[] in1, double[] io, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_3", type = Inplaces.Arity16_3.class)
+	public static void dependentAddDoubles16_3(double[] in1, double[] in2, double[] io, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_4", type = Inplaces.Arity16_4.class)
+	public static void dependentAddDoubles16_4(double[] in1, double[] in2, double[] in3, double[] io, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_5", type = Inplaces.Arity16_5.class)
+	public static void dependentAddDoubles16_5(double[] in1, double[] in2, double[] in3, double[] in4, double[] io, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_6", type = Inplaces.Arity16_6.class)
+	public static void dependentAddDoubles16_6(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] io, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_7", type = Inplaces.Arity16_7.class)
+	public static void dependentAddDoubles16_7(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] io, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_8", type = Inplaces.Arity16_8.class)
+	public static void dependentAddDoubles16_8(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] io, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_9", type = Inplaces.Arity16_9.class)
+	public static void dependentAddDoubles16_9(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] io, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_10", type = Inplaces.Arity16_10.class)
+	public static void dependentAddDoubles16_10(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] io, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_11", type = Inplaces.Arity16_11.class)
+	public static void dependentAddDoubles16_11(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] io, double[] in12, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_12", type = Inplaces.Arity16_12.class)
+	public static void dependentAddDoubles16_12(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] io, double[] in13, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_13", type = Inplaces.Arity16_13.class)
+	public static void dependentAddDoubles16_13(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] io, double[] in14, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_14", type = Inplaces.Arity16_14.class)
+	public static void dependentAddDoubles16_14(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] io, double[] in15, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in15);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_15", type = Inplaces.Arity16_15.class)
+	public static void dependentAddDoubles16_15(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] io, double[] in16, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in16);
+	}
+
+	@OpMethod(names = "test.dependentAddDoubles16_16", type = Inplaces.Arity16_16.class)
+	public static void dependentAddDoubles16_16(double[] in1, double[] in2, double[] in3, double[] in4, double[] in5, double[] in6, double[] in7, double[] in8, double[] in9, double[] in10, double[] in11, double[] in12, double[] in13, double[] in14, double[] in15, double[] io, @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+			op.mutate(io, in1);
+			op.mutate(io, in2);
+			op.mutate(io, in3);
+			op.mutate(io, in4);
+			op.mutate(io, in5);
+			op.mutate(io, in6);
+			op.mutate(io, in7);
+			op.mutate(io, in8);
+			op.mutate(io, in9);
+			op.mutate(io, in10);
+			op.mutate(io, in11);
+			op.mutate(io, in12);
+			op.mutate(io, in13);
+			op.mutate(io, in14);
+			op.mutate(io, in15);
 	}
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/InferTypeVariablesTest.java
@@ -34,7 +34,7 @@ public class InferTypeVariablesTest {
 
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
 			new HashMap<>();
-		MatchingUtils.inferTypeVariables(tArgs, destArgs, typeAssigns);
+		MatchingUtils.inferTypeVariablesWithTypeMappings(tArgs, destArgs, typeAssigns);
 
 		// We expect I=String, O=Double
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
@@ -61,7 +61,7 @@ public class InferTypeVariablesTest {
 
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
 			new HashMap<>();
-		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
+		MatchingUtils.inferTypeVariablesWithTypeMappings(types, inferFroms, typeAssigns);
 
 		// We expect T=Number
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
@@ -85,7 +85,7 @@ public class InferTypeVariablesTest {
 
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns2 =
 			new HashMap<>();
-		MatchingUtils.inferTypeVariables(types2, inferFroms2, typeAssigns2);
+		MatchingUtils.inferTypeVariablesWithTypeMappings(types2, inferFroms2, typeAssigns2);
 
 		// We expect T=Number
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected2 =
@@ -158,7 +158,7 @@ public class InferTypeVariablesTest {
 
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
 			new HashMap<>();
-		MatchingUtils.inferTypeVariables(types, inferFroms, typeAssigns);
+		MatchingUtils.inferTypeVariablesWithTypeMappings(types, inferFroms, typeAssigns);
 
 		// We expect T=Number
 		final Map<TypeVariable<?>, MatchingUtils.TypeMapping> expected =
@@ -222,7 +222,7 @@ public class InferTypeVariablesTest {
 
 		Map<TypeVariable<?>, MatchingUtils.TypeMapping> typeAssigns =
 			new HashMap<>();
-		MatchingUtils.inferTypeVariables(tArr, badInferFrom, typeAssigns);
+		MatchingUtils.inferTypeVariablesWithTypeMappings(tArr, badInferFrom, typeAssigns);
 
 		// We expect T=Number
 		TypeVariable<?> typeVarT = (TypeVariable<?>) t;

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.list
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.list
@@ -1,0 +1,103 @@
+.include templates/main/java/org/scijava/ops/function/Globals.list
+arities = (0..maxArity).collect()
+
+inputDoubles = ```
+{ arity ->
+  (0..(arity)).stream().map{a -> "Double"}.collect()
+}
+```
+genericDoubles = ```
+{ arity ->
+  '<' + String.join(', ', inputDoubles(arity)) + '>'
+}
+```
+args = ```
+{arity ->
+  arity == 0 ? '' :
+  arity == 1 ? 'input' :
+  String.join(', ',(1..arity).stream().map{a -> 'input' + a}.collect())
+}
+```
+inputArrays = ```
+{ arity ->
+  (0..(arity - 1)).stream().map{a -> "double[]"}.collect()
+}
+```
+arrayGenerics = ```
+{ arity ->
+  '<' + String.join(', ', inputArrays(arity)) + '>'
+}
+```
+computerArrayGenerics = ```
+{ arity ->
+  arrayGenerics(arity + 1)
+}
+```
+
+[OpMethodTest.java]
+computerInputs=```
+{ arity ->
+  arity == 0 ? '' :
+  String.join(', ', (1..arity).stream().map{a -> 'in'}.collect())
+}
+```
+typeVarNums = ```
+{ arity, io ->
+  (1..arity).subList(0, io - 1) + 'O' + (1..arity).subList(io, arity)
+}
+```
+inplaceArgs=```
+{ arity, io ->
+  String.join(', ', typeVarNums(arity, io).stream().map{a -> a == 'O' ? 'io' : 'in'}.collect())
+}
+```
+
+wildcardOutputDoubles = ```
+{ arity ->
+  '<' + String.join(', ', inputDoubles(arity-1)) + ', ?>'
+}
+```
+doubleClassString = ```
+{ arity ->
+  String.join(', ', inputDoubles(arity-1).stream().map{a -> a + '.class'}.collect())
+}
+```
+arrayClassString = ```
+{ arity ->
+  String.join(', ', inputArrays(arity).stream().map{a -> a + '.class'}.collect())
+}
+```
+functionInputName = ```
+{ arity, num ->
+  arity == 1 ? 'input' :
+  'input'+num
+}
+```
+inplaceExpectedArray = ```
+{ arity ->
+  '{ ' + String.join(', ', (1..3).stream().map{a -> "" + Math.pow(a, arity)}.collect()) + " }"
+}
+```
+computerExpectedArray = ```
+{ arity ->
+  '{ ' + String.join(', ', (1..3).stream().map{a -> "" + arity * a}.collect()) + " }"
+}
+```
+inplaceActualArg=```
+{ arity, i ->
+  arity == 1 ? "input" :
+  "input" + i
+}
+```
+inplaceMethod=```
+{ arity, i -> 
+  arity == 1 ? "inplace" :
+  "inplace" + i
+}
+```
+mutateMethod=```
+{ arity, i -> 
+  arity == 1 ? "mutate" :
+  "mutate" + i
+}
+```

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
@@ -1,0 +1,169 @@
+/*
+ * #%L
+ * SciJava Operations: a framework for reusable algorithms.
+ * %%
+ * Copyright (C) 2018 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Computers;
+import org.scijava.ops.function.Inplaces;
+import org.scijava.ops.function.Producer;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+import org.scijava.types.Nil;
+
+/**
+ * Tests the construction of {@link OpMethod}s.
+ * 
+ * @author Gabriel Selzer
+ * @author Marcel Wiedenmann
+ */
+@Plugin(type = OpCollection.class)
+public class OpMethodTest extends AbstractTestEnvironment {
+
+//	@Test
+//	public void testParseIntegerOp() {
+//		// Will match a lambda created and returned by createParseIntegerOp() below.
+//		final Function<String, Integer> parseIntegerOp = ops.op("test.parseInteger")
+//			.inType(String.class).outType(Integer.class).function();
+//
+//		final String numericString = "42";
+//		final Integer parsedInteger = parseIntegerOp.apply(numericString);
+//		assertEquals(Integer.parseInt(numericString), (int) parsedInteger);
+//	}
+//
+//	@Test
+//	public void testMultiplyNumericStringsOpMethod() {
+//		// Will match a lambda created and returned by
+//		// createMultiplyNumericStringsOp(..), which itself captured a lambda
+//		// created and returned by createParseIntegerOp().
+//		final BiFunction<String, String, Integer> multiplyNumericStringsOp = ops.op(
+//			"test.multiplyNumericStrings").inType(String.class, String.class).outType(
+//				Integer.class).function();
+//
+//		final String numericString1 = "3";
+//		final String numericString2 = "18";
+//		final Integer multipliedNumericStrings = multiplyNumericStringsOp.apply(
+//			numericString1, numericString2);
+//		assertEquals(Integer.parseInt(numericString1) * Integer.parseInt(
+//			numericString2), (int) multipliedNumericStrings);
+//	}
+//
+//	@OpMethod(names = "test.parseInteger", type = Function.class)
+//	// Refers to the input parameter of the function that's returned by this
+//	// factory method.
+//	@Parameter(key = "numericString")
+//	// Refers to the output parameter of the function.
+//	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
+//	public static Integer createParseIntegerOp(String in) {
+//		return Integer.parseInt(in);
+//	}
+//
+//	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
+//	@Parameter(key = "numericString1")
+//	@Parameter(key = "numericString2")
+//	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+//	public static Integer createMultiplyNumericStringsOp(final String in1,
+//		final String in2, @OpDependency(
+//			name = "test.parseInteger") Function<String, Integer> parseIntegerOp)
+//	{
+//		return parseIntegerOp.apply(in1) * parseIntegerOp.apply(in2);
+//	}
+	// -- Functions -- //
+
+	@Test
+	public void testOpMethodProducer() {
+		final Integer out = ops.op("test.multiplyNumericStrings").input()
+			.outType(Integer.class).create();
+		final Integer expected = Integer.valueOf(1);
+		assertEquals(expected, out);
+	}
+#foreach($arity in [1..$maxArity])
+
+	@Test
+	public void testOpMethodFunction$arity() {
+		final String in = "2";
+		final Integer out = ops.op("test.multiplyNumericStrings").input($computerInputs.call($arity))
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, $arity), out, 0);
+	}
+#end
+
+	// -- Computers -- //
+
+	public List<Double> expected(double expected, int size) {
+		List<Double> list = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			list.add(expected);
+		}
+		return list;
+	}
+#foreach($arity in [0..$maxArity])
+
+	@Test
+	public void testOpMethodComputer$arity() {
+		String in = "$arity";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.doubleList").input($computerInputs.call($arity))
+			.output(out).compute();
+		assertEquals(expected($arity, $arity), out);
+	}
+#end
+
+	// -- Inplaces -- //
+
+	private boolean outputExpected(double[] array, int multiplier) {
+		for (int i = 0; i < array.length; i++) {
+			if (array[i] != (i + 1) * multiplier) return false;
+		}
+		return true;
+	}
+#foreach($arity in [1..$maxArity])
+#foreach($a in [1..$arity])
+
+	@Test
+	public void testOpMethodInplace${inplaceSuffix.call($arity, $a)}() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.addDoubles${inplaceSuffix.call($arity, $a)}").input($inplaceArgs.call($arity, $a)).mutate#if($arity == 1)#{else}$a#end();
+		assertTrue(outputExpected(io, $arity));
+	}
+#end
+#end
+}

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
@@ -166,4 +166,43 @@ public class OpMethodTest extends AbstractTestEnvironment {
 	}
 #end
 #end
+
+	// -- Dependent Functions -- //
+#foreach($arity in [1..$maxArity])
+
+	@Test
+	public void testDependentMethodFunction$arity() {
+		final String in = "2";
+		final Integer out = ops.op("test.dependentMultiplyStrings").input($computerInputs.call($arity))
+			.outType(Integer.class).apply();
+		assertEquals(Math.pow(2, $arity), out, 0);
+	}
+#end
+
+	// -- Dependent Computers -- //
+#foreach($arity in [1..$maxArity])
+
+	@Test
+	public void testDependentMethodComputer$arity() {
+		String in = "$arity";
+		List<Double> out = new ArrayList<>();
+		ops.op("test.dependentDoubleList").input($computerInputs.call($arity))
+			.output(out).compute();
+		assertEquals(expected($arity, $arity), out);
+	}
+#end
+
+	// -- Dependent Inplaces -- //
+#foreach($arity in [1..$maxArity])
+#foreach($a in [1..$arity])
+
+	@Test
+	public void testDependentMethodInplace${inplaceSuffix.call($arity, $a)}() {
+		final double[] io = { 1., 2., 3. };
+		final double[] in = { 1., 2., 3. };
+		ops.op("test.dependentAddDoubles${inplaceSuffix.call($arity, $a)}").input($inplaceArgs.call($arity, $a)).mutate#if($arity == 1)#{else}$a#end();
+		assertTrue(outputExpected(io, $arity));
+	}
+#end
+#end
 }

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.list
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.list
@@ -1,0 +1,43 @@
+.include templates/main/java/org/scijava/ops/function/Globals.list
+
+argsList = ```
+{arity ->
+  arity == 0 ? [] :
+  arity == 1 ? ['input'] :
+  (1..arity).stream().map{a -> 'input' + a}.collect()
+}
+```
+
+[OpMethodTestOps.java]
+
+stringInputs = ```
+{ arity ->
+  String.join(", ", (1..arity).stream().map{a -> 'String in' + a}.collect())
+}
+```
+addDoublesOutput = ```
+{ arity ->
+  arity == 0 ? '0.' :
+  String.join(" + ", argsList(arity))
+}
+```
+typeVarNums = ```
+{ arity, io ->
+  (1..arity).subList(0, io - 1) + 'O' + (1..arity).subList(io, arity)
+}
+```
+inplaceArgs=```
+{ arity, io ->
+   typeVarNums(arity, io).stream().map{a -> a == 'O' ? 'io' : 'in'+a}.collect()
+}
+```
+inputOnlyInplaceArgs=```
+{ arity, io ->
+  typeVarNums(arity, io).stream().filter{a -> a != 'O'}.map{a -> 'in'+a}.collect()
+}
+```
+doubleInputs=```
+{ arity, io ->
+  String.join(', ', inplaceArgs(arity, io).stream().map{a -> 'double[] ' + a}.collect())
+}
+```

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.list
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.list
@@ -10,9 +10,16 @@ argsList = ```
 
 [OpMethodTestOps.java]
 
+opArgs = ```
+{ arity ->
+  names = genericsNamesList(arity)
+  names[0..names.size() - 2]
+}
+```
 stringInputs = ```
 { arity ->
-  String.join(", ", (1..arity).stream().map{a -> 'String in' + a}.collect())
+  names = genericsNamesList(arity)
+  String.join(", ", names[0..names.size() - 2].stream().map{a -> 'String ' + a}.collect())
 }
 ```
 addDoublesOutput = ```
@@ -39,5 +46,10 @@ inputOnlyInplaceArgs=```
 doubleInputs=```
 { arity, io ->
   String.join(', ', inplaceArgs(arity, io).stream().map{a -> 'double[] ' + a}.collect())
+}
+```
+inplaceArgsString =```
+{ arity, io ->
+  String.join(', ', inplaceArgs(arity, io))
 }
 ```

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
@@ -56,31 +56,21 @@ public class OpMethodTestOps {
 	@OpMethod(names = "test.multiplyNumericStrings", type = ${functionArity.call($arity)}.class)
 	public static Integer multiplyNumericStringsFunction$arity($stringInputs.call($arity))
 	{
-		Integer out = Integer.valueOf(1);
-		
-#foreach($a in [1..$arity])
-		out *= Integer.parseInt(in${a});
-#end
-
-		return out;
+		return multiplyNumericStringsFunction${arity}($applyArgs.call($arity), parseInt);
 	}
 #end
 
 	// -- Computers -- //
 	
 	@OpMethod(names = "test.doubleList", type = Computers.Arity0.class)
-	public static void doublesToListArity1(List<Double> output) {
+	public static void doublesToList0(List<Double> output) {
 		output.clear();
 	}
 #foreach($arity in [1..$maxArity])
 
 	@OpMethod(names = "test.doubleList", type = ${computerArity.call($arity)}.class)
 	public static void doublesToList$arity($stringInputs.call($arity)#if($arity > 0),#{else}#end List<Double> output) {
-		output.clear();
-		
-#foreach($a in [1..$arity])
-		output.add(Double.parseDouble(in$a));
-#end
+		doublesToListWithOp${arity}($applyArgs.call($arity), output, appendDouble);
 	}
 #end
 
@@ -91,11 +81,70 @@ public class OpMethodTestOps {
 
 	@OpMethod(names = "test.addDoubles$inplaceSuffix.call($arity, $a)", type = ${inplaceType.call($arity, $a)}.class)
 	public static void addDoubles$inplaceSuffix.call($arity, $a)($doubleInputs.call($arity, $a)) {
-		for (int i = 0; i < io.length; i++) {
-#foreach($input in $inputOnlyInplaceArgs.call($arity, $a))
-			io[i] += ${input}[i];
+		dependentAddDoubles$inplaceSuffix.call($arity, $a)($inplaceArgsString.call($arity, $a), addArrays);
+	}
 #end
-		}
+#end
+
+	// -- Helper Op -- //
+
+	@OpField(names = "test.parseInt")
+	public static final Function<String, Integer> parseInt = in -> Integer
+		.parseInt(in);
+
+	@OpField(names = "test.appendDouble")
+	public static final Inplaces.Arity2_1<List<Double>, String> appendDouble = (
+		list, element) -> list.add(Double.parseDouble(element));
+
+	@OpField(names = "test.addArrays")
+	public static final Inplaces.Arity2_1<double[], double[]> addArrays = (io,
+		in2) -> {
+		for (int i = 0; i < io.length; i++)
+			io[i] += in2[i];
+	};
+
+	// -- Dependent Functions -- //
+#foreach($arity in [1..$maxArity])
+
+	@OpMethod(names = "test.dependentMultiplyStrings", type = ${functionArity.call($arity)}.class)
+	public static Integer multiplyNumericStringsFunction$arity($stringInputs.call($arity),
+		@OpDependency(name = "test.parseInt") Function<String, Integer> op)
+	{
+		Integer out = Integer.valueOf(1);
+
+#foreach($a in $opArgs.call($arity))
+		out *= op.apply(${a});
+#end
+
+		return out;
+	}
+#end
+
+	// -- Dependent Computers -- //
+#foreach($arity in [1..$maxArity])
+
+	@OpMethod(names = "test.dependentDoubleList", type = ${computerArity.call($arity)}.class)
+	public static void doublesToListWithOp${arity}($stringInputs.call($arity),
+		List<Double> output,
+		@OpDependency(name = "test.appendDouble") Inplaces.Arity2_1<List<Double>, String> op)
+	{
+		output.clear();
+#foreach($a in $opArgs.call($arity))
+		op.mutate(output, $a);
+#end
+	}
+#end
+
+	// -- Dependent Inplaces -- //
+
+#foreach($arity in [1..$maxArity])
+#foreach($a in [1..$arity])
+
+	@OpMethod(names = "test.dependentAddDoubles$inplaceSuffix.call($arity, $a)", type = ${inplaceType.call($arity, $a)}.class)
+	public static void dependentAddDoubles$inplaceSuffix.call($arity, $a)($doubleInputs.call($arity, $a), @OpDependency(name = "test.addArrays") Inplaces.Arity2_1<double[], double[]> op) {
+#foreach($input in $inputOnlyInplaceArgs.call($arity, $a))
+			op.mutate(io, $input);
+#end
 	}
 #end
 #end

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * SciJava Operations: a framework for reusable algorithms.
+ * %%
+ * Copyright (C) 2016 - 2019 SciJava Ops developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ops;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.scijava.ops.core.OpCollection;
+import org.scijava.ops.function.Computers;
+import org.scijava.ops.function.Functions;
+import org.scijava.ops.function.Inplaces;
+import org.scijava.ops.function.Producer;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+@Plugin(type = OpCollection.class)
+public class OpMethodTestOps {
+
+	// -- Functions -- //
+	@OpMethod(names = "test.multiplyNumericStrings", type = Producer.class)
+	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+	public static Integer multiplyNumericStringsProducer() {
+		return Integer.valueOf(1);
+	}
+#foreach($arity in [1..$maxArity])
+
+	@OpMethod(names = "test.multiplyNumericStrings", type = ${functionArity.call($arity)}.class)
+	public static Integer multiplyNumericStringsFunction$arity($stringInputs.call($arity))
+	{
+		Integer out = Integer.valueOf(1);
+		
+#foreach($a in [1..$arity])
+		out *= Integer.parseInt(in${a});
+#end
+
+		return out;
+	}
+#end
+
+	// -- Computers -- //
+	
+	@OpMethod(names = "test.doubleList", type = Computers.Arity0.class)
+	public static void doublesToListArity1(List<Double> output) {
+		output.clear();
+	}
+#foreach($arity in [1..$maxArity])
+
+	@OpMethod(names = "test.doubleList", type = ${computerArity.call($arity)}.class)
+	public static void doublesToList$arity($stringInputs.call($arity)#if($arity > 0),#{else}#end List<Double> output) {
+		output.clear();
+		
+#foreach($a in [1..$arity])
+		output.add(Double.parseDouble(in$a));
+#end
+	}
+#end
+
+	// -- Inplaces -- //
+
+#foreach($arity in [1..$maxArity])
+#foreach($a in [1..$arity])
+
+	@OpMethod(names = "test.addDoubles$inplaceSuffix.call($arity, $a)", type = ${inplaceType.call($arity, $a)}.class)
+	public static void addDoubles$inplaceSuffix.call($arity, $a)($doubleInputs.call($arity, $a)) {
+		for (int i = 0; i < io.length; i++) {
+#foreach($input in $inputOnlyInplaceArgs.call($arity, $a))
+			io[i] += ${input}[i];
+#end
+		}
+	}
+#end
+#end
+}


### PR DESCRIPTION
This PR introduces support for writing ops as methods. Ops written as methods are discovered using the `@OpMethod` annotation, which declares both the `name` of the Op as well as the `type` of the Op (this allows for extensibility). Method ops allow the declaration of `OpDependencies`, which are included within the parameters accepted by the method. 

Method ops might look as follows:

```java
@OpMethod(names = "stats.mean", type = java.util.function.Function.class)
public Double meanOp(
  Iterable<Number> data, 
  @OpDependency(name = "stats.sum") Function<Iterable<Number>, Double> sumOp, 
  @OpDependency(name = "stats.size") Function<Iterable<Number>, Double> sizeOp) 
  {
    Double sum = sumOp.apply(data);
    Double size =  sizeOp.apply(data);
    return sum / size;
  }
```

This Op calculates the mean (hence the name `stats.mean`), and is a `Function<Iterable<Number>, Double>` (as declared by `type` and the set of parameters in the method). This Op also has two `OpDependencies`: one `Function<Iterable<Number>, Double> sumOp` and one `Function<Iterable<Number>, Double> sizeOp`. There are (should be :grin:) **no restrictions on the position of the `OpDependencies` within the method signature**.

The op would be called as follows:

```java
Iterable<Number> data = ...
Double mean = ops.op("stats.mean").input(data).outType(Double.class).apply();
```

Both `OpDependencies` will automagically be injected by the `OpService` using [Javassist](https://www.javassist.org/). **It is important to note that this PR does introduce a dependency on Javassist, which does not yet have a module**. When a method op has no `OpDependencies`, it will be constructed instead using [`LambdaMetaFactory`](https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/LambdaMetafactory.html); this method is faster than using Javassist since we do not have to incur the compilation process during runtime.

This PR also introduces a suite of tests, ensuring that method Ops can be written for all of our supported Op types (`Computer`, `Inplace`, `Function`) **both with and without `OpDependencies`**.

TODO:
* [x] Decide whether we should proceed without a declared module name for Javassist. It would be nice to have one, but is probably not necessary.

Closes scijava/scijava-ops#23.

Thanks to @MarcelWiedenmann for starting this work.