### PR TITLE
Improve OpMatchingException error messages

### DIFF
--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -68,6 +68,7 @@ import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers.Arity1;
 import org.scijava.ops.matcher.DefaultOpMatcher;
 import org.scijava.ops.matcher.MatchingResult;
+import org.scijava.ops.matcher.DependencyMatchingException;
 import org.scijava.ops.matcher.MatchingUtils;
 import org.scijava.ops.matcher.OpAdaptationInfo;
 import org.scijava.ops.matcher.OpCandidate;
@@ -501,11 +502,14 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 			final OpRef dependencyRef = inferOpRef(dependency, typeVarAssigns);
 			try {
 				resolvedDependencies.add(findOpInstance(dependencyRef, dependency.isAdaptable(), false));
-			} catch (final Exception e) {
-				throw new OpMatchingException("Could not find Op that matches requested Op dependency:" + "\nOp class: "
-						+ info.implementationName() + //
-						"\nDependency identifier: " + dependency.getKey() + //
-						"\n\n Attempted request:\n" + dependencyRef, e);
+			}
+			catch (final OpMatchingException e) {
+				String message = DependencyMatchingException.message(info
+					.implementationName(), dependency.getKey(), dependencyRef);
+				if (e instanceof DependencyMatchingException) {
+					throw new DependencyMatchingException(message, (DependencyMatchingException) e);
+				}
+				throw new DependencyMatchingException(message);
 			}
 		}
 		return resolvedDependencies;
@@ -532,6 +536,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 	 */
 	private OpCandidate adaptOp(OpRef ref) throws OpMatchingException {
 
+		List<DependencyMatchingException> depExceptions = new ArrayList<>();
 		for (final OpInfo adaptor : infos("adapt")) {
 			Type adaptTo = adaptor.output().getType();
 			Map<TypeVariable<?>, Type> map = new HashMap<>();
@@ -572,14 +577,24 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 				adaptedCandidate.setStatus(StatusCode.MATCH);
 				return adaptedCandidate;
 			}
+			catch (DependencyMatchingException d) {
+				depExceptions.add(d);
+			}
 			catch (OpMatchingException e1) {
 				log.trace(e1);
 			}
 		}
 
-		// no adaptors available.
-		throw new OpMatchingException(
-			"Op adaptation failed: no adaptable Ops of type " + ref.getName());
+		//no adaptors available.
+		if (depExceptions.size() == 0) {
+			throw new OpMatchingException(
+				"Op adaptation failed: no adaptable Ops of type " + ref.getName());
+		}
+		StringBuilder sb = new StringBuilder();
+		for (DependencyMatchingException d : depExceptions) {
+			sb.append("\n\n" + d.getMessage());
+		}
+		throw new DependencyMatchingException(sb.toString());
 	}
 
 	private boolean adaptOpOutputSatisfiesRefTypes(Type adaptTo, Map<TypeVariable<?>, Type> map, OpRef ref) {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -312,12 +312,16 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 					return findSimplifiedOp(ref);
 				}
 				catch (OpMatchingException e3) {
-					// no direct, adapted, or simplified matches
-					OpMatchingException matchingException = new OpMatchingException(
-						"No Op available for request: " + ref, e1);
-					matchingException.addSuppressed(e2);
-					matchingException.addSuppressed(e3);
-					throw matchingException;
+					// NB: It is important that the adaptation and simplification errors be
+					// suppressed here. If a failure occurs in Op matching, it
+					// is not the fault of our adaptation/simplification process but is
+					// instead due to the incongruity between the request and the set of
+					// available Ops. Thus the error stemming from the direct match
+					// attempt will provide the user with more information on how to fix
+					// their Op request.
+					e1.addSuppressed(e2);
+					e1.addSuppressed(e3);
+					throw e1;
 				}
 			}
 		}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DependencyMatchingException.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DependencyMatchingException.java
@@ -1,0 +1,46 @@
+
+package org.scijava.ops.matcher;
+
+/**
+ * An {@link OpMatchingException} caused by another {@code OpMatchingException}
+ * thrown when resolving dependencies. We illustrate the need for
+ * {@code DependencyMatchingException} with an example: Suppose Op {@code A} has
+ * an dependency on Op {@code B}, which in turn has a dependency on Op
+ * {@code C}. Suppose further that {@code A} and {@code B} are found, but no
+ * {@code C} is found to satisfy {@code B}. This will result in an
+ * {@link OpMatchingException} thrown for Op {@code A}. We would want to know:
+ * <ol>
+ * <li>that the request for {@code A} was not fulfilled
+ * <li>that no match could be found for {@code C}, which was the cause for (1)
+ * </ol>
+ * This logic can be generalized for an arbitrarily long Op chain.
+ *
+ * TODO: Consider supporting non-DependencyMatchingException {@code cause}s.
+ *
+ * @author Gabriel Selzer
+ */
+public class DependencyMatchingException extends OpMatchingException {
+
+	public DependencyMatchingException(final String message) {
+		super(message);
+	}
+
+	public static String message(String dependentOp, final String dependencyName, OpRef dependency) {
+		return "Could not instantiate dependency of: " + dependentOp + 
+				"\nDependency identifier: " + dependencyName + //
+				"\n\nAttempted request:\n" + dependency;
+	}
+
+	public DependencyMatchingException(final String message,
+		final DependencyMatchingException cause)
+	{
+		super(message, cause);
+	}
+
+	@Override
+	public String getMessage() {
+		if (getCause() == null) return super.getMessage();
+		return super.getMessage() + "\n\nCause:\n\n" +
+			getCause().getMessage();
+	}
+}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/DefaultMatchingErrorTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/DefaultMatchingErrorTest.java
@@ -1,3 +1,4 @@
+
 package org.scijava.ops.matcher;
 
 import java.util.function.Function;
@@ -16,13 +17,17 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = OpCollection.class)
 public class DefaultMatchingErrorTest extends AbstractTestEnvironment {
-	
+
 	@OpField(names = "test.duplicateOp")
 	public final Function<Double, Double> duplicateA = (in) -> in;
 
 	@OpField(names = "test.duplicateOp")
 	public final Function<Double, Double> duplicateB = (in) -> in;
-	
+
+	/**
+	 * Assert a relevant (i.e. informational) message is thrown when multiple Ops
+	 * conflict for a given OpRef.
+	 */
 	@Test
 	public void duplicateErrorRegressionTest() {
 		try {
@@ -37,7 +42,10 @@ public class DefaultMatchingErrorTest extends AbstractTestEnvironment {
 					"ops of priority 0.0:"));
 		}
 	}
-	
+
+	/**
+	 * Assert that a relevant error is thrown when a dependency is missing
+	 */
 	@Test
 	public void missingDependencyRegressionTest() {
 		try {
@@ -52,9 +60,10 @@ public class DefaultMatchingErrorTest extends AbstractTestEnvironment {
 			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
 		}
 	}
-	
+
 	/**
-	 * Assert the DependencyMatchingException contains both dependencies in the chain
+	 * Assert the DependencyMatchingException contains both dependencies in the
+	 * chain
 	 */
 	@Test
 	public void missingNestedDependencyRegressionTest() {
@@ -70,30 +79,35 @@ public class DefaultMatchingErrorTest extends AbstractTestEnvironment {
 			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
 		}
 	}
-	
+
+	/**
+	 * Assert that DependencyMatchingExceptions do not omit relevant information
+	 * when an adaptation is involved.
+	 */
 	@Test
 	public void missingDependencyViaAdaptationTest() {
 		Double[] d = new Double[0];
 		try {
 			ops.op("test.adaptMissingDep").input(d).outType(Double[].class).apply();
 			Assert.fail("Expected DependencyMatchingException");
-		} catch (IllegalArgumentException e) {
+		}
+		catch (IllegalArgumentException e) {
 			Throwable cause = e.getCause();
 			Assert.assertTrue(cause instanceof DependencyMatchingException);
 			String message = cause.getMessage();
 			Assert.assertTrue(message.contains("adapted"));
 			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
-			
+
 		}
 	}
-	
+
 }
 
 @Plugin(type = Op.class, name = "test.furtherOutsideOp")
 @Parameter(key = "in")
 @Parameter(key = "out", itemIO = ItemIO.OUTPUT)
 class FurtherDependentOp implements Function<Double, Double> {
-	
+
 	@OpDependency(name = "test.outsideOp")
 	private Function<Double, Double> op;
 
@@ -101,14 +115,14 @@ class FurtherDependentOp implements Function<Double, Double> {
 	public Double apply(Double t) {
 		return op.apply(t);
 	}
-	
+
 }
 
 @Plugin(type = Op.class, name = "test.outsideOp")
 @Parameter(key = "in")
 @Parameter(key = "out", itemIO = ItemIO.OUTPUT)
 class DependentOp implements Function<Double, Double> {
-	
+
 	@OpDependency(name = "test.missingDependencyOp")
 	private Function<Double, Double> op;
 
@@ -116,14 +130,14 @@ class DependentOp implements Function<Double, Double> {
 	public Double apply(Double t) {
 		return op.apply(t);
 	}
-	
+
 }
 
 @Plugin(type = Op.class, name = "test.missingDependencyOp")
 @Parameter(key = "in")
 @Parameter(key = "out", itemIO = ItemIO.OUTPUT)
 class MissingDependencyOp implements Function<Double, Double> {
-	
+
 	@OpDependency(name = "test.nonexistingOp")
 	private Function<Double, Double> op;
 
@@ -131,28 +145,27 @@ class MissingDependencyOp implements Function<Double, Double> {
 	public Double apply(Double t) {
 		return op.apply(t);
 	}
-	
+
 }
 
 @Plugin(type = Op.class, name = "test.adaptMissingDep")
 @Parameter(key = "in")
 @Parameter(key = "out", itemIO = ItemIO.OUTPUT)
 class MissingDependencyOpArr1 implements Computers.Arity1<Double[], Double[]> {
-	
+
 	@OpDependency(name = "test.nonexistingOp")
 	private Function<Double, Double> op;
 
 	@Override
-	public void compute(Double[] t, Double[] out) {
-	}
-	
+	public void compute(Double[] t, Double[] out) {}
+
 }
 
 @Plugin(type = Op.class, name = "test.adaptMissingDep")
 @Parameter(key = "in")
 @Parameter(key = "out", itemIO = ItemIO.OUTPUT)
 class MissingDependencyOpArr2 implements Function<Double, Double> {
-	
+
 	@OpDependency(name = "test.nonexistingOp")
 	private Function<Double, Double> op;
 
@@ -160,5 +173,5 @@ class MissingDependencyOpArr2 implements Function<Double, Double> {
 	public Double apply(Double t) {
 		return op.apply(t);
 	}
-	
+
 }

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/DefaultMatchingErrorTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/DefaultMatchingErrorTest.java
@@ -1,0 +1,164 @@
+package org.scijava.ops.matcher;
+
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.scijava.ops.function.Computers;
+import org.scijava.ops.AbstractTestEnvironment;
+import org.scijava.ops.OpDependency;
+import org.scijava.ops.OpField;
+import org.scijava.ops.core.Op;
+import org.scijava.ops.core.OpCollection;
+import org.scijava.param.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.struct.ItemIO;
+
+@Plugin(type = OpCollection.class)
+public class DefaultMatchingErrorTest extends AbstractTestEnvironment {
+	
+	@OpField(names = "test.duplicateOp")
+	public final Function<Double, Double> duplicateA = (in) -> in;
+
+	@OpField(names = "test.duplicateOp")
+	public final Function<Double, Double> duplicateB = (in) -> in;
+	
+	@Test
+	public void duplicateErrorRegressionTest() {
+		try {
+			ops.op("test.duplicateOp").inType(Double.class).outType(Double.class)
+				.function();
+			Assert.fail();
+		}
+		catch (IllegalArgumentException e) {
+			Assert.assertTrue(e.getMessage().startsWith(
+				"org.scijava.ops.matcher.OpMatchingException: " +
+					"Multiple 'test.duplicateOp/java.util.function.Function<java.lang.Double, java.lang.Double>' " +
+					"ops of priority 0.0:"));
+		}
+	}
+	
+	@Test
+	public void missingDependencyRegressionTest() {
+		try {
+			ops.op("test.missingDependencyOp").input(1.).outType(Double.class)
+				.apply();
+			Assert.fail("Expected DependencyMatchingException");
+		}
+		catch (IllegalArgumentException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause instanceof DependencyMatchingException);
+			String message = cause.getMessage();
+			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+		}
+	}
+	
+	/**
+	 * Assert the DependencyMatchingException contains both dependencies in the chain
+	 */
+	@Test
+	public void missingNestedDependencyRegressionTest() {
+		try {
+			ops.op("test.outsideOp").input(1.).outType(Double.class).apply();
+			Assert.fail("Expected DependencyMatchingException");
+		}
+		catch (IllegalArgumentException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause instanceof DependencyMatchingException);
+			String message = cause.getMessage();
+			Assert.assertTrue(message.contains("Name: \"test.missingDependencyOp\""));
+			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+		}
+	}
+	
+	@Test
+	public void missingDependencyViaAdaptationTest() {
+		Double[] d = new Double[0];
+		try {
+			ops.op("test.adaptMissingDep").input(d).outType(Double[].class).apply();
+			Assert.fail("Expected DependencyMatchingException");
+		} catch (IllegalArgumentException e) {
+			Throwable cause = e.getCause();
+			Assert.assertTrue(cause instanceof DependencyMatchingException);
+			String message = cause.getMessage();
+			Assert.assertTrue(message.contains("adapted"));
+			Assert.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+			
+		}
+	}
+	
+}
+
+@Plugin(type = Op.class, name = "test.furtherOutsideOp")
+@Parameter(key = "in")
+@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+class FurtherDependentOp implements Function<Double, Double> {
+	
+	@OpDependency(name = "test.outsideOp")
+	private Function<Double, Double> op;
+
+	@Override
+	public Double apply(Double t) {
+		return op.apply(t);
+	}
+	
+}
+
+@Plugin(type = Op.class, name = "test.outsideOp")
+@Parameter(key = "in")
+@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+class DependentOp implements Function<Double, Double> {
+	
+	@OpDependency(name = "test.missingDependencyOp")
+	private Function<Double, Double> op;
+
+	@Override
+	public Double apply(Double t) {
+		return op.apply(t);
+	}
+	
+}
+
+@Plugin(type = Op.class, name = "test.missingDependencyOp")
+@Parameter(key = "in")
+@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+class MissingDependencyOp implements Function<Double, Double> {
+	
+	@OpDependency(name = "test.nonexistingOp")
+	private Function<Double, Double> op;
+
+	@Override
+	public Double apply(Double t) {
+		return op.apply(t);
+	}
+	
+}
+
+@Plugin(type = Op.class, name = "test.adaptMissingDep")
+@Parameter(key = "in")
+@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+class MissingDependencyOpArr1 implements Computers.Arity1<Double[], Double[]> {
+	
+	@OpDependency(name = "test.nonexistingOp")
+	private Function<Double, Double> op;
+
+	@Override
+	public void compute(Double[] t, Double[] out) {
+	}
+	
+}
+
+@Plugin(type = Op.class, name = "test.adaptMissingDep")
+@Parameter(key = "in")
+@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+class MissingDependencyOpArr2 implements Function<Double, Double> {
+	
+	@OpDependency(name = "test.nonexistingOp")
+	private Function<Double, Double> op;
+
+	@Override
+	public Double apply(Double t) {
+		return op.apply(t);
+	}
+	
+}


### PR DESCRIPTION
This PR improves the error messages resulting from Op matching, making it easier to tune Op requests. Current improvements focus in two areas
* Identifying when two Ops conflict over a particular Op request. `OpMatchingException`s now describe all Ops that **fully** satisfy the request.
* Clearly identifying when an Op was not provided due to the unavailability of an `OpDependency`. A new class, `DependencyMatchingException`, was created to chain the errors resulting from a failing dependency. `DependencyMatchingException.getMessage()` will return a `String` *combining* its own message with the messages of `DependencyMatchingException`s that are (super)causes of the returned exception. This helps users recognize that the problem **does not lie with the requested Op, but instead lies with one of that Op's dependencies**. An example message, describing an Op `test.dependentOp` that depends on `test.missingDependencyOp`, which in turn depends on `test.nonexistingOp`, is included below:
```
Could not instantiate dependency of: org.scijava.ops.matcher.DependentOp
Dependency identifier: op

Attempted request:
Name: "test.missingDependencyOp", Types: [java.util.function.Function<java.lang.Double, java.lang.Double>]
Input Types: 
		* java.lang.Double
Output Type: 
		* java.lang.Double

Cause:

Could not instantiate dependency of: org.scijava.ops.matcher.MissingDependencyOp
Dependency identifier: op

Attempted request:
Name: "test.nonexistingOp", Types: [java.util.function.Function<java.lang.Double, java.lang.Double>]
Input Types: 
		* java.lang.Double
Output Type: 
		* java.lang.Double
```

TODO: 
* [x] It would also be nice to make standard `OpMatchingException`s more informational (such as describing the set of parameters that prevented an `OpRef` from matching a particular `OpInfo`. This might be difficult, however, as `DefaultMatchingService` does not really provide us with the flexibility to report this information. It would thus require significant change. This information could also become overwhelming (think, for example, of the overwhelming number of failures upon requesting some `Function<X , X> create`) to the point where it could cause more confusion than good.
