### PR TITLE
Introduce separate Container concept for computer outputs

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/icq/LiICQ.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/icq/LiICQ.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "image2")
 @Parameter(key = "mean1")
 @Parameter(key = "mean2")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class LiICQ<T extends RealType<T>, U extends RealType<U>, V extends RealType<V>>
 		implements Functions.Arity4<Iterable<T>, Iterable<U>, DoubleType, DoubleType, Double> {
 
@@ -122,7 +122,7 @@ public class LiICQ<T extends RealType<T>, U extends RealType<U>, V extends RealT
 @Plugin(type = Op.class, name = "coloc.icq")
 @Parameter(key = "image1")
 @Parameter(key = "image2")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class LiICQSimple<T extends RealType<T>, U extends RealType<U>, V extends RealType<V>>
 		implements BiFunction<Iterable<T>, Iterable<U>, Double> {
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/kendallTau/KendallTauBRank.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/kendallTau/KendallTauBRank.java
@@ -78,7 +78,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "coloc.kendallTau")
 @Parameter(key = "image1")
 @Parameter(key = "image2")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class KendallTauBRank<T extends RealType<T>, U extends RealType<U>>
 		/* extends Algorithm<T> */ implements BiFunction<Iterable<T>, Iterable<U>, Double> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/maxTKendallTau/MTKT.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/maxTKendallTau/MTKT.java
@@ -71,7 +71,7 @@ import org.scijava.util.IntArray;
 @Parameter(key = "image1")
 @Parameter(key = "image2")
 @Parameter(key = "seed")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class MTKT<T extends RealType<T>, U extends RealType<U>>
 	implements Functions.Arity3<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Long, Double> 
 {
@@ -250,7 +250,7 @@ public class MTKT<T extends RealType<T>, U extends RealType<U>>
 @Plugin(type = Op.class, name = "coloc.maxTKendallTau")
 @Parameter(key = "image1")
 @Parameter(key = "image2")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class MTKTSimple<T extends RealType<T>, U extends RealType<U>>
 	implements BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pValue/DefaultPValue.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pValue/DefaultPValue.java
@@ -70,7 +70,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "psfSize")
 @Parameter(key = "seed")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultPValue<T extends RealType<T>, U extends RealType<U>> implements
 		Computers.Arity7<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double>, Integer, Dimensions, Long, ExecutorService, PValueResult> {
 
@@ -197,7 +197,7 @@ public class DefaultPValue<T extends RealType<T>, U extends RealType<U>> impleme
 @Parameter(key = "op")
 @Parameter(key = "nrRandomizations")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class PValueSimpleWithRandomizations<T extends RealType<T>, U extends RealType<U>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double>, Integer, ExecutorService, PValueResult> {
 
@@ -219,7 +219,7 @@ class PValueSimpleWithRandomizations<T extends RealType<T>, U extends RealType<U
 @Parameter(key = "image2")
 @Parameter(key = "op")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class PValueSimple<T extends RealType<T>, U extends RealType<U>> implements
 		Computers.Arity4<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double>, ExecutorService, PValueResult> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pValue/DefaultPValue.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pValue/DefaultPValue.java
@@ -50,7 +50,6 @@ import net.imglib2.view.Views;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -207,7 +206,7 @@ class PValueSimpleWithRandomizations<T extends RealType<T>, U extends RealType<U
 	@Override
 	public void compute(RandomAccessibleInterval<T> in1, RandomAccessibleInterval<U> in2,
 			BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double> in3, Integer in4,
-			ExecutorService in5, @Mutable PValueResult out) {
+			ExecutorService in5, PValueResult out) {
 		Long defaultSeed = 0x27372034l;
 		pValueOp.compute(in1, in2, in3, in4, null, defaultSeed, in5, out);
 	}
@@ -229,7 +228,7 @@ class PValueSimple<T extends RealType<T>, U extends RealType<U>> implements
 	@Override
 	public void compute(RandomAccessibleInterval<T> in1, RandomAccessibleInterval<U> in2,
 			BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, Double> in3, ExecutorService in4,
-			@Mutable PValueResult out) {
+			PValueResult out) {
 		Integer defaultNumberRandomizations = 100;
 		pValueOp.compute(in1, in2, in3, defaultNumberRandomizations, in4, out);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pearsons/DefaultPearsons.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/coloc/pearsons/DefaultPearsons.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "coloc.pearsons")
 @Parameter(key = "image1")
 @Parameter(key = "image2")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultPearsons<T extends RealType<T>, U extends RealType<U>> implements
 	BiFunction<Iterable<T>, Iterable<U>, Double> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/clip/ClipRealTypes.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/clip/ClipRealTypes.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "convert.clip")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ClipRealTypes<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<I, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/copy/CopyRealTypes.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/copy/CopyRealTypes.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "convert.copy")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CopyRealTypes<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyArrayImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyArrayImg.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.img", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "copy", itemIO = ItemIO.BOTH)
+@Parameter(key = "copy")
 public class CopyArrayImg<T extends NativeType<T>, A extends ArrayDataAccess<A>>
 		implements Computers.Arity1<ArrayImg<T, A>, ArrayImg<T, A>> {
 	@Override
@@ -70,7 +70,7 @@ public class CopyArrayImg<T extends NativeType<T>, A extends ArrayDataAccess<A>>
 
 @Plugin(type = Op.class, name = "copy, copy.img", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "copy", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "copy")
 class CopyArrayImgFunction<T extends NativeType<T>, A extends ArrayDataAccess<A>>
 		implements Function<ArrayImg<T, A>, ArrayImg<T, A>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyII.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyII.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.iterableInterval", priority = 1.0)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CopyII<T> implements Computers.Arity1<IterableInterval<T>, IterableInterval<T>> {
 
 	// used internally
@@ -70,7 +70,7 @@ public class CopyII<T> implements Computers.Arity1<IterableInterval<T>, Iterable
 
 @Plugin(type = Op.class, name = "copy, copy.iterableInterval", priority = 1.0)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class CopyIIFunction<T> implements Function<IterableInterval<T>, IterableInterval<T>> {
 
 	@OpDependency(name = "create.img")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyImg.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.img")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CopyImg<T extends NativeType<T>> implements Computers.Arity1<Img<T>, Img<T>> {
 
 	@OpDependency(name = "copy.iterableInterval")
@@ -66,7 +66,7 @@ public class CopyImg<T extends NativeType<T>> implements Computers.Arity1<Img<T>
 
 @Plugin(type = Op.class, name = "copy, copy.img")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class CopyImgFunction<T extends NativeType<T>> implements Function<Img<T>, Img<T>> {
 
 	@OpDependency(name = "copy.img")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyImgLabeling.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyImgLabeling.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.imgLabeling")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CopyImgLabeling<T extends IntegerType<T> & NativeType<T>, L>
 		implements Computers.Arity1<ImgLabeling<L, T>, ImgLabeling<L, T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyLabelingMapping.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyLabelingMapping.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.labelingMapping", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CopyLabelingMapping<L> implements Computers.Arity1<LabelingMapping<L>, LabelingMapping<L>> {
 
 	@Override
@@ -64,7 +64,7 @@ public class CopyLabelingMapping<L> implements Computers.Arity1<LabelingMapping<
 
 //@Plugin(type = Op.class, name = "copy.labelingMapping", priority = Priority.VERY_HIGH)
 //@Parameter(key = "input")
-//@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+//@Parameter(key = "output")
 //class CopyLabelingMappingFunction<L> implements Function<LabelingMapping<L>, LabelingMapping<L>> {
 //
 //	@OpDependency(name = "copy.labelingMapping")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyRAI.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.rai", priority = 1.0)
 @Parameter(key = "input")
-@Parameter(key = "copy", itemIO = ItemIO.BOTH)
+@Parameter(key = "copy")
 public class CopyRAI<T> implements Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 
 	@OpDependency(name = "copy")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyType.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/CopyType.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "copy, copy.type")
 @Parameter(key = "input")
-@Parameter(key = "copy", itemIO = ItemIO.BOTH)
+@Parameter(key = "copy")
 public class CopyType<T extends Type<T>> implements Computers.Arity1<T, T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/NonCirculantFirstGuess.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/NonCirculantFirstGuess.java
@@ -64,7 +64,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "outType")
 @Parameter(key = "k")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class NonCirculantFirstGuess<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 	implements
 	Functions.Arity3<RandomAccessibleInterval<I>, O, Dimensions, RandomAccessibleInterval<O>>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/NonCirculantNormalizationFactor.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/NonCirculantNormalizationFactor.java
@@ -70,7 +70,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "deconvolve.normalizationFactor",
 	priority = Priority.LOW)
-@Parameter(key = "io", itemIO = ItemIO.BOTH)
+@Parameter(key = "io")
 @Parameter(key = "k")
 @Parameter(key = "l")
 @Parameter(key = "fftInput")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyC.java
@@ -81,7 +81,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "raiExtendedEstimate")
 @Parameter(key = "iterativePostProcessingOps")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class RichardsonLucyC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		implements Computers.Arity13<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>, //
 			RandomAccessibleInterval<C>, Boolean, Boolean, C, Integer, Inplaces.Arity1<RandomAccessibleInterval<O>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyCorrection.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyCorrection.java
@@ -67,7 +67,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "fftBuffer")
 @Parameter(key = "fftKernel")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class RichardsonLucyCorrection<I extends RealType<I>, O extends RealType<O>, C extends ComplexType<C>>
 	implements
 	Computers.Arity5<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, ExecutorService, RandomAccessibleInterval<O>>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyF.java
@@ -76,7 +76,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "nonCirculant", description = "indicates whether to use non-circulant edge handling")
 @Parameter(key = "accelerate", description = "indicates whether or not to use acceleration")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class RichardsonLucyF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 		implements
 		Functions.Arity11<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, long[], OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, OutOfBoundsFactory<K, RandomAccessibleInterval<K>>, O, C, Integer, Boolean, Boolean, ExecutorService, RandomAccessibleInterval<O>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyTVF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyTVF.java
@@ -86,7 +86,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "accelerate", description = "indicates whether or not to use acceleration")
 @Parameter(key = "regularizationFactor")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class RichardsonLucyTVF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 	implements Functions.Arity12<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, long[], OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, OutOfBoundsFactory<K, RandomAccessibleInterval<K>>, O, C, Integer, Boolean, Boolean, Float, ExecutorService, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyTVUpdate.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyTVUpdate.java
@@ -66,7 +66,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "regularizationFactor")
 @Parameter(key = "variation")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class RichardsonLucyTVUpdate<T extends RealType<T> & NativeType<T>, I extends RandomAccessibleInterval<T>>
 	implements Computers.Arity3<I, Float, RandomAccessibleInterval<T>, I> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyUpdate.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/RichardsonLucyUpdate.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "deconvolve.richardsonLucyUpdate",
 	priority = Priority.HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class RichardsonLucyUpdate<T extends RealType<T>> implements
 	Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/accelerate/VectorAccelerator.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/deconvolve/accelerate/VectorAccelerator.java
@@ -63,7 +63,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "deconvolve.accelerate",
 	priority = Priority.NORMAL)
-@Parameter(key = "io", itemIO = ItemIO.BOTH)
+@Parameter(key = "io")
 public class VectorAccelerator<T extends RealType<T> & NativeType<T>> implements
 	Inplaces.Arity1<RandomAccessibleInterval<T>> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/eval/DefaultEval.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/eval/DefaultEval.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "vars")
 @Parameter(key = "opService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultEval implements Functions.Arity3<String, Map<String, Object>, OpService, Object>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultASM.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultASM.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultASM<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterPromenence.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterPromenence.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultClusterPromenence<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocMeanX")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterShade.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultClusterShade.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultClusterShade<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocMeanX")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultContrast.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultContrast.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultContrast<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocPXMinusY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultCorrelation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultCorrelation.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultCorrelation<T extends RealType<T>> extends
 		AbstractHaralickFeature<T> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceEntropy.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultDifferenceEntropy<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	// Avoid log 0

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultDifferenceVariance.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultDifferenceVariance<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocPXMinusY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultEntropy.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultEntropy<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	// Avoid log 0

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM1.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM1.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultICM1<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocHXY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM2.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultICM2.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultICM2<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocHXY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultIFDM.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultIFDM.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultIFDM<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultMaxProbability.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultMaxProbability.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultMaxProbability<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumAverage.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumAverage.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultSumAverage<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocPXPlusY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumEntropy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumEntropy.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultSumEntropy<T extends RealType<T>> extends
 		AbstractHaralickFeature<T> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultSumVariance.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultSumVariance<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@OpDependency(name = "features.haralick.coocPXPlusY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultTextureHomogeneity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultTextureHomogeneity.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultTextureHomogeneity<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/DefaultVariance.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numGreyLevels")
 @Parameter(key = "distance")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultVariance<T extends RealType<T>> extends AbstractHaralickFeature<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocHXY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocHXY.java
@@ -46,7 +46,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocHXY")
 @Parameter(key = "matix")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocHXY implements Function<double[][], double[]> {
 
 	private static final double EPSILON = Double.MIN_NORMAL;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocMeanX.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocMeanX.java
@@ -46,7 +46,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocMeanX")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocMeanX implements Function<double[][], DoubleType> {
 
 	@OpDependency(name = "features.haralick.coocPX")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocMeanY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocMeanY.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocMeanY")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocMeanY implements Function<double[][], DoubleType> {
 
 	@OpDependency(name = "features.haralick.coocPY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPX.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPX.java
@@ -43,7 +43,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocPX")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocPX implements Function<double[][], double[]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPXMinusY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPXMinusY.java
@@ -43,7 +43,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocPXMinusY")
 @Parameter(key = "matrix")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocPXMinusY implements Function<double[][], double[]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPXPlusY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPXPlusY.java
@@ -43,7 +43,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocPXPlusY")
 @Parameter(key = "matrix")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocPXPlusY implements Function<double[][], double[]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocPY.java
@@ -43,7 +43,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocPY")
 @Parameter(key = "matrix")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocPY implements Function<double[][], double[]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocStdX.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocStdX.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocStdX")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocStdX implements Function<double[][], DoubleType> {
 
 	@OpDependency(name = "features.haralick.coocMeanX")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocStdY.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/haralick/helper/CoocStdY.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.haralick.coocStdY")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CoocStdY implements Function<double[][], DoubleType> {
 
 	@OpDependency(name = "features.haralick.coocMeanY")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/hog/HistogramOfOrientedGradients2D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/hog/HistogramOfOrientedGradients2D.java
@@ -84,7 +84,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "numOrientations")
 @Parameter(key = "spanOfNeighborhood")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class HistogramOfOrientedGradients2D<T extends RealType<T>> implements
 		Computers.Arity4<RandomAccessibleInterval<T>, Integer, Integer, ExecutorService, RandomAccessibleInterval<T>> {
 
@@ -278,7 +278,7 @@ public class HistogramOfOrientedGradients2D<T extends RealType<T>> implements
 @Parameter(key = "numOrientations")
 @Parameter(key = "spanOfNeighborhood")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class HistogramOfOrientedGradients2DFunction<T extends RealType<T>> implements
 		Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, ExecutorService, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/lbp2d/DefaultLBP2D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/lbp2d/DefaultLBP2D.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "distance")
 @Parameter(key = "histogramSize")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultLBP2D<I extends RealType<I>>
 		implements Functions.Arity3<RandomAccessibleInterval<I>, Integer, Integer, ArrayList<LongType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultCoarsenessFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultCoarsenessFeature.java
@@ -66,7 +66,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.tamura.coarseness")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCoarsenessFeature<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultContrastFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultContrastFeature.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "features.tamura.contrast")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultContrastFeature<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<IterableInterval<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultDirectionalityFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/tamura2d/DefaultDirectionalityFeature.java
@@ -62,7 +62,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "features.tamura.directionality")
 @Parameter(key = "input")
 @Parameter(key = "histogramSize")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultDirectionalityFeature<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity2<RandomAccessibleInterval<I>, Integer, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/DefaultMagnitudeFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/DefaultMagnitudeFeature.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "order")
 @Parameter(key = "repetition")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMagnitudeFeature<T extends RealType<T>>
 		implements Computers.Arity3<IterableInterval<T>, Integer, Integer, DoubleType> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/DefaultPhaseFeature.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/DefaultPhaseFeature.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "order")
 @Parameter(key = "repetition")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultPhaseFeature<T extends RealType<T>>
 		implements Computers.Arity3<IterableInterval<T>, Integer, Integer, DoubleType> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/helper/ZernikeComputer.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/features/zernike/helper/ZernikeComputer.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "order")
 @Parameter(key = "repetition")
-@Parameter(key = "zernikeMoment", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "zernikeMoment")
 public class ZernikeComputer<T extends RealType<T>>
 		implements Functions.Arity3<IterableInterval<T>, Integer, Integer, ZernikeMoment> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ApplyCenterAwareNeighborhoodBasedFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ApplyCenterAwareNeighborhoodBasedFilter.java
@@ -38,7 +38,6 @@ import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.view.Views;
 
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 
 public final class ApplyCenterAwareNeighborhoodBasedFilter<I, O> {
 
@@ -60,7 +59,7 @@ public final class ApplyCenterAwareNeighborhoodBasedFilter<I, O> {
 		final Shape inputNeighborhoodShape,
 		OutOfBoundsFactory<I, RandomAccessibleInterval<I>> outOfBoundsFactory,
 		final Computers.Arity2<Iterable<I>, I, O> filterOp,
-		@Mutable final RandomAccessibleInterval<O> output)
+		final RandomAccessibleInterval<O> output)
 	{
 		if (outOfBoundsFactory == null) outOfBoundsFactory =
 			defaultOutOfBoundsFactory();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/FFTMethodsLinearFFTFilterC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/FFTMethodsLinearFFTFilterC.java
@@ -65,7 +65,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "performKernelFFT")
 @Parameter(key = "executorService")
 @Parameter(key = "frequencyOp")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class FFTMethodsLinearFFTFilterC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		implements Computers.Arity8<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, Boolean, Boolean, ExecutorService, Computers.Arity2<RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>>, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/bilateral/DefaultBilateral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/bilateral/DefaultBilateral.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sigmaR", description = "range smoothing param, larger sigma means larger effect of intensity differences.")
 @Parameter(key = "sigmaS", description = "spatial smoothing param, larger sigma means smoother image.")
 @Parameter(key = "radius", description = "defines size of the square of pixels considered at each iteration.")
-@Parameter(key = "outputRAI", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputRAI")
 public class DefaultBilateral<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity4<RandomAccessibleInterval<I>, Double, Double, Integer, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveFFTC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveFFTC.java
@@ -63,7 +63,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "performInputFFT")
 @Parameter(key = "performKernelFFT")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ConvolveFFTC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		implements Computers.Arity7<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, Boolean, Boolean, ExecutorService, RandomAccessibleInterval<O>> {
 
@@ -90,7 +90,7 @@ public class ConvolveFFTC<I extends RealType<I>, O extends RealType<O>, K extend
 @Parameter(key = "fftInput")
 @Parameter(key = "fftKernel")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class ConvolveFFTCSimple<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		implements
 		Computers.Arity5<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, ExecutorService, RandomAccessibleInterval<O>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveFFTF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveFFTF.java
@@ -73,7 +73,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outType")
 @Parameter(key = "fftType")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class ConvolveFFTF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 		/* extends AbstractFFTFilterF<I, O, K, C> */ implements
 		Functions.Arity7<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, long[], OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, O, C, ExecutorService, RandomAccessibleInterval<O>> {
@@ -170,7 +170,7 @@ public class ConvolveFFTF<I extends RealType<I> & NativeType<I>, O extends RealT
 @Parameter(key = "input")
 @Parameter(key = "kernel")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class SimpleConvolveFFTF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 		implements
 		Functions.Arity3<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, ExecutorService, RandomAccessibleInterval<FloatType>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveNaiveC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveNaiveC.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.convolve")
 @Parameter(key = "input")
 @Parameter(key = "kernel")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ConvolveNaiveC<I extends RealType<I>, K extends RealType<K>, O extends RealType<O>>
 		implements Computers.Arity2<RandomAccessible<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> {
 	// TODO: should this be binary so we can use different kernels?? Not sure.. what

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveNaiveF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/convolve/ConvolveNaiveF.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "kernel")
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "outType")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
 		implements
 		Functions.Arity4<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, O, RandomAccessibleInterval<O>> {
@@ -133,7 +133,7 @@ public class ConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & Nativ
 @Plugin(type = Op.class, name = "filter.convolve", priority = Priority.HIGH + 1)
 @Parameter(key = "input")
 @Parameter(key = "kernel")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class SimpleConvolveNaiveF<I extends RealType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K>>
 		implements
 		BiFunction<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<O>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/correlate/CorrelateFFTC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/correlate/CorrelateFFTC.java
@@ -61,7 +61,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "performInputFFT")
 @Parameter(key = "performKernelFFT")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CorrelateFFTC<I extends RealType<I>, O extends RealType<O>, K extends RealType<K>, C extends ComplexType<C>>
 		implements Computers.Arity7<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, RandomAccessibleInterval<C>, RandomAccessibleInterval<C>, Boolean, Boolean, ExecutorService, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/correlate/CorrelateFFTF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/correlate/CorrelateFFTF.java
@@ -71,7 +71,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outType")
 @Parameter(key = "fftType")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CorrelateFFTF<I extends RealType<I> & NativeType<I>, O extends RealType<O> & NativeType<O>, K extends RealType<K> & NativeType<K>, C extends ComplexType<C> & NativeType<C>>
 //	extends AbstractFFTFilterF<I, O, K, C>
 implements Functions.Arity8<RandomAccessibleInterval<I>, RandomAccessibleInterval<K>, long[], OutOfBoundsFactory<I, RandomAccessibleInterval<I>>, OutOfBoundsFactory<K, RandomAccessibleInterval<K>>, O, C, ExecutorService, RandomAccessibleInterval<O>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivative/PartialDerivativeRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivative/PartialDerivativeRAI.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.partialDerivative")
 @Parameter(key = "input")
 @Parameter(key = "dimension")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class PartialDerivativeRAI<T extends RealType<T>>
 		implements Computers.Arity2<RandomAccessibleInterval<T>, Integer, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivative/PartialDerivativesRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivative/PartialDerivativesRAI.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "filter.partialDerivative")
 @Parameter(key = "input")
-@Parameter(key = "outputComposite", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputComposite")
 public class PartialDerivativesRAI<T extends RealType<T>>
 		implements Function<RandomAccessibleInterval<T>, CompositeIntervalView<T, RealComposite<T>>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGauss.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/derivativeGauss/DefaultDerivativeGauss.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "sigma", description = "the sigma in each dimension of the gaussian")
 @Parameter(key = "derivatives", description = "the value at each index indicates the derivative to take in each dimension of the image.")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultDerivativeGauss<T extends RealType<T>>
 		implements Computers.Arity3<RandomAccessibleInterval<T>, double[], int[], RandomAccessibleInterval<DoubleType>> {
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DefaultDoG.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DefaultDoG.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "gauss1")
 @Parameter(key = "gauss2")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultDoG<T extends NumericType<T> & NativeType<T>> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>, Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DoGVaryingSigmas.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DoGVaryingSigmas.java
@@ -60,7 +60,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sigmas2")
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DoGVaryingSigmas<T extends NumericType<T> & NativeType<T>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, double[], double[], OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, ExecutorService, RandomAccessibleInterval<T>> {
 
@@ -96,7 +96,7 @@ public class DoGVaryingSigmas<T extends NumericType<T> & NativeType<T>> implemen
 @Parameter(key = "sigma2")
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class DoGSingleSigma<T extends NumericType<T> & NativeType<T>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, ExecutorService, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DoGVaryingSigmas.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/dog/DoGVaryingSigmas.java
@@ -42,7 +42,6 @@ import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -107,7 +106,7 @@ class DoGSingleSigma<T extends NumericType<T> & NativeType<T>> implements
 	@Override
 	public void compute(RandomAccessibleInterval<T> in1, Double in2, Double in3,
 			OutOfBoundsFactory<T, RandomAccessibleInterval<T>> in4, ExecutorService in5,
-			@Mutable RandomAccessibleInterval<T> out) {
+			RandomAccessibleInterval<T> out) {
 		double[] sigmas1 = new double[in1.numDimensions()];
 		double[] sigmas2 = new double[in1.numDimensions()];
 		for (int i = 0; i < in1.numDimensions(); i++) {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/CreateOutputFFTMethods.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/CreateOutputFFTMethods.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "Dimensions")
 @Parameter(key = "outType")
 @Parameter(key = "fast")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class CreateOutputFFTMethods<T> implements Functions.Arity3<Dimensions, T, Boolean, Img<T>> {
 
 	@OpDependency(name = "create.img")
@@ -71,7 +71,7 @@ public class CreateOutputFFTMethods<T> implements Functions.Arity3<Dimensions, T
 @Plugin(type = Op.class, name = "filter.createFFTOutput")
 @Parameter(key = "Dimensions")
 @Parameter(key = "outType")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class CreateOutputFFTMethodsSimple<T> implements BiFunction<Dimensions, T, Img<T>> {
 	@OpDependency(name = "filter.createFFTOutput")
 	private Functions.Arity3<Dimensions, T, Boolean, Img<T>> create;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/FFTMethodsOpC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/FFTMethodsOpC.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.fft", priority = Priority.NORMAL)
 @Parameter(key = "input")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class FFTMethodsOpC<T extends RealType<T>, C extends ComplexType<C>>
 	implements Computers.Arity2<RandomAccessibleInterval<T>, ExecutorService, RandomAccessibleInterval<C>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/FFTMethodsOpF.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fft/FFTMethodsOpF.java
@@ -64,7 +64,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "fast", description = "whether to perform a fast FFT; default true")
 @Parameter(key = "fftType", description = "the complex type of the output")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class FFTMethodsOpF<T extends RealType<T>, C extends ComplexType<C>> implements
 		Functions.Arity5<RandomAccessibleInterval<T>, long[], Boolean, C, ExecutorService, RandomAccessibleInterval<C>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/ComputeFFTMethodsSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/ComputeFFTMethodsSize.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "dimensions")
 @Parameter(key = "forward")
 @Parameter(key = "fast")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class ComputeFFTMethodsSize implements Functions.Arity3<Dimensions, Boolean, Boolean, long[][]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/ComputeFFTSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/ComputeFFTSize.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "fftSize")
 @Parameter(key = "forward")
 @Parameter(key = "fast")
-@Parameter(key = "outputs", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputs")
 public class ComputeFFTSize implements Functions.Arity5<Dimensions, long[], long[], Boolean, Boolean, Pair<long[], long[]>> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/DefaultComputeFFTSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/fftSize/DefaultComputeFFTSize.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.fftSize")
 @Parameter(key = "dimensions")
 @Parameter(key = "powerOfTwo")
-@Parameter(key = "outputSizes", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputSizes")
 public class DefaultComputeFFTSize implements BiFunction<Dimensions, Boolean, long[][]> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/hessian/HessianRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/hessian/HessianRAI.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "filter.hessian")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class HessianRAI<T extends RealType<T>>
 		implements Function<RandomAccessibleInterval<T>, CompositeIntervalView<T, RealComposite<T>>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ifft/IFFTMethodsOpC.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ifft/IFFTMethodsOpC.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.ifft")
 @Parameter(key = "input")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class IFFTMethodsOpC<C extends ComplexType<C>, T extends RealType<T>>
 		implements Computers.Arity2<RandomAccessibleInterval<C>, ExecutorService, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ifft/IFFTMethodsOpI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/ifft/IFFTMethodsOpI.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  * @author Brian Northan
  */
 @Plugin(type = Op.class, name = "filter.ifft")
-@Parameter(key = "input", itemIO = ItemIO.BOTH)
+@Parameter(key = "input")
 @Parameter(key = "executorService")
 public class IFFTMethodsOpI<C extends ComplexType<C>>
 		implements Inplaces.Arity2_1<RandomAccessibleInterval<C>, ExecutorService> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/max/DefaultMaxFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/max/DefaultMaxFilter.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMaxFilter<T, V> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/mean/DefaultMeanFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/mean/DefaultMeanFilter.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMeanFilter<T, V> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/median/DefaultMedianFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/median/DefaultMedianFilter.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMedianFilter<T, V> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/min/DefaultMinFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/min/DefaultMinFilter.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMinFilter<T, V> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/DefaultPadInputFFT.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/DefaultPadInputFFT.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "paddedDimensions")
 @Parameter(key = "fast")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultPadInputFFT<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 		extends PadInputFFT<T, I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/DefaultPadShiftKernelFFT.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/DefaultPadShiftKernelFFT.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.padShiftFFTKernel", priority = Priority.HIGH)
 @Parameter(key = "input")
 @Parameter(key = "paddedDimensions")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultPadShiftKernelFFT<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 		extends PadShiftKernel<T, I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadInput.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadInput.java
@@ -60,7 +60,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "paddedDimensions")
 @Parameter(key = "outOfBoundsFactory", description = "The OutOfBoundsFactory used to extend the image")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PadInput<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 		implements Functions.Arity3<I, Dimensions, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadInputFFTMethods.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadInputFFTMethods.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "paddedDimensions")
 @Parameter(key = "fast")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PadInputFFTMethods<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 		extends PadInputFFT<T, I, O> {
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadShiftKernel.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadShiftKernel.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.padShiftKernel")
 @Parameter(key = "kernel")
 @Parameter(key = "paddedDimensions")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PadShiftKernel<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 	implements BiFunction<I, Dimensions, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadShiftKernelFFTMethods.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PadShiftKernelFFTMethods.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 	priority = Priority.HIGH)
 @Parameter(key = "input")
 @Parameter(key = "paddedDimensions")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PadShiftKernelFFTMethods<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends RandomAccessibleInterval<T>>
 	extends PadShiftKernel<T, I, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PaddingIntervalCentered.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PaddingIntervalCentered.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.padIntervalCentered", priority = Priority.HIGH)
 @Parameter(key = "input")
 @Parameter(key = "paddedDimensions")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PaddingIntervalCentered<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends Interval>
 		implements BiFunction<I, Dimensions, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PaddingIntervalOrigin.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/pad/PaddingIntervalOrigin.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "filter.padIntervalOrigin", priority = Priority.HIGH)
 @Parameter(key = "input")
 @Parameter(key = "interval")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class PaddingIntervalOrigin<T extends ComplexType<T>, I extends RandomAccessibleInterval<T>, O extends Interval>
 		implements BiFunction<I, Interval, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sigma/DefaultSigmaFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sigma/DefaultSigmaFilter.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "outOfBoundsFactory")
 @Parameter(key = "range")
 @Parameter(key = "minPixelFraction")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultSigmaFilter<T extends RealType<T>, V extends RealType<V>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, Double, Double, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sobel/SobelRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/sobel/SobelRAI.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "filter.sobel")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class SobelRAI<T extends RealType<T>>
 		implements Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> {
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/tubeness/DefaultTubeness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/tubeness/DefaultTubeness.java
@@ -103,7 +103,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "executorService")
 @Parameter(key = "sigma")
 @Parameter(key = "calibration")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultTubeness<T extends RealType<T>> implements
 		Computers.Arity4<RandomAccessibleInterval<T>, ExecutorService, Double, double[], IterableInterval<DoubleType>>,
 		Cancelable {
@@ -259,7 +259,7 @@ public class DefaultTubeness<T extends RealType<T>> implements
 @Parameter(key = "input")
 @Parameter(key = "executorService")
 @Parameter(key = "sigma")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class DefaultTubenessWithoutCalibration<T extends RealType<T>> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, ExecutorService, Double, IterableInterval<DoubleType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/tubeness/DefaultTubeness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/tubeness/DefaultTubeness.java
@@ -54,7 +54,6 @@ import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -268,7 +267,7 @@ class DefaultTubenessWithoutCalibration<T extends RealType<T>> implements
 
 	@Override
 	public void compute(RandomAccessibleInterval<T> in1, ExecutorService in2, Double in3,
-			@Mutable IterableInterval<DoubleType> out) {
+			IterableInterval<DoubleType> out) {
 		tubenessOp.compute(in1, in2, in3, new double[] {}, out);
 	}
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/variance/DefaultVarianceFilter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/variance/DefaultVarianceFilter.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "outOfBoundsFactory")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultVarianceFilter<T, V> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/vesselness/DefaultFrangi.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/vesselness/DefaultFrangi.java
@@ -62,7 +62,7 @@ import Jama.Matrix;
 @Parameter(key = "input")
 @Parameter(key = "spacing", description = "physicl distance between data points")
 @Parameter(key = "scale", description = "size of vessels to search for")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultFrangi<T extends RealType<T>, U extends RealType<U>>
 		implements Computers.Arity3<RandomAccessibleInterval<T>, double[], Integer, RandomAccessibleInterval<U>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidII.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidII.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.centroid", priority = 1)
 @Parameter(key = "input")
-@Parameter(key = "centroid", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "centroid")
 public class CentroidII implements Function<IterableInterval<?>, RealLocalizable> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidLabelRegion.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidLabelRegion.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.centroid", priority = 2)
 @Parameter(key = "input")
-@Parameter(key = "centroid", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "centroid")
 public class CentroidLabelRegion implements Function<LabelRegion<?>, RealLocalizable> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidMesh.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.centroid", label = "Geometric: Centroid")
 @Parameter(key = "input")
-@Parameter(key = "centroid", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "centroid")
 public class CentroidMesh implements Function<Mesh, RealLocalizable> {
 
 	@OpDependency(name = "geom.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/CentroidPolygon.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.centroid", label = "Geometric: Center of Gravity")
 @Parameter(key = "input")
-@Parameter(key = "centroid", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "centroid")
 public class CentroidPolygon implements Function<Polygon2D, RealLocalizable> {
 
 	@OpDependency(name = "geom.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/DefaultCenterOfGravity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/DefaultCenterOfGravity.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.centerOfGravity")
 @Parameter(key = "input")
-@Parameter(key = "centerOfGravity", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "centerOfGravity")
 public class DefaultCenterOfGravity<T extends RealType<T>> implements Function<IterableInterval<T>, RealLocalizable> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/SizeII.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/SizeII.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.size", label = "Geometric: Size", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "size", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "size")
 public class SizeII implements Function<IterableInterval<?>, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoundarySizeConvexHullPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoundarySizeConvexHullPolygon.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boundarySizeConvexHull", label = "Geometric (2D): Perimeter Convex Hull", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "boundarySizeConvexHull", itemIO = ItemIO.BOTH)
+@Parameter(key = "boundarySizeConvexHull")
 public class DefaultBoundarySizeConvexHullPolygon extends AbstractBoundarySizeConvexHull<Polygon2D> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoundingBox.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoundingBox.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boundingBox")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultBoundingBox implements Function<Polygon2D, Polygon2D> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoxivityPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultBoxivityPolygon.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boxivity", label = "Geometric (2D): Rectangularity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "boxivity", itemIO = ItemIO.BOTH)
+@Parameter(key = "boxivity")
 public class DefaultBoxivityPolygon extends AbstractBoxivity<Polygon2D> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultCircularity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultCircularity.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.circularity", label = "Geometric (2D): Circularity")
 @Parameter(key = "input")
-@Parameter(key = "circularity", itemIO = ItemIO.BOTH)
+@Parameter(key = "circularity")
 public class DefaultCircularity implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultContour.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultContour.java
@@ -62,7 +62,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "geom.contour")
 @Parameter(key = "input")
 @Parameter(key = "useJacobs", description = "Set this flag to use refined Jacobs stopping criteria")
-@Parameter(key = "contour", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "contour")
 public class DefaultContour<B extends BooleanType<B>>
 		implements BiFunction<RandomAccessibleInterval<B>, Boolean, Polygon2D> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultConvexHull2D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultConvexHull2D.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.convexHull")
 @Parameter(key = "input")
-@Parameter(key = "convexHull", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "convexHull")
 public class DefaultConvexHull2D implements Function<Polygon2D, Polygon2D> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultConvexityPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultConvexityPolygon.java
@@ -42,5 +42,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.convexity", label = "Geometric (2D): Convexity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "convexity", itemIO = ItemIO.BOTH)
+@Parameter(key = "convexity")
 public class DefaultConvexityPolygon extends AbstractConvexity<Polygon2D> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultEccentricity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultEccentricity.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.eccentricity", label = "Geometric (2D): Eccentricity")
 @Parameter(key = "input")
-@Parameter(key = "eccentricity", itemIO = ItemIO.BOTH)
+@Parameter(key = "eccentricity")
 public class DefaultEccentricity implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.minorAxis")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultElongation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultElongation.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.mainElongation", label = "Geometric (2D): Elongation")
 @Parameter(key = "input")
-@Parameter(key = "elongation", itemIO = ItemIO.BOTH)
+@Parameter(key = "elongation")
 public class DefaultElongation implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.smallestEnclosingBoundingBox")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsAngle.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsAngle.java
@@ -46,7 +46,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.feretsAngle", label = "Geometric (2D): Ferets Angle")
 @Parameter(key = "points")
-@Parameter(key = "feretsAngle", itemIO = ItemIO.BOTH)
+@Parameter(key = "feretsAngle")
 public class DefaultFeretsAngle implements Computers.Arity1<Pair<RealLocalizable, RealLocalizable>, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsDiameter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsDiameter.java
@@ -46,7 +46,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.feretsDiameter", label = "Geometric (2D): Ferets Diameter")
 @Parameter(key = "points")
-@Parameter(key = "feretsDiameter", itemIO = ItemIO.BOTH)
+@Parameter(key = "feretsDiameter")
 public class DefaultFeretsDiameter implements Computers.Arity1<Pair<RealLocalizable, RealLocalizable>, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsDiameterForAngle.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultFeretsDiameterForAngle.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "geom.feretsDiameter")
 @Parameter(key = "input")
 @Parameter(key = "angle")
-@Parameter(key = "feretsDiameter", itemIO = ItemIO.BOTH)
+@Parameter(key = "feretsDiameter")
 public class DefaultFeretsDiameterForAngle implements Computers.Arity2<Polygon2D, Double, DoubleType> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMajorAxis.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMajorAxis.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.majorAxis", label = "Geometric (2D): Major Axis")
 @Parameter(key = "input")
-@Parameter(key = "majorAxis", itemIO = ItemIO.BOTH)
+@Parameter(key = "majorAxis")
 public class DefaultMajorAxis implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.secondMoment")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeret.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeret.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.maximumFeret")
 @Parameter(key = "input")
-@Parameter(key = "maximumFeret", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "maximumFeret")
 public class DefaultMaximumFeret implements Function<Polygon2D, Pair<RealLocalizable, RealLocalizable>> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeretAngle.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeretAngle.java
@@ -44,7 +44,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "geom.maximumFeretsAngle")
 @Parameter(key = "input")
-@Parameter(key = "maxFeretsAngle", itemIO = ItemIO.BOTH)
+@Parameter(key = "maxFeretsAngle")
 public class DefaultMaximumFeretAngle implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.maximumFeret")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeretDiameter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMaximumFeretDiameter.java
@@ -44,7 +44,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "geom.maximumFeretsDiameter")
 @Parameter(key = "input")
-@Parameter(key = "maxFeretsDiameter", itemIO = ItemIO.BOTH)
+@Parameter(key = "maxFeretsDiameter")
 public class DefaultMaximumFeretDiameter implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.maximumFeret")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeret.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeret.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.minimumFeret")
 @Parameter(key = "input")
-@Parameter(key = "minFeret", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "minFeret")
 public class DefaultMinimumFeret implements Function<Polygon2D, Pair<RealLocalizable, RealLocalizable>> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeretAngle.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeretAngle.java
@@ -44,7 +44,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "geom.minimumFeretsAngle")
 @Parameter(key = "input")
-@Parameter(key = "minFeretAngle", itemIO = ItemIO.BOTH)
+@Parameter(key = "minFeretAngle")
 public class DefaultMinimumFeretAngle implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.minimumFeret")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeretDiameter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinimumFeretDiameter.java
@@ -44,7 +44,7 @@ import org.scijava.struct.ItemIO;
 
 @Plugin(type = Op.class, name = "geom.minimumFeretsDiameter")
 @Parameter(key = "input")
-@Parameter(key = "minFeretDiameter", itemIO = ItemIO.BOTH)
+@Parameter(key = "minFeretDiameter")
 public class DefaultMinimumFeretDiameter implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.minimumFeret")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinorAxis.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinorAxis.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.minorAxis", label = "Geometric (2D): Minor Axis")
 @Parameter(key = "input")
-@Parameter(key = "minorAxis", itemIO = ItemIO.BOTH)
+@Parameter(key = "minorAxis")
 public class DefaultMinorAxis implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.secondMoment")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinorMajorAxis.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultMinorMajorAxis.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.secondMoment")
 @Parameter(key = "input")
-@Parameter(key = "minorMajorAxisPair", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "minorMajorAxisPair")
 public class DefaultMinorMajorAxis implements Function<Polygon2D, Pair<DoubleType, DoubleType>> {
 
 	/**

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultPerimeterLength.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultPerimeterLength.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boundarySize", label = "Geometric (2D): Perimeter")
 @Parameter(key = "input")
-@Parameter(key = "boundarySize", itemIO = ItemIO.BOTH)
+@Parameter(key = "boundarySize")
 public class DefaultPerimeterLength implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultRoundness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultRoundness.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.roundness", label = "Geometric (2D): Roundness")
 @Parameter(key = "input")
-@Parameter(key = "roundness", itemIO = ItemIO.BOTH)
+@Parameter(key = "roundness")
 public class DefaultRoundness implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSizeConvexHullPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSizeConvexHullPolygon.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.sizeConvexHull", label = "Geometric (2D): Size ConvexHull", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "sizeConvexHull", itemIO = ItemIO.BOTH)
+@Parameter(key = "sizeConvexHull")
 public class DefaultSizeConvexHullPolygon extends AbstractSizeConvexHull<Polygon2D> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSizePolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSizePolygon.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.size", label = "Geometric (2D): Size", priority = Priority.VERY_HIGH - 1)
 @Parameter(key = "input")
-@Parameter(key = "size", itemIO = ItemIO.BOTH)
+@Parameter(key = "size")
 public class DefaultSizePolygon implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSmallestEnclosingRectangle.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSmallestEnclosingRectangle.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.smallestEnclosingBoundingBox", label = "Geometric (2D): Smallest Enclosing Rectangle")
 @Parameter(key = "input")
-@Parameter(key = "smallestEnclosingBoundingBox", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "smallestEnclosingBoundingBox")
 public class DefaultSmallestEnclosingRectangle implements Function<Polygon2D, Polygon2D> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSolidityPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultSolidityPolygon.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.solidity", label = "Geometric (2D): Solidity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "solidity", itemIO = ItemIO.BOTH)
+@Parameter(key = "solidity")
 public class DefaultSolidityPolygon extends AbstractSolidity<Polygon2D> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultVerticesCountConvexHullPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultVerticesCountConvexHullPolygon.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.verticesCountConvexHull", label = "Geometric (2D): Convex Hull Vertices Count", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "verticesCountConvexHull", itemIO = ItemIO.BOTH)
+@Parameter(key = "verticesCountConvexHull")
 public class DefaultVerticesCountConvexHullPolygon implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultVerticesCountPolygon.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom2d/DefaultVerticesCountPolygon.java
@@ -44,7 +44,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.verticesCount", label = "Geometric (2D): Convex Hull Vertices Count", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "verticesCount", itemIO = ItemIO.BOTH)
+@Parameter(key = "verticesCount")
 public class DefaultVerticesCountPolygon implements Computers.Arity1<Polygon2D, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultBoxivityMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultBoxivityMesh.java
@@ -44,6 +44,6 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "geom.boxivity",
 	label = "Geometric (3D): Boxivity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "boxivity", itemIO = ItemIO.BOTH)
+@Parameter(key = "boxivity")
 public class DefaultBoxivityMesh extends AbstractBoxivity<Mesh> {
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultCompactness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultCompactness.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.compactness", label = "Geometric (3D): Compactness", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "compactness", itemIO = ItemIO.BOTH)
+@Parameter(key = "compactness")
 public class DefaultCompactness implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.boundarySize")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultConvexHull3D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultConvexHull3D.java
@@ -63,7 +63,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.convexHull")
 @Parameter(key = "input")
-@Parameter(key = "convexHull", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "convexHull")
 public class DefaultConvexHull3D implements Function<Mesh, Mesh>
 {
 
@@ -613,7 +613,7 @@ public class DefaultConvexHull3D implements Function<Mesh, Mesh>
 
 @Plugin(type = Op.class, name = "geom.convexHullEpsilon")
 @Parameter(key = "input")
-@Parameter(key = "epsilon", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "epsilon")
 class DefaultConvexHull3DEpsilon implements Function<Mesh, Double>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultConvexityMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultConvexityMesh.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.convexity", label = "Geometric (3D): Convexity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "convexity", itemIO = ItemIO.BOTH)
+@Parameter(key = "convexity")
 public class DefaultConvexityMesh extends AbstractConvexity<Mesh> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultInertiaTensor3D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultInertiaTensor3D.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.secondMoment")
 @Parameter(key = "iterableRegion")
-@Parameter(key = "inertiaTensor", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "inertiaTensor")
 public class DefaultInertiaTensor3D<B extends BooleanType<B>> implements Function<IterableRegion<B>, RealMatrix> {
 
 	@OpDependency(name = "geom.centroid")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultInertiaTensor3DMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultInertiaTensor3DMesh.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.secondMoment")
 @Parameter(key = "input")
-@Parameter(key = "inertiaTensor", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "inertiaTensor")
 public class DefaultInertiaTensor3DMesh implements Function<Mesh, RealMatrix> {
 
 	@OpDependency(name = "geom.centroid")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMainElongation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMainElongation.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.mainElongation", label = "Geometric (3D): Main Elongation", priority = Priority.VERY_HIGH)
 @Parameter(key = "inputMesh")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMainElongation implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.secondMoment")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMarchingCubes.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMarchingCubes.java
@@ -64,7 +64,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "isolevel")
 @Parameter(key = "interpolatorClass")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class DefaultMarchingCubes<T extends BooleanType<T>>
 		implements Functions.Arity3<RandomAccessibleInterval<T>, Double, VertexInterpolator, Mesh> {
 
@@ -558,7 +558,7 @@ public class DefaultMarchingCubes<T extends BooleanType<T>>
 
 @Plugin(type = Op.class, name = "geom.marchingCubes")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class SimpleMarchingCubes<T extends BooleanType<T>>
 		implements Function<RandomAccessibleInterval<T>, Mesh> {
 	

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMedianElongation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultMedianElongation.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.medianElongation", label = "Geometric (3D): Median Elongation", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "medianElongation", itemIO = ItemIO.BOTH)
+@Parameter(key = "medianElongation")
 public class DefaultMedianElongation implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.secondMoment")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSolidityMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSolidityMesh.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.solidity", label = "Geometric (3D): Solidity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "solidity", itemIO = ItemIO.BOTH)
+@Parameter(key = "solidity")
 public class DefaultSolidityMesh extends AbstractSolidity<Mesh> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSparenessMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSparenessMesh.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.spareness", label = "Geometric (3D): Spareness", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "spareness", itemIO = ItemIO.BOTH)
+@Parameter(key = "spareness")
 public class DefaultSparenessMesh implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.secondMoment")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSphericity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSphericity.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.sphericity", label = "Geometric (3D): Sphericity", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "sphericity", itemIO = ItemIO.BOTH)
+@Parameter(key = "sphericity")
 public class DefaultSphericity implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSurfaceArea.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSurfaceArea.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boundarySize", label = "Geometric (3D): Surface Area", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "boundarySize", itemIO = ItemIO.BOTH)
+@Parameter(key = "boundarySize")
 public class DefaultSurfaceArea implements Computers.Arity1<Mesh, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSurfaceAreaConvexHullMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultSurfaceAreaConvexHullMesh.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.boundarySizeConvexHull", label = "Geometric (3D): Surface Area Convex Hull", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "boundarySizeConvexHull", itemIO = ItemIO.BOTH)
+@Parameter(key = "boundarySizeConvexHull")
 public class DefaultSurfaceAreaConvexHullMesh extends AbstractBoundarySizeConvexHull<Mesh> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVerticesCountConvexHullMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVerticesCountConvexHullMesh.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.verticesCountConvexHull", label = "Geometric (3D): Convex Hull Vertices Count", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "verticesCountConvexHull", itemIO = ItemIO.BOTH)
+@Parameter(key = "verticesCountConvexHull")
 public class DefaultVerticesCountConvexHullMesh implements Computers.Arity1<Mesh, DoubleType> {
 
 	@OpDependency(name = "geom.convexHull")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVerticesCountMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVerticesCountMesh.java
@@ -46,7 +46,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.verticesCount", label = "Geometric3D: Surface Vertices Count", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "verticesCountMesh", itemIO = ItemIO.BOTH)
+@Parameter(key = "verticesCountMesh")
 public class DefaultVerticesCountMesh implements Computers.Arity1<Mesh, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVolumeConvexHullMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVolumeConvexHullMesh.java
@@ -43,5 +43,5 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.sizeConvexHull", label = "Geometric (3D): Convex Hull Volume", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "volumeConvexHullMesh", itemIO = ItemIO.BOTH)
+@Parameter(key = "volumeConvexHullMesh")
 public class DefaultVolumeConvexHullMesh extends AbstractSizeConvexHull<Mesh> {}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVolumeMesh.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVolumeMesh.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "geom.size", label = "Geometric3D: Volume", priority = Priority.VERY_HIGH - 1)
 @Parameter(key = "input")
-@Parameter(key = "volume", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "volume")
 public class DefaultVolumeMesh implements Function<Mesh, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVoxelization3D.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/geom/geom3d/DefaultVoxelization3D.java
@@ -67,7 +67,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "width", required = false)
 @Parameter(key = "height", required = false)
 @Parameter(key = "depth", required = false)
-@Parameter(key = "voxelizedImage", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "voxelizedImage")
 public class DefaultVoxelization3D
 		implements Functions.Arity4<Mesh, Integer, Integer, Integer, RandomAccessibleInterval<BitType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/help/HelpForName.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
 	description = "Gets documentation for all Ops with the given name")
 @Parameter(key = "name")
 @Parameter(key = "opService")
-@Parameter(key = "opInfo", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "opInfo")
 public class HelpForName extends AbstractHelp implements BiFunction<String, OpService, String> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/identity/DefaultIdentity.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/identity/DefaultIdentity.java
@@ -41,7 +41,7 @@ import org.scijava.struct.ItemIO;
  * @author Curtis Rueden
  */
 @Plugin(type = Op.class, name = "identity")
-@Parameter(key = "io", itemIO = ItemIO.BOTH)
+@Parameter(key = "io")
 public class DefaultIdentity<A> implements Inplaces.Arity1<A>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/ascii/DefaultASCII.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/ascii/DefaultASCII.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "iterableInput")
 @Parameter(key = "min")
 @Parameter(key = "max")
-@Parameter(key = "ASCIIArt", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "ASCIIArt")
 public class DefaultASCII<T extends RealType<T>> implements Functions.Arity3<IterableInterval<T>, T, T, String>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/cooccurrenceMatrix/CooccurrenceMatrix.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/cooccurrenceMatrix/CooccurrenceMatrix.java
@@ -26,7 +26,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "nrGreyLevels", min = "0", max = "128", stepSize = "1", initializer = "32")
 @Parameter(key = "distance", min = "0", max = "128", stepSize = "1", initializer = "1")
 @Parameter(key = "matrixOrientation")
-@Parameter(key = "cooccurrenceMatrix", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "cooccurrenceMatrix")
 public class CooccurrenceMatrix<T extends RealType<T>>
 		implements Functions.Arity4<RandomAccessibleInterval<T>, Integer, Integer, MatrixOrientation, double[][]> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/CalibratedDistanceTransformer.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/CalibratedDistanceTransformer.java
@@ -58,7 +58,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "binaryInput")
 @Parameter(key = "calibration")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class CalibratedDistanceTransformer<B extends BooleanType<B>, T extends RealType<T>>
 		implements Computers.Arity3<RandomAccessibleInterval<B>, double[], ExecutorService, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/DefaultDistanceTransformCalibration.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/DefaultDistanceTransformCalibration.java
@@ -312,7 +312,7 @@ class NextPhaseCal<T extends RealType<T>> implements Callable<Void> {
 @Parameter(key = "binaryInput")
 @Parameter(key = "calibration")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class DefaultDistanceTransformCalibrationOp <B extends BooleanType<B>, T extends RealType<T>>implements Computers.Arity3<RandomAccessibleInterval<B>, double[], ExecutorService, RandomAccessibleInterval<T>>{
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/DistanceTransformer.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/distancetransform/DistanceTransformer.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "image.distanceTransform")
 @Parameter(key = "binaryInput")
 @Parameter(key = "executorService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DistanceTransformer<B extends BooleanType<B>, T extends RealType<T>>
 		implements Computers.Arity2<RandomAccessibleInterval<B>, ExecutorService, RandomAccessibleInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/equation/DefaultCoordinatesEquation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/equation/DefaultCoordinatesEquation.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.equation")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCoordinatesEquation<T extends RealType<T>, N extends Number>
 		implements Computers.Arity1<Function<long[], N>, IterableInterval<T>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/equation/DefaultEquation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/equation/DefaultEquation.java
@@ -66,7 +66,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "image.equation")
 @Parameter(key = "input")
 @Parameter(key = "scriptService")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultEquation<T extends RealType<T>> implements
 	Computers.Arity2<String, ScriptService, IterableInterval<T>> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/DefaultFill.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/DefaultFill.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.fill")
 @Parameter(key = "constant")
-@Parameter(key = "iterableOutput", itemIO = ItemIO.BOTH)
+@Parameter(key = "iterableOutput")
 public class DefaultFill<T extends Type<T>> implements
 	Computers.Arity1<T, Iterable<T>> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/FillRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/fill/FillRAI.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.fill", priority = Priority.HIGH)
 @Parameter(key = "constant")
-@Parameter(key = "iterableOutput", itemIO = ItemIO.BOTH)
+@Parameter(key = "iterableOutput")
 public class FillRAI<T extends Type<T>> implements
 	Computers.Arity1<T, RandomAccessibleInterval<T>> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/histogram/HistogramCreate.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/histogram/HistogramCreate.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "image.histogram")
 @Parameter(key = "iterable")
 @Parameter(key = "numBins", required = false)
-@Parameter(key = "histogram", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "histogram")
 public class HistogramCreate<T extends RealType<T>> implements BiFunction<Iterable<T>, Integer, Histogram1d<T>> {
 
 	public static final int DEFAULT_NUM_BINS = 256;
@@ -77,7 +77,7 @@ public class HistogramCreate<T extends RealType<T>> implements BiFunction<Iterab
 
 @Plugin(type = Op.class, name = "image.histogram")
 @Parameter(key = "iterable")
-@Parameter(key = "histogram", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "histogram")
 class HistogramCreateSimple<T extends RealType<T>> implements Function<Iterable<T>, Histogram1d<T>> {
 
 	@OpDependency(name = "image.histogram")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/DefaultIntegralImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/DefaultIntegralImg.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.integral", priority = Priority.LOW + 1)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultIntegralImg<I extends RealType<I>, O extends RealType<O>> extends AbstractIntegralImg<I, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/SquareIntegralImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/SquareIntegralImg.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.squareIntegral", priority = Priority.LOW + 1)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class SquareIntegralImg<I extends RealType<I>, O extends RealType<O>> extends AbstractIntegralImg<I, O>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/WrappedIntegralImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/integral/WrappedIntegralImg.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.integral", priority = Priority.LOW)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class WrappedIntegralImg<I extends RealType<I>>
 	implements Function<RandomAccessibleInterval<I>, RandomAccessibleInterval<DoubleType>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/InvertII.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/InvertII.java
@@ -53,7 +53,7 @@
 //@Parameter(key = "input")
 //@Parameter(key = "min")
 //@Parameter(key = "max")
-//@Parameter(key = "invertedOutput", itemIO = ItemIO.BOTH)
+//@Parameter(key = "invertedOutput")
 //public class InvertII<T extends RealType<T>> implements
 //	Computers.Arity3<IterableInterval<T>, T, T, IterableInterval<T>> 
 //{

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/InvertIIInteger.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/InvertIIInteger.java
@@ -55,7 +55,7 @@
 //@Parameter(key = "input")
 //@Parameter(key = "min")
 //@Parameter(key = "max")
-//@Parameter(key = "invertedOutput", itemIO = ItemIO.BOTH)
+//@Parameter(key = "invertedOutput")
 //public class InvertIIInteger<T extends IntegerType<T>> implements
 //	Computers.Arity3<IterableInterval<T>, T, T, IterableInterval<T>> 
 //{

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/Inverters.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/invert/Inverters.java
@@ -15,7 +15,6 @@ import net.imglib2.util.Util;
 import org.scijava.ops.OpField;
 import org.scijava.ops.core.OpCollection;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.plugin.Plugin;
 
 @Plugin(type = OpCollection.class)
@@ -78,7 +77,7 @@ public class Inverters<T extends RealType<T>, I extends IntegerType<I>> {
 	// TODO: Think of a better solution.
 	@SuppressWarnings("unchecked")
 	public void computeIIInteger(final RandomAccessibleInterval<T> input, final T min, final T max,
-			final @Mutable RandomAccessibleInterval<T> output) {
+			final RandomAccessibleInterval<T> output) {
 
 		final BigInteger minValue = getBigInteger(min);
 		final BigInteger maxValue = getBigInteger(max);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIComputer.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIComputer.java
@@ -63,7 +63,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sourceMax")
 @Parameter(key = "targetMin")
 @Parameter(key = "targetMax")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class NormalizeIIComputer<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIFunction.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIIFunction.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sourceMax")
 @Parameter(key = "targetMin")
 @Parameter(key = "targetMax")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class NormalizeIIFunction<I extends RealType<I>, O extends RealType<O>>
 	implements
 	Functions.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
@@ -39,7 +39,6 @@ import net.imglib2.util.Util;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -68,7 +67,7 @@ public class NormalizeIILazy<I extends RealType<I>, O extends RealType<O>>
 	private Computers.Arity5<RandomAccessibleInterval<I>, I, I, O, O, RandomAccessibleInterval<O>> normalizerFunc;
 
 	@Override
-	public void compute(RandomAccessibleInterval<I> img, @Mutable RandomAccessibleInterval<O> output) {
+	public void compute(RandomAccessibleInterval<I> img, RandomAccessibleInterval<O> output) {
 		Pair<I, I> sourceMinMax = minMaxFunc.apply(img);
 		O min = Util.getTypeFromInterval(output).createVariable();
 		min.setReal(min.getMinValue());

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazy.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.normalize")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class NormalizeIILazy<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazyFunction.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/normalize/NormalizeIILazyFunction.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "image.normalize")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class NormalizeIILazyFunction<I extends RealType<I>>
 		implements Function<RandomAccessibleInterval<I>, RandomAccessibleInterval<I>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/Watershed.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/Watershed.java
@@ -100,7 +100,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "mask")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 public class Watershed<T extends RealType<T>, B extends BooleanType<B>> implements
 		Computers.Arity4<RandomAccessibleInterval<T>, Boolean, Boolean, RandomAccessibleInterval<B>, ImgLabeling<Integer, IntType>> {
 
@@ -391,7 +391,7 @@ public class Watershed<T extends RealType<T>, B extends BooleanType<B>> implemen
 @Parameter(key = "input")
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 class WatershedMaskless<T extends RealType<T>, B extends BooleanType<B>> implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Boolean, Boolean, ImgLabeling<Integer, IntType>> {
 	
@@ -411,7 +411,7 @@ class WatershedMaskless<T extends RealType<T>, B extends BooleanType<B>> impleme
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "mask")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedFunction<T extends RealType<T>, B extends BooleanType<B>>
 		implements Functions.Arity4<RandomAccessibleInterval<T>, Boolean, Boolean, RandomAccessibleInterval<B>, ImgLabeling<Integer, IntType>> {
 
@@ -433,7 +433,7 @@ class WatershedFunction<T extends RealType<T>, B extends BooleanType<B>>
 @Parameter(key = "input")
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedFunctionMaskless<T extends RealType<T>, B extends BooleanType<B>>
 		implements Functions.Arity3<RandomAccessibleInterval<T>, Boolean, Boolean, ImgLabeling<Integer, IntType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/Watershed.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/Watershed.java
@@ -60,7 +60,6 @@ import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Functions;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -400,7 +399,7 @@ class WatershedMaskless<T extends RealType<T>, B extends BooleanType<B>> impleme
 
 	@Override
 	public void compute(RandomAccessibleInterval<T> in, Boolean useEightConnectivity, Boolean drawWatersheds,
-			@Mutable ImgLabeling<Integer, IntType> outputLabeling) {
+			ImgLabeling<Integer, IntType> outputLabeling) {
 		watershedOp.compute(in, useEightConnectivity, drawWatersheds, null, outputLabeling);
 		
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
@@ -91,7 +91,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sigma")
 @Parameter(key = "mask")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 public class WatershedBinary<T extends BooleanType<T>, B extends BooleanType<B>> implements
 		Computers.Arity6<RandomAccessibleInterval<T>, Boolean, Boolean, double[], RandomAccessibleInterval<B>, ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -147,7 +147,7 @@ public class WatershedBinary<T extends BooleanType<T>, B extends BooleanType<B>>
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "sigma")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 class WatershedBinaryMaskless<T extends BooleanType<T>, B extends BooleanType<B>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, Boolean, Boolean, double[], ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -169,7 +169,7 @@ class WatershedBinaryMaskless<T extends BooleanType<T>, B extends BooleanType<B>
 @Parameter(key = "sigma")
 @Parameter(key = "mask")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedBinaryFunction<T extends BooleanType<T>, B extends BooleanType<B>> implements
 		Functions.Arity6<RandomAccessibleInterval<T>, Boolean, Boolean, double[], RandomAccessibleInterval<B>, ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -193,7 +193,7 @@ class WatershedBinaryFunction<T extends BooleanType<T>, B extends BooleanType<B>
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "sigma")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedBinaryFunctionMaskless<T extends BooleanType<T>, B extends BooleanType<B>>
 		implements Functions.Arity5<RandomAccessibleInterval<T>, Boolean, Boolean, double[], ExecutorService, ImgLabeling<Integer, IntType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinary.java
@@ -45,7 +45,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -156,7 +155,7 @@ class WatershedBinaryMaskless<T extends BooleanType<T>, B extends BooleanType<B>
 
 	@Override
 	public void compute(RandomAccessibleInterval<T> in, Boolean useEightConnectivity, Boolean drawWatersheds,
-			double[] sigma, ExecutorService es, @Mutable ImgLabeling<Integer, IntType> outputLabeling) {
+			double[] sigma, ExecutorService es, ImgLabeling<Integer, IntType> outputLabeling) {
 		watershedOp.compute(in, useEightConnectivity, drawWatersheds, sigma, null, es, outputLabeling);
 
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
@@ -97,7 +97,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "sigma")
 @Parameter(key = "mask")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 public class WatershedBinarySingleSigma<T extends BooleanType<T>, B extends BooleanType<B>> implements
 		Computers.Arity6<RandomAccessibleInterval<T>, Boolean, Boolean, Double, RandomAccessibleInterval<B>, ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -148,7 +148,7 @@ public class WatershedBinarySingleSigma<T extends BooleanType<T>, B extends Bool
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "sigma")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 class WatershedBinarySingleSigmaMaskless<T extends RealType<T>, B extends BooleanType<B>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, Boolean, Boolean, Double, ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -170,7 +170,7 @@ class WatershedBinarySingleSigmaMaskless<T extends RealType<T>, B extends Boolea
 @Parameter(key = "sigma")
 @Parameter(key = "mask")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedBinarySingleSigmaFunction<T extends RealType<T>, B extends BooleanType<B>> implements
 		Functions.Arity6<RandomAccessibleInterval<T>, Boolean, Boolean, Double, RandomAccessibleInterval<B>, ExecutorService, ImgLabeling<Integer, IntType>> {
 
@@ -194,7 +194,7 @@ class WatershedBinarySingleSigmaFunction<T extends RealType<T>, B extends Boolea
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "sigma")
 @Parameter(key = "executorService")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedBinarySigngleSigmaFunctionMaskless<T extends RealType<T>, B extends BooleanType<B>> implements
 		Functions.Arity5<RandomAccessibleInterval<T>, Boolean, Boolean, Double, ExecutorService, ImgLabeling<Integer, IntType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedBinarySingleSigma.java
@@ -52,7 +52,6 @@ import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
 import org.scijava.ops.function.Functions;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -157,7 +156,7 @@ class WatershedBinarySingleSigmaMaskless<T extends RealType<T>, B extends Boolea
 
 	@Override
 	public void compute(RandomAccessibleInterval<T> in, Boolean useEightConnectivity, Boolean drawWatersheds,
-			Double sigma, ExecutorService es, @Mutable ImgLabeling<Integer, IntType> outputLabeling) {
+			Double sigma, ExecutorService es, ImgLabeling<Integer, IntType> outputLabeling) {
 		watershedOp.compute(in, useEightConnectivity, drawWatersheds, sigma, null, es, outputLabeling);
 
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedSeeded.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedSeeded.java
@@ -108,7 +108,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "mask")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class WatershedSeeded<T extends RealType<T>, B extends BooleanType<B>> implements
 		Computers.Arity5<RandomAccessibleInterval<T>, ImgLabeling<Integer, IntType>, Boolean, Boolean, RandomAccessibleInterval<B>, ImgLabeling<Integer, IntType>> {
 
@@ -394,7 +394,7 @@ public class WatershedSeeded<T extends RealType<T>, B extends BooleanType<B>> im
 @Parameter(key = "seeds")
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.BOTH)
+@Parameter(key = "outputLabeling")
 class WatershedSeededMaskless<T extends RealType<T>, B extends BooleanType<B>> implements
 		Computers.Arity4<RandomAccessibleInterval<T>, ImgLabeling<Integer, IntType>, Boolean, Boolean, ImgLabeling<Integer, IntType>> {
 
@@ -415,7 +415,7 @@ class WatershedSeededMaskless<T extends RealType<T>, B extends BooleanType<B>> i
 @Parameter(key = "seeds")
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedSeededMasklessFunction<T extends RealType<T>, B extends BooleanType<B>> implements
 		Functions.Arity4<RandomAccessibleInterval<T>, ImgLabeling<Integer, IntType>, Boolean, Boolean, ImgLabeling<Integer, IntType>> {
 
@@ -439,7 +439,7 @@ class WatershedSeededMasklessFunction<T extends RealType<T>, B extends BooleanTy
 @Parameter(key = "useEightConnectivity")
 @Parameter(key = "drawWatersheds")
 @Parameter(key = "mask")
-@Parameter(key = "outputLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputLabeling")
 class WatershedSeededFunction<T extends RealType<T>, B extends BooleanType<B>> implements
 		Functions.Arity5<RandomAccessibleInterval<T>, ImgLabeling<Integer, IntType>, Boolean, Boolean, RandomAccessibleInterval<B>, ImgLabeling<Integer, IntType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedSeeded.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/image/watershed/WatershedSeeded.java
@@ -68,7 +68,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Functions;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -404,7 +403,7 @@ class WatershedSeededMaskless<T extends RealType<T>, B extends BooleanType<B>> i
 	@Override
 	public void compute(RandomAccessibleInterval<T> in, ImgLabeling<Integer, IntType> seeds,
 			Boolean useEightConnectivity, Boolean drawWatersheds,
-			@Mutable ImgLabeling<Integer, IntType> outputLabeling) {
+			ImgLabeling<Integer, IntType> outputLabeling) {
 		watershedOp.compute(in, seeds, useEightConnectivity, drawWatersheds, null, outputLabeling);
 
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment00.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment00.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment00", label = "Image Moment: CentralMoment00")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment00<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment01.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment01.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.centralMoment01", label = "Image Moment: CentralMoment01",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment01<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment02.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment02.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment02", label = "Image Moment: CentralMoment02")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment02<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment03.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment03.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment03", label = "Image Moment: CentralMoment03")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment03<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment10.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment10.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.centralMoment10", label = "Image Moment: CentralMoment10",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment10<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment11.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment11", label = "Image Moment: CentralMoment11")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment11<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment12.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment12.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment12", label = "Image Moment: CentralMoment12")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment12<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment20.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment20.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment20", label = "Image Moment: CentralMoment20")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment20<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment21.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment21.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment21", label = "Image Moment: CentralMoment21")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment21<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment30.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/DefaultCentralMoment30.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment30", label = "Image Moment: CentralMoment30")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultCentralMoment30<I extends RealType<I>, O extends RealType<O>>
 		implements AbstractImageMomentOp<I, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment00.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment00.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment00", label = "Image Moment: CentralMoment00", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class IterableCentralMoment00<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<IterableInterval<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/centralmoments/IterableCentralMoment11.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.centralMoment11", label = "Image Moment: CentralMoment11", priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class IterableCentralMoment11<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<IterableInterval<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment1.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment1.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment1", label = "Image Moment: HuMoment1")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment1<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment2.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment2.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment2", label = "Image Moment: HuMoment2")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment2<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment20")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment3.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment3.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment3", label = "Image Moment: HuMoment3")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment3<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment4.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment4", label = "Image Moment: HuMoment4")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment4<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment5.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment5.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment5", label = "Image Moment: HuMoment5")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment5<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment6.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment6", label = "Image Moment: HuMoment6")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment6<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/hu/DefaultHuMoment7.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "imageMoments.huMoment7", label = "Image Moment: HuMoment7")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultHuMoment7<I extends RealType<I>, O extends RealType<O>> implements AbstractImageMomentOp<I, O> {
 
 	@OpDependency(name = "imageMoments.normalizedCentralMoment30")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment00.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment00.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.moment00", label = "Image Moment: Moment00",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMoment00<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment01.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment01.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.moment01", label = "Image Moment: Moment01",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMoment01<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment10.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment10.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.moment10", label = "Image Moment: Moment10",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMoment10<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/moments/DefaultMoment11.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.moment11", label = "Image Moment: Moment11",
 	priority = Priority.VERY_HIGH)
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMoment11<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment02.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment02",
 	label = "Image Moment: NormalizedCentralMoment02")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment02<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment03.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment03",
 	label = "Image Moment: NormalizedCentralMoment03")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment03<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment11.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment11",
 	label = "Image Moment: NormalizedCentralMoment11")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment11<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment12.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment12",
 	label = "Image Moment: NormalizedCentralMoment12")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment12<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment20.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment20",
 	label = "Image Moment: NormalizedCentralMoment20")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment20<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment21.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment21",
 	label = "Image Moment: NormalizedCentralMoment21")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment21<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/imagemoments/normalizedcentralmoments/DefaultNormalizedCentralMoment30.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "imageMoments.normalizedCentralMoment30",
 	label = "Image Moment: NormalizedCentralMoment30")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultNormalizedCentralMoment30<I extends RealType<I>, O extends RealType<O>>
 	implements AbstractImageMomentOp<I, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/MergeLabeling.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/MergeLabeling.java
@@ -63,7 +63,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "labeling1")
 @Parameter(key = "labeling2")
 @Parameter(key = "mask")
-@Parameter(key = "combinedLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "combinedLabeling")
 public class MergeLabeling<L, I extends IntegerType<I>, B extends BooleanType<B>>
 		implements Functions.Arity3<ImgLabeling<L, I>, ImgLabeling<L, I>, RandomAccessibleInterval<B>, ImgLabeling<L, I>> {
 
@@ -114,7 +114,7 @@ public class MergeLabeling<L, I extends IntegerType<I>, B extends BooleanType<B>
 @Plugin(type = Op.class, name = "labeling.merge")
 @Parameter(key = "labeling1")
 @Parameter(key = "labeling2")
-@Parameter(key = "combinedLabeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "combinedLabeling")
 class MergeLabelingMaskless<L, I extends IntegerType<I>, B extends BooleanType<B>>
 		implements BiFunction<ImgLabeling<L, I>, ImgLabeling<L, I>, ImgLabeling<L, I>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/cca/DefaultCCA.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/cca/DefaultCCA.java
@@ -60,7 +60,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "executorService")
 @Parameter(key = "structuringElement")
 @Parameter(key = "labelGenerator")
-@Parameter(key = "labeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "labeling")
 public class DefaultCCA<T extends IntegerType<T>, L, I extends IntegerType<I>> implements
 		Functions.Arity4<RandomAccessibleInterval<T>, ExecutorService, StructuringElement, Iterator<Integer>, ImgLabeling<Integer, IntType>> {
 
@@ -83,7 +83,7 @@ public class DefaultCCA<T extends IntegerType<T>, L, I extends IntegerType<I>> i
 @Parameter(key = "input")
 @Parameter(key = "executorService")
 @Parameter(key = "structuringElement")
-@Parameter(key = "labeling", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "labeling")
 class SimpleCCA<T extends IntegerType<T>, L, I extends IntegerType<I>> implements
 		Functions.Arity3<RandomAccessibleInterval<T>, ExecutorService, StructuringElement, ImgLabeling<Integer, IntType>> {
 	@OpDependency(name = "labeling.cca")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/logic/Default.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/logic/Default.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "logic.default")
 @Parameter(key = "input")
 @Parameter(key = "defaultValue")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class Default<I extends BooleanType<I>, O extends Type<O>> implements
 	Computers.Arity2<I, O, O> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/logic/Ternary.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/logic/Ternary.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "ifTrueVal")
 @Parameter(key = "ifFalseVal")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class Ternary<I extends BooleanType<I>, O extends Type<O>> implements Computers.Arity3<I, O, O, O>
 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/map/neighborhood/DefaultMapNeighborhood.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/map/neighborhood/DefaultMapNeighborhood.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultMapNeighborhood<I, O> implements
 	Computers.Arity3<RandomAccessibleInterval<I>, Shape, Computers.Arity1<Iterable<I>, O>, IterableInterval<O>>
 {
@@ -94,7 +94,7 @@ public class DefaultMapNeighborhood<I, O> implements
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class MapNeighborhoodAllRAI<I, O> implements
 	Computers.Arity3<RandomAccessibleInterval<I>, Shape, Computers.Arity1<Iterable<I>, O>, RandomAccessibleInterval<O>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -62,7 +62,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class MapNeighborhoodWithCenter<I, O> implements Computers.Arity3<RandomAccessibleInterval<I>, Shape, Computers.Arity2<Iterable<I>, I, O>, IterableInterval<O>>
 {
 
@@ -101,7 +101,7 @@ public class MapNeighborhoodWithCenter<I, O> implements Computers.Arity3<RandomA
 @Parameter(key = "input")
 @Parameter(key = "shape")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class MapNeighborhoodWithCenterAllRAI<I, O> implements
 	Computers.Arity3<RandomAccessibleInterval<I>, Shape, Computers.Arity2<Iterable<I>, I, O>, RandomAccessibleInterval<O>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/multiply/ComplexConjugateMultiplyOp.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/multiply/ComplexConjugateMultiplyOp.java
@@ -41,7 +41,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "math.complexConjugateMultiply", priority = Priority.LOW)
 @Parameter(key = "input1")
 @Parameter(key = "input2")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComplexConjugateMultiplyOp<T extends ComplexType<T>> implements Computers.Arity2<T, T, T> {
 
 	// TODO: extend common abstract base class which implements Contingent

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/ExtractHoles.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/ExtractHoles.java
@@ -40,7 +40,6 @@ import net.imglib2.type.BooleanType;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -84,7 +83,7 @@ class SimpleExtractHolesComputer<T extends BooleanType<T>> implements
 	private Computers.Arity2<RandomAccessibleInterval<T>, Shape, RandomAccessibleInterval<T>> extractOp;
 
 	@Override
-	public void compute(RandomAccessibleInterval<T> in1, @Mutable RandomAccessibleInterval<T> out) {
+	public void compute(RandomAccessibleInterval<T> in1, RandomAccessibleInterval<T> out) {
 		Shape defaultStructElement = new RectangleShape(1, false);
 		extractOp.compute(in1, defaultStructElement, out);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/ExtractHoles.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/ExtractHoles.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "morphology.extractHoles")
 @Parameter(key = "input")
 @Parameter(key = "structElement")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ExtractHoles<T extends BooleanType<T>> implements
 	Computers.Arity2<RandomAccessibleInterval<T>, Shape, RandomAccessibleInterval<T>>
 {
@@ -76,7 +76,7 @@ public class ExtractHoles<T extends BooleanType<T>> implements
 
 @Plugin(type = Op.class, name = "morphology.extractHoles")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class SimpleExtractHolesComputer<T extends BooleanType<T>> implements
 	Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/FillHoles.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/FillHoles.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "morphology.fillHoles")
 @Parameter(key = "input")
 @Parameter(key = "structElement")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class FillHoles<T extends BooleanType<T>> implements
 	Computers.Arity2<RandomAccessibleInterval<T>, Shape, RandomAccessibleInterval<T>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/Outline.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/Outline.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "morphology.outline")
 @Parameter(key = "input")
 @Parameter(key = "excludeEdges")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class Outline<B extends BooleanType<B>>
 		implements Computers.Arity2<RandomAccessibleInterval<B>, Boolean, RandomAccessibleInterval<BitType>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinGuoHall.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinGuoHall.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "morphology.thinGuoHall")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ThinGuoHall extends AbstractThin {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinHilditch.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinHilditch.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "morphology.thinHilditch")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ThinHilditch extends AbstractThin {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinMorphological.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinMorphological.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "morphology.thinMorphological")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ThinMorphological extends AbstractThin {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinZhangSuen.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/morphology/thin/ThinZhangSuen.java
@@ -45,7 +45,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "morphology.thinZhangSuen")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ThinZhangSuen extends AbstractThin {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/DefaultProjectParallel.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/DefaultProjectParallel.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "op")
 @Parameter(key = "dim")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultProjectParallel<T, V> implements
 	Computers.Arity3<RandomAccessibleInterval<T>, Computers.Arity1<Iterable<T>, V>, Integer, RandomAccessibleInterval<V>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/ProjectRAIToIterableInterval.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/project/ProjectRAIToIterableInterval.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "op")
 @Parameter(key = "dim")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ProjectRAIToIterableInterval<T, V>
 		implements Computers.Arity3<RandomAccessibleInterval<T>, Computers.Arity1<Iterable<T>, V>, Integer, IterableInterval<V>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/segment/detectJunctions/DefaultDetectJunctions.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/segment/detectJunctions/DefaultDetectJunctions.java
@@ -64,7 +64,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "segment.detectJunctions")
 @Parameter(key = "lines")
 @Parameter(key = "threshold", description = "Maximum distance between polylines to be considered a junction")
-@Parameter(key = "junctions", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "junctions")
 public class DefaultDetectJunctions implements BiFunction<List<? extends WritablePolyline>, Double, List<RealPoint>> {
 
 	// @Parameter(required = false)
@@ -318,7 +318,7 @@ public class DefaultDetectJunctions implements BiFunction<List<? extends Writabl
 
 @Plugin(type = Op.class, name = "segment.detectJunctions")
 @Parameter(key = "lines")
-@Parameter(key = "junctions", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "junctions")
 class SimpleDetectJunctions implements Function<List<? extends WritablePolyline>, List<RealPoint>> {
 
 	@OpDependency(name = "segment.detectJunctions")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidges.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/segment/detectRidges/DefaultDetectRidges.java
@@ -65,7 +65,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "lowerThreshold")
 @Parameter(key = "higherThreshold")
 @Parameter(key = "ridgeLengthMin")
-@Parameter(key = "ridges", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "ridges")
 public class DefaultDetectRidges<T extends RealType<T>> implements
 		Functions.Arity5<RandomAccessibleInterval<T>, Double, Double, Double, Integer, List<DefaultWritablePolyline>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/slice/SliceRAI2RAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/slice/SliceRAI2RAI.java
@@ -57,7 +57,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "Op")
 @Parameter(key = "axisIndices")
 @Parameter(key = "dropSingleDimensions")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class SliceRAI2RAI<I, O> implements
 		Computers.Arity4<RandomAccessibleInterval<I>, Computers.Arity1<RandomAccessibleInterval<I>, RandomAccessibleInterval<O>>, int[], Boolean, RandomAccessibleInterval<O>> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultGeometricMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultGeometricMean.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.geometricMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "geometricMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "geometricMean")
 public class DefaultGeometricMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.size")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultHarmonicMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultHarmonicMean.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.harmonicMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "harmonicMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "harmonicMean")
 public class DefaultHarmonicMean<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultKurtosis.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultKurtosis.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.kurtosis")
 @Parameter(key = "iterableInput")
-@Parameter(key = "kurtosis", itemIO = ItemIO.BOTH)
+@Parameter(key = "kurtosis")
 public class DefaultKurtosis<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMax.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMax.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.max", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "max", itemIO = ItemIO.BOTH)
+@Parameter(key = "max")
 public class DefaultMax<T extends RealType<T>> implements Computers.Arity1<RandomAccessibleInterval<T>, T> {
 	
 	@OpDependency(name = "stats.minMax")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMean.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.mean",
 	priority = Priority.HIGH)
 @Parameter(key = "rai")
-@Parameter(key = "mean", itemIO = ItemIO.BOTH)
+@Parameter(key = "mean")
 public class DefaultMean<I extends RealType<I>, O extends RealType<O>> 
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMedian.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMedian.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.median")
 @Parameter(key = "iterableInput")
-@Parameter(key = "median", itemIO = ItemIO.BOTH)
+@Parameter(key = "median")
 public class DefaultMedian<I extends RealType<I>, O extends RealType<O>> 
 		implements Computers.Arity1<Iterable<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMin.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMin.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.min", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "max", itemIO = ItemIO.BOTH)
+@Parameter(key = "max")
 public class DefaultMin<T extends RealType<T>> implements Computers.Arity1<RandomAccessibleInterval<T>, T> {
 	
 	@OpDependency(name = "stats.minMax")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMinMax.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMinMax.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.minMax", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "minMax", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "minMax")
 public class DefaultMinMax<I extends RealType<I>> implements Function<RandomAccessibleInterval<I>, Pair<I, I>> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment1AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment1AboutMean.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment1AboutMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment1AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment1AboutMean")
 public class DefaultMoment1AboutMean<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment2AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment2AboutMean.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment2AboutMean", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment2AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment2AboutMean")
 public class DefaultMoment2AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.momentNAboutMean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment3AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment3AboutMean.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment3AboutMean", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment3AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment3AboutMean")
 public class DefaultMoment3AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.momentNAboutMean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment4AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMoment4AboutMean.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment4AboutMean", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment4AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment4AboutMean")
 public class DefaultMoment4AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.momentNAboutMean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMomentNAboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultMomentNAboutMean.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.momentNAboutMean", priority = Priority.HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment3AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment3AboutMean")
 public class DefaultMomentNAboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity2<RandomAccessibleInterval<I>, Integer, O> {
 
 	@OpDependency(name = "stats.mean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultPercentile.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultPercentile.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "stats.percentile")
 @Parameter(key = "iterableInput")
 @Parameter(key = "percent", min="0", max="100")
-@Parameter(key = "percentile", itemIO = ItemIO.BOTH)
+@Parameter(key = "percentile")
 public class DefaultPercentile<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity2<Iterable<I>, Double, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultQuantile.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultQuantile.java
@@ -58,7 +58,7 @@ import static java.util.Collections.swap;
 @Plugin(type = Op.class, name = "stats.quantile")
 @Parameter(key = "iterableInput")
 @Parameter(key = "quantile", min = "0.0", max = "1.0")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class DefaultQuantile<I extends RealType<I>, O extends RealType<O>>
 implements Computers.Arity2<Iterable<I>, Double, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSize.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.size")
 @Parameter(key = "interval")
-@Parameter(key = "size", itemIO = ItemIO.BOTH)
+@Parameter(key = "size")
 public class DefaultSize<I extends RealType<I>, O extends RealType<O>> 
 	implements Computers.Arity1<Interval, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSkewness.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSkewness.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.skewness")
 @Parameter(key = "iterableInput")
-@Parameter(key = "skewness", itemIO = ItemIO.BOTH)
+@Parameter(key = "skewness")
 public class DefaultSkewness<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.moment3AboutMean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultStandardDeviation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultStandardDeviation.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.stdDev", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "stdDev", itemIO = ItemIO.BOTH)
+@Parameter(key = "stdDev")
 public class DefaultStandardDeviation<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSum.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSum.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sum", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "sum", itemIO = ItemIO.BOTH)
+@Parameter(key = "sum")
 public class DefaultSum<I extends RealType<I>, O extends RealType<O>> implements
 	Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfInverses.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfInverses.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfInverses", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "sumOfInverses", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfInverses")
 public class DefaultSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity2<RandomAccessibleInterval<I>, O, O> {
 	
 	@OpDependency(name = "create.img")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfLogs.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfLogs.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfLogs", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "sumOfLogs", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfLogs")
 public class DefaultSumOfLogs<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 	
 	@OpDependency(name = "create.img")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfSquares.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultSumOfSquares.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfSquares", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "sumOfSquares", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfSquares")
 public class DefaultSumOfSquares<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<RandomAccessibleInterval<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/DefaultVariance.java
@@ -62,7 +62,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.variance", priority = Priority.HIGH)
 @Parameter(key = "raiInput")
-@Parameter(key = "variance", itemIO = ItemIO.BOTH)
+@Parameter(key = "variance")
 public class DefaultVariance<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<RandomAccessibleInterval<I>, O> {
 
 	@OpDependency(name = "stats.mean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralMean.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.integralMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "integralMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "integralMean")
 public class IntegralMean<I extends RealType<I>> implements Computers.Arity1<RectangleNeighborhood<? extends Composite<I>>, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralSum.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralSum.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.integralSum")
 @Parameter(key = "iterableInput")
-@Parameter(key = "integralSum", itemIO = ItemIO.BOTH)
+@Parameter(key = "integralSum")
 public class IntegralSum<I extends RealType<I>> implements Computers.Arity1<RectangleNeighborhood<I>, DoubleType> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IntegralVariance.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.integralVariance")
 @Parameter(key = "iterableInput")
-@Parameter(key = "integralVariance", itemIO = ItemIO.BOTH)
+@Parameter(key = "integralVariance")
 public class IntegralVariance<I extends RealType<I>>
 		implements Computers.Arity1<RectangleNeighborhood<? extends Composite<I>>, DoubleType> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableGeometricMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableGeometricMean.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.geometricMean", priority = Priority.VERY_HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "geometricMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "geometricMean")
 public class IterableGeometricMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableHarmonicMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableHarmonicMean.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.harmonicMean", priority = Priority.VERY_HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "harmonicMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "harmonicMean")
 public class IterableHarmonicMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMax.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMax.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.max")
 @Parameter(key = "iterableInput")
-@Parameter(key = "max", itemIO = ItemIO.BOTH)
+@Parameter(key = "max")
 public class IterableMax<T extends RealType<T>> implements Computers.Arity1<Iterable<T>, T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMean.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.mean", priority = Priority.VERY_HIGH)
 @Parameter(key = "iterableInput")
-@Parameter(key = "mean", itemIO = ItemIO.BOTH)
+@Parameter(key = "mean")
 public class IterableMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMin.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMin.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.min")
 @Parameter(key = "iterableInput")
-@Parameter(key = "min", itemIO = ItemIO.BOTH)
+@Parameter(key = "min")
 public class IterableMin<T extends RealType<T>> implements Computers.Arity1<Iterable<T>, T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMinMax.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMinMax.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.minMax")
 @Parameter(key = "iterableInput")
-@Parameter(key = "minMax", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "minMax")
 public class IterableMinMax<I extends RealType<I>> implements Function<Iterable<I>, Pair<I, I>> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMoment3AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMoment3AboutMean.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment3AboutMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment3AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment3AboutMean")
 public class IterableMoment3AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@OpDependency(name = "stats.mean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMoment4AboutMean.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableMoment4AboutMean.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.moment4AboutMean")
 @Parameter(key = "iterableInput")
-@Parameter(key = "moment4AboutMean", itemIO = ItemIO.BOTH)
+@Parameter(key = "moment4AboutMean")
 public class IterableMoment4AboutMean<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@OpDependency(name = "stats.mean")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSize.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSize.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.size", priority = Priority.LOW)
 @Parameter(key = "iterableInput")
-@Parameter(key = "size", itemIO = ItemIO.BOTH)
+@Parameter(key = "size")
 public class IterableSize<I extends RealType<I>, O extends RealType<O>> 
 	implements Computers.Arity1<Iterable<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableStandardDeviation.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableStandardDeviation.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.stdDev")
 @Parameter(key = "iterableInput")
-@Parameter(key = "stdDev", itemIO = ItemIO.BOTH)
+@Parameter(key = "stdDev")
 public class IterableStandardDeviation<I extends RealType<I>, O extends RealType<O>>
 		implements Computers.Arity1<Iterable<I>, O> {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSum.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSum.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sum")
 @Parameter(key = "iterableInput")
-@Parameter(key = "sum", itemIO = ItemIO.BOTH)
+@Parameter(key = "sum")
 public class IterableSum<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<Iterable<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfInverses.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfInverses.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfInverses")
 @Parameter(key = "iterableInput")
-@Parameter(key = "sumOfInverses", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfInverses")
 public class IterableSumOfInverses<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity2<Iterable<I>, O, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfLogs.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfLogs.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfLogs")
 @Parameter(key = "iterableInput")
-@Parameter(key = "sumOfLogs", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfLogs")
 public class IterableSumOfLogs<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfSquares.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableSumOfSquares.java
@@ -47,7 +47,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.sumOfSquares")
 @Parameter(key = "iterableInput")
-@Parameter(key = "sumOfSquares", itemIO = ItemIO.BOTH)
+@Parameter(key = "sumOfSquares")
 public class IterableSumOfSquares<I extends RealType<I>, O extends RealType<O>>
 	implements Computers.Arity1<Iterable<I>, O>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableVariance.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/IterableVariance.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.variance")
 @Parameter(key = "iterableInput")
-@Parameter(key = "variance", itemIO = ItemIO.BOTH)
+@Parameter(key = "variance")
 public class IterableVariance<I extends RealType<I>, O extends RealType<O>> implements Computers.Arity1<Iterable<I>, O> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/regression/leastSquares/Quadric.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/stats/regression/leastSquares/Quadric.java
@@ -60,7 +60,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "stats.leastSquares")
 @Parameter(key = "vectorCollection")
-@Parameter(key = "outputMatrix", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "outputMatrix")
 public class Quadric implements
 	Function<Collection<Vector3d>, Matrix4d> 
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/thread/chunker/ChunkerInterleaved.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/thread/chunker/ChunkerInterleaved.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  * @author Michael Zinsmaier (University of Konstanz)
  */
 @Plugin(type = Op.class, name = "thread.chunker", priority = Priority.VERY_LOW)
-@Parameter(key = "chunk", itemIO = ItemIO.BOTH)
+@Parameter(key = "chunk")
 @Parameter(key = "numberOfElements")
 @Parameter(key = "executorService")
 public class ChunkerInterleaved implements Inplaces.Arity3_1<Chunk, Long, ExecutorService>{

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/thread/chunker/DefaultChunker.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/thread/chunker/DefaultChunker.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  * @author Christian Dietz (University of Konstanz)
  */
 @Plugin(type = Op.class, name = "thread.chunker")
-@Parameter(key = "chunk", itemIO = ItemIO.BOTH)
+@Parameter(key = "chunk")
 @Parameter(key = "numberOfElements")
 @Parameter(key = "executorService")
 public class DefaultChunker implements Inplaces.Arity3_1<Chunk, Long, ExecutorService> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/AbstractApplyThresholdIterable.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/AbstractApplyThresholdIterable.java
@@ -43,7 +43,7 @@ import org.scijava.struct.ItemIO;
  * @author Christian Dietz (University of Konstanz)
  */
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public abstract class AbstractApplyThresholdIterable<T> implements
 	Computers.Arity1<Iterable<T>, Iterable<BitType>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/AbstractApplyThresholdIterable.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/AbstractApplyThresholdIterable.java
@@ -34,7 +34,6 @@ import net.imglib2.type.logic.BitType;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.struct.ItemIO;
 
@@ -53,7 +52,7 @@ public abstract class AbstractApplyThresholdIterable<T> implements
 
 	@Override
 	public void compute(final Iterable<T> input,
-		@Mutable final Iterable<BitType> output)
+		final Iterable<BitType> output)
 	{
 		applyThresholdOp.compute(input, computeThreshold(input), output);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
@@ -317,7 +317,7 @@ public final class ApplyThresholdMethodLocal {
 	@Parameter(key = "input")
 	@Parameter(key = "inputNeighborhoodShape")
 	@Parameter(key = "outOfBoundsFactory", required = false)
-	@Parameter(key = "output", itemIO = ItemIO.BOTH)
+	@Parameter(key = "output")
 	private abstract static class AbstractApplyLocalHistogramBasedThreshold<T extends RealType<T>>
 		implements
 		Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ApplyThresholdMethodLocal.java
@@ -46,7 +46,6 @@ import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -339,7 +338,7 @@ public final class ApplyThresholdMethodLocal {
 		public void compute(final RandomAccessibleInterval<T> input,
 			final Shape inputNeighborhoodShape,
 			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-			@Mutable final RandomAccessibleInterval<BitType> output)
+			final RandomAccessibleInterval<BitType> output)
 		{
 			if (thresholdOp == null) thresholdOp = getThresholdOp();
 			ApplyCenterAwareNeighborhoodBasedFilter.compute(input,
@@ -353,7 +352,7 @@ public final class ApplyThresholdMethodLocal {
 
 				@Override
 				public void compute(final Iterable<T> inputNeighborhood,
-					final T inputCenterPixel, @Mutable final BitType output)
+					final T inputCenterPixel, final BitType output)
 				{
 					final Histogram1d<T> histogram = createHistogramOp.apply(
 						inputNeighborhood, null);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyConstantThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyConstantThreshold.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "threshold")
 @Parameter(key = "comparator")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ApplyConstantThreshold<T extends RealType<T>>
 		implements Computers.Arity3<Iterable<T>, T, Comparator<T>, Iterable<BitType>> {
 
@@ -80,7 +80,7 @@ public class ApplyConstantThreshold<T extends RealType<T>>
 @Plugin(type = Op.class, name = "threshold.apply")
 @Parameter(key = "input")
 @Parameter(key = "threshold")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class ApplyConstantThresholdSimple<T extends RealType<T>> implements Computers.Arity2<Iterable<T>, T, Iterable<BitType>> {
 
 	@OpDependency(name = "threshold.apply")

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparable.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparable.java
@@ -48,7 +48,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.apply")
 @Parameter(key = "input")
 @Parameter(key = "threshold")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ApplyThresholdComparable<T> implements
 	Computers.Arity2<Comparable<? super T>, T, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparable.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparable.java
@@ -33,7 +33,6 @@ import net.imglib2.type.logic.BitType;
 
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -55,7 +54,7 @@ public class ApplyThresholdComparable<T> implements
 
 	@Override
 	public void compute(final Comparable<? super T> input, final T threshold,
-		final @Mutable BitType output)
+		final BitType output)
 	{
 		output.set(input.compareTo(threshold) > 0);
 	}

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparator.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparator.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "threshold")
 @Parameter(key = "comparator")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ApplyThresholdComparator<T> implements Computers.Arity3<T, T, Comparator<? super T>, BitType>
 {
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparator.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyThresholdComparator.java
@@ -35,7 +35,6 @@ import net.imglib2.type.logic.BitType;
 
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -56,7 +55,7 @@ public class ApplyThresholdComparator<T> implements Computers.Arity3<T, T, Compa
 {
 
 	@Override
-	public void compute(T input1, T input2, Comparator<? super T> comparator, @Mutable BitType out) {
+	public void compute(T input1, T input2, Comparator<? super T> comparator, BitType out) {
 		out.set(comparator.compare(input1, input2) > 0);
 	}
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/huang/ComputeHuangThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/huang/ComputeHuangThreshold.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.huang")
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeHuangThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ij1/ComputeIJ1Threshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/ij1/ComputeIJ1Threshold.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.ij1", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeIJ1Threshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/intermodes/ComputeIntermodesThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/intermodes/ComputeIntermodesThreshold.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.intermodes",
 	priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeIntermodesThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/isoData/ComputeIsoDataThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/isoData/ComputeIsoDataThreshold.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.isoData", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeIsoDataThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/li/ComputeLiThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/li/ComputeLiThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.li", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLiThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/ComputeLocalBernsenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/ComputeLocalBernsenThreshold.java
@@ -39,7 +39,6 @@ import net.imglib2.util.Pair;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -70,7 +69,7 @@ public class ComputeLocalBernsenThreshold<T extends RealType<T>> implements
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
 		final T inputCenterPixel, final Double contrastThreshold,
-		final Double halfMaxValue, @Mutable final BitType output)
+		final Double halfMaxValue, final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, contrastThreshold,
 			halfMaxValue, minMaxOp, output);
@@ -80,7 +79,7 @@ public class ComputeLocalBernsenThreshold<T extends RealType<T>> implements
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel,
 		final Double contrastThreshold, final Double halfMaxValue,
 		final Function<Iterable<T>, Pair<T, T>> minMaxOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final Pair<T, T> outputs = minMaxOp.apply(inputNeighborhood);
 		final double minValue = outputs.getA().getRealDouble();

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/ComputeLocalBernsenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/ComputeLocalBernsenThreshold.java
@@ -59,7 +59,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "contrastThreshold")
 @Parameter(key = "halfMaxValue")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalBernsenThreshold<T extends RealType<T>> implements
 	Computers.Arity4<Iterable<T>, T, Double, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "contrastThreshold")
 @Parameter(key = "halfMaxValue")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalBernsenThreshold<T extends RealType<T>> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
 			RandomAccessibleInterval<BitType>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localBernsen/LocalBernsenThreshold.java
@@ -40,7 +40,6 @@ import net.imglib2.type.numeric.RealType;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -69,7 +68,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> implements
 		final Shape inputNeighborhoodShape, final Double contrastThreshold,
 		final Double halfMaxValue,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, contrastThreshold, halfMaxValue,
 			outOfBoundsFactory, computeThresholdOp, output);
@@ -80,7 +79,7 @@ public class LocalBernsenThreshold<T extends RealType<T>> implements
 		final Double contrastThreshold, final Double halfMaxValue,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, contrastThreshold,

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/ComputeLocalContrastThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/ComputeLocalContrastThreshold.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.localContrast")
 @Parameter(key = "inputNeighborhood")
 @Parameter(key = "inputCenterPixel")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalContrastThreshold<T extends RealType<T>> implements
 	Computers.Arity2<Iterable<T>, T, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/ComputeLocalContrastThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/ComputeLocalContrastThreshold.java
@@ -38,7 +38,6 @@ import net.imglib2.util.Pair;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -63,7 +62,7 @@ public class ComputeLocalContrastThreshold<T extends RealType<T>> implements
 
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
-		final T inputCenterPixel, @Mutable final BitType output)
+		final T inputCenterPixel, final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, minMaxOp, output);
 	}
@@ -71,7 +70,7 @@ public class ComputeLocalContrastThreshold<T extends RealType<T>> implements
 	public static <T extends RealType<T>> void compute(
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel,
 		final Function<Iterable<T>, Pair<T, T>> minMaxOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final Pair<T, T> outputs = minMaxOp.apply(inputNeighborhood);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "input")
 @Parameter(key = "inputNeighborhoodShape")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalContrastThreshold<T extends RealType<T>> implements
 	Computers.Arity3<RandomAccessibleInterval<T>, Shape, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
 			RandomAccessibleInterval<BitType>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localContrast/LocalContrastThreshold.java
@@ -40,7 +40,6 @@ import net.imglib2.type.numeric.RealType;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -65,7 +64,7 @@ public class LocalContrastThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -75,7 +74,7 @@ public class LocalContrastThreshold<T extends RealType<T>> implements
 		final RandomAccessibleInterval<T> input, final Shape inputNeighborhoodShape,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity2<Iterable<T>, T, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		ApplyCenterAwareNeighborhoodBasedFilter.compute(input,
 			inputNeighborhoodShape, outOfBoundsFactory, computeThresholdOp, output);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThreshold.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhood")
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalMeanThreshold<T extends RealType<T>> implements
 	Computers.Arity3<Iterable<T>, T, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThreshold.java
@@ -38,7 +38,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -64,7 +63,7 @@ public class ComputeLocalMeanThreshold<T extends RealType<T>> implements
 
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
-		final T inputCenterPixel, final Double c, @Mutable final BitType output)
+		final T inputCenterPixel, final Double c, final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, c, meanOp, output);
 	}
@@ -72,7 +71,7 @@ public class ComputeLocalMeanThreshold<T extends RealType<T>> implements
 	public static <T extends RealType<T>> void compute(
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel,
 		final Double c, final Computers.Arity1<Iterable<T>, DoubleType> meanOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final DoubleType m = new DoubleType();
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
@@ -41,7 +41,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -80,7 +79,7 @@ public class ComputeLocalMeanThresholdIntegral<T extends RealType<T>, U extends 
 	public void compute(
 		final RectangleNeighborhood<? extends Composite<U>> inputNeighborhood,
 		final T inputCenterPixel, final Double c,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final DoubleType sum = new DoubleType();
 		integralMeanOp.compute(inputNeighborhood, sum);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/ComputeLocalMeanThresholdIntegral.java
@@ -68,7 +68,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhood")
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalMeanThresholdIntegral<T extends RealType<T>, U extends RealType<U>> implements
 	Computers.Arity3<RectangleNeighborhood<? extends Composite<U>>, T, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/LocalMeanThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/LocalMeanThreshold.java
@@ -50,7 +50,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -87,7 +86,7 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
 		RectangleShape rShape = inputNeighborhoodShape instanceof RectangleShape
@@ -111,7 +110,7 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 		final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);
@@ -126,7 +125,7 @@ public class LocalMeanThreshold<T extends RealType<T>> extends
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
 		final Computers.Arity3<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/LocalMeanThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMean/LocalMeanThreshold.java
@@ -69,7 +69,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhoodShape")
 @Parameter(key = "c")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalMeanThreshold<T extends RealType<T>> extends
 	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity4<RandomAccessibleInterval<T>, Shape, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/ComputeLocalMedianThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/ComputeLocalMedianThreshold.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhood")
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalMedianThreshold<T extends RealType<T>> implements
 	Computers.Arity3<Iterable<T>, T, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/ComputeLocalMedianThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/ComputeLocalMedianThreshold.java
@@ -37,7 +37,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -62,7 +61,7 @@ public class ComputeLocalMedianThreshold<T extends RealType<T>> implements
 
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
-		final T inputCenterPixel, final Double c, @Mutable final BitType output)
+		final T inputCenterPixel, final Double c, final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, c, medianOp, output);
 	}
@@ -70,7 +69,7 @@ public class ComputeLocalMedianThreshold<T extends RealType<T>> implements
 	public static <T extends RealType<T>> void compute(
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel,
 		final Double c, final Computers.Arity1<Iterable<T>, DoubleType> medianOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final DoubleType m = new DoubleType();
 		medianOp.compute(inputNeighborhood, m);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
@@ -40,7 +40,6 @@ import net.imglib2.type.numeric.RealType;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -66,7 +65,7 @@ public class LocalMedianThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, c, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -77,7 +76,7 @@ public class LocalMedianThreshold<T extends RealType<T>> implements
 		final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMedian/LocalMedianThreshold.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhoodShape")
 @Parameter(key = "c")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalMedianThreshold<T extends RealType<T>> implements
 	Computers.Arity4<RandomAccessibleInterval<T>, Shape, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
 			RandomAccessibleInterval<BitType>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/ComputeLocalMidGreyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/ComputeLocalMidGreyThreshold.java
@@ -39,7 +39,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -66,7 +65,7 @@ public class ComputeLocalMidGreyThreshold<T extends RealType<T>> implements
 
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
-		final T inputCenterPixel, final Double c, @Mutable final BitType output)
+		final T inputCenterPixel, final Double c, final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, c, minMaxOp, output);
 	}
@@ -74,7 +73,7 @@ public class ComputeLocalMidGreyThreshold<T extends RealType<T>> implements
 	public static <T extends RealType<T>> void compute(
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel,
 		final Double c, final Function<Iterable<T>, Pair<T, T>> minMaxOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final Pair<T, T> outputs = minMaxOp.apply(inputNeighborhood);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/ComputeLocalMidGreyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/ComputeLocalMidGreyThreshold.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhood")
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalMidGreyThreshold<T extends RealType<T>> implements
 	Computers.Arity3<Iterable<T>, T, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
@@ -56,7 +56,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputNeighborhoodShape")
 @Parameter(key = "c")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalMidGreyThreshold<T extends RealType<T>> implements
 	Computers.Arity4<RandomAccessibleInterval<T>, Shape, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //
 			RandomAccessibleInterval<BitType>> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localMidGrey/LocalMidGreyThreshold.java
@@ -41,7 +41,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -68,7 +67,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> implements
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		compute(input, inputNeighborhoodShape, c, outOfBoundsFactory,
 			computeThresholdOp, output);
@@ -79,7 +78,7 @@ public class LocalMidGreyThreshold<T extends RealType<T>> implements
 		final Double c,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity3<Iterable<T>, T, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThreshold.java
@@ -55,7 +55,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
 @Parameter(key = "k")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalNiblackThreshold<T extends RealType<T>> implements
 	Computers.Arity4<Iterable<T>, T, Double, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThreshold.java
@@ -38,7 +38,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -69,7 +68,7 @@ public class ComputeLocalNiblackThreshold<T extends RealType<T>> implements
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
 		final T inputCenterPixel, final Double c, final Double k,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, c, k, meanOp, stdDeviationOp,
 			output);
@@ -80,7 +79,7 @@ public class ComputeLocalNiblackThreshold<T extends RealType<T>> implements
 		final Double c, final Double k,
 		final Computers.Arity1<Iterable<T>, DoubleType> meanOp,
 		final Computers.Arity1<Iterable<T>, DoubleType> stdDeviationOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final DoubleType m = new DoubleType();
 		meanOp.compute(inputNeighborhood, m);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
@@ -69,7 +69,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "c")
 @Parameter(key = "k")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalNiblackThresholdIntegral<T extends RealType<T>, U extends RealType<U>>
 	implements
 	Computers.Arity4<RectangleNeighborhood<? extends Composite<U>>, T, Double, Double, BitType>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/ComputeLocalNiblackThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -85,7 +84,7 @@ public class ComputeLocalNiblackThresholdIntegral<T extends RealType<T>, U exten
 	public void compute(
 		final RectangleNeighborhood<? extends Composite<U>> inputNeighborhood,
 		final T inputCenterPixel, final Double c, final Double k,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		final DoubleType threshold = new DoubleType(0.0d);
 

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
@@ -49,7 +49,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -80,7 +79,7 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double c, final Double k,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
 		RectangleShape rShape = inputNeighborhoodShape instanceof RectangleShape
@@ -105,7 +104,7 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 		final Double c, final Double k,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, k, o);
@@ -121,7 +120,7 @@ public class LocalNiblackThreshold<T extends RealType<T>> extends
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> squareIntegralImageOp,
 		final Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, c, k, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localNiblack/LocalNiblackThreshold.java
@@ -61,7 +61,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "c")
 @Parameter(key = "k")
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalNiblackThreshold<T extends RealType<T>> extends
 	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThreshold.java
@@ -38,7 +38,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -95,7 +94,7 @@ public class ComputeLocalPhansalkarThreshold<T extends RealType<T>> implements
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
 		final T inputCenterPixel, final Double k, final Double r,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, k, r, meanOp, stdDeviationOp,
 			output);
@@ -105,7 +104,7 @@ public class ComputeLocalPhansalkarThreshold<T extends RealType<T>> implements
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel, Double k,
 		Double r, final Computers.Arity1<Iterable<T>, DoubleType> meanOp,
 		final Computers.Arity1<Iterable<T>, DoubleType> stdDeviationOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;
 		if (r == null) r = DEFAULT_R;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThreshold.java
@@ -75,7 +75,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalPhansalkarThreshold<T extends RealType<T>> implements
 	Computers.Arity4<Iterable<T>, T, Double, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
@@ -69,7 +69,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalPhansalkarThresholdIntegral<T extends RealType<T>>
 	implements
 	Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/ComputeLocalPhansalkarThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -91,7 +90,7 @@ public class ComputeLocalPhansalkarThresholdIntegral<T extends RealType<T>>
 	public void compute(
 		final RectangleNeighborhood<? extends Composite<DoubleType>> inputNeighborhood,
 		final T inputCenterPixel, Double k, Double r,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;
 		if (r == null) r = DEFAULT_R;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -61,7 +61,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localPhansalkar/LocalPhansalkarThreshold.java
@@ -49,7 +49,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -80,7 +79,7 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
 		RectangleShape rShape = inputNeighborhoodShape instanceof RectangleShape
@@ -105,7 +104,7 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 		final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);
@@ -121,7 +120,7 @@ public class LocalPhansalkarThreshold<T extends RealType<T>> extends
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> squareIntegralImageOp,
 		final Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThreshold.java
@@ -67,7 +67,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalSauvolaThreshold<T extends RealType<T>> implements
 	Computers.Arity4<Iterable<T>, T, Double, Double, BitType>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThreshold.java
@@ -38,7 +38,6 @@ import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -84,7 +83,7 @@ public class ComputeLocalSauvolaThreshold<T extends RealType<T>> implements
 	@Override
 	public void compute(final Iterable<T> inputNeighborhood,
 		final T inputCenterPixel, final Double k, final Double r,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		compute(inputNeighborhood, inputCenterPixel, k, r, meanOp, stdDeviationOp,
 			output);
@@ -94,7 +93,7 @@ public class ComputeLocalSauvolaThreshold<T extends RealType<T>> implements
 		final Iterable<T> inputNeighborhood, final T inputCenterPixel, Double k,
 		Double r, final Computers.Arity1<Iterable<T>, DoubleType> meanOp,
 		final Computers.Arity1<Iterable<T>, DoubleType> stdDeviationOp,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;
 		if (r == null) r = DEFAULT_R;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
@@ -69,7 +69,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "inputCenterPixel")
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeLocalSauvolaThresholdIntegral<T extends RealType<T>>
 	implements
 	Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType>

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/ComputeLocalSauvolaThresholdIntegral.java
@@ -42,7 +42,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -88,7 +87,7 @@ public class ComputeLocalSauvolaThresholdIntegral<T extends RealType<T>>
 	public void compute(
 		final RectangleNeighborhood<? extends Composite<DoubleType>> inputNeighborhood,
 		final T inputCenterPixel, Double k, Double r,
-		@Mutable final BitType output)
+		final BitType output)
 	{
 		if (k == null) k = DEFAULT_K;
 		if (r == null) r = DEFAULT_R;

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/LocalSauvolaThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/LocalSauvolaThreshold.java
@@ -61,7 +61,7 @@ import org.scijava.struct.ItemIO;
 @Parameter(key = "k", required = false)
 @Parameter(key = "r", required = false)
 @Parameter(key = "outOfBoundsFactory", required = false)
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class LocalSauvolaThreshold<T extends RealType<T>> extends
 	ApplyLocalThresholdIntegral<T, DoubleType> implements
 	Computers.Arity5<RandomAccessibleInterval<T>, Shape, Double, Double, OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/LocalSauvolaThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/localSauvola/LocalSauvolaThreshold.java
@@ -49,7 +49,6 @@ import org.scijava.Priority;
 import org.scijava.ops.OpDependency;
 import org.scijava.ops.core.Op;
 import org.scijava.ops.function.Computers;
-import org.scijava.param.Mutable;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.struct.ItemIO;
@@ -80,7 +79,7 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends
 	public void compute(final RandomAccessibleInterval<T> input,
 		final Shape inputNeighborhoodShape, final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		// Use integral images for sufficiently large windows.
 		if (inputNeighborhoodShape instanceof RectangleShape &&
@@ -102,7 +101,7 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends
 		final Double k, final Double r,
 		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBoundsFactory,
 		final Computers.Arity4<Iterable<T>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<Iterable<T>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);
@@ -118,7 +117,7 @@ public class LocalSauvolaThreshold<T extends RealType<T>> extends
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> integralImageOp,
 		final Function<RandomAccessibleInterval<T>, RandomAccessibleInterval<DoubleType>> squareIntegralImageOp,
 		final Computers.Arity4<RectangleNeighborhood<? extends Composite<DoubleType>>, T, Double, Double, BitType> computeThresholdOp,
-		@Mutable final RandomAccessibleInterval<BitType> output)
+		final RandomAccessibleInterval<BitType> output)
 	{
 		final Computers.Arity2<RectangleNeighborhood<? extends Composite<DoubleType>>, T, BitType> parametrizedComputeThresholdOp = //
 			(i1, i2, o) -> computeThresholdOp.compute(i1, i2, k, r, o);

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/maxEntropy/ComputeMaxEntropyThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.maxEntropy",
 	priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMaxEntropyThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/maxLikelihood/ComputeMaxLikelihoodThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/maxLikelihood/ComputeMaxLikelihoodThreshold.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.maxLikelihood")
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMaxLikelihoodThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/mean/ComputeMeanThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/mean/ComputeMeanThreshold.java
@@ -49,7 +49,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.mean")
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMeanThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/minError/ComputeMinErrorThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/minError/ComputeMinErrorThreshold.java
@@ -54,7 +54,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.minError", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMinErrorThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/minimum/ComputeMinimumThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/minimum/ComputeMinimumThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.minimum", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMinimumThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/moments/ComputeMomentsThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/moments/ComputeMomentsThreshold.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.moments", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeMomentsThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/otsu/ComputeOtsuThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/otsu/ComputeOtsuThreshold.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.otsu", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeOtsuThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/percentile/ComputePercentileThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/percentile/ComputePercentileThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.percentile",
 	priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputePercentileThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/renyiEntropy/ComputeRenyiEntropyThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/renyiEntropy/ComputeRenyiEntropyThreshold.java
@@ -53,7 +53,7 @@ import org.scijava.struct.ItemIO;
 @Plugin(type = Op.class, name = "threshold.renyiEntropy",
 	priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeRenyiEntropyThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/rosin/ComputeRosinThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/rosin/ComputeRosinThreshold.java
@@ -52,7 +52,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.rosin", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeRosinThreshold<T extends RealType<T>> extends AbstractComputeThresholdHistogram<T> {
 
 	@Override

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/shanbhag/ComputeShanbhagThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/shanbhag/ComputeShanbhagThreshold.java
@@ -50,7 +50,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.shanbhag", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeShanbhagThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/triangle/ComputeTriangleThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/triangle/ComputeTriangleThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.triangle", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeTriangleThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/yen/ComputeYenThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/yen/ComputeYenThreshold.java
@@ -51,7 +51,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "threshold.yen", priority = Priority.HIGH)
 @Parameter(key = "inputHistogram")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class ComputeYenThreshold<T extends RealType<T>> extends
 	AbstractComputeThresholdHistogram<T>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/BoxCount.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/BoxCount.java
@@ -332,7 +332,7 @@ public class BoxCount {
 @Parameter(key = "minSize")
 @Parameter(key = "scaling")
 @Parameter(key = "gridMoves")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class DefaultBoxCount<B extends BooleanType<B>> implements
 	Functions.Arity5<RandomAccessibleInterval<B>, Long, Long, Double, Long, List<ValuePair<DoubleType, DoubleType>>>
 {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26N.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26N.java
@@ -70,7 +70,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "topology.eulerCharacteristic26N")
 @Parameter(key = "interval")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class EulerCharacteristic26N<B extends BooleanType<B>>
         implements Computers.Arity1<RandomAccessibleInterval<B>, DoubleType> {
     /** Δχ(v) for all configurations of a 2x2x2 voxel neighborhood */

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NFloating.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCharacteristic26NFloating.java
@@ -72,7 +72,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "topology.eulerCharacteristic26NFloating")
 @Parameter(key = "interval")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class EulerCharacteristic26NFloating
         <B extends BooleanType<B>> implements Computers.Arity1<RandomAccessibleInterval<B>, DoubleType> {
     /** Δχ(v) for all configurations of a 2x2x2 voxel neighborhood */

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCorrection.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/topology/eulerCharacteristic/EulerCorrection.java
@@ -72,7 +72,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "topology.eulerCorrection")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 public class EulerCorrection<B extends BooleanType<B>>
         implements Computers.Arity1<RandomAccessibleInterval<B>, DoubleType> {
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/conversionLoss/IdentityLossReporter.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/conversionLoss/IdentityLossReporter.java
@@ -18,7 +18,7 @@ import org.scijava.types.Nil;
 @Plugin(type = Op.class, name = "lossReporter")
 @Parameter(key = "fromType")
 @Parameter(key = "toType")
-@Parameter(key = "maximumLoss", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "maximumLoss")
 public class IdentityLossReporter<T> implements LossReporter<T, T> {
 
 	@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/conversionLoss/PrimitiveArrayLossReporters.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/conversionLoss/PrimitiveArrayLossReporters.java
@@ -25,7 +25,7 @@ public class PrimitiveArrayLossReporters {
 //@Plugin(type = Op.class, name = "lossReporter")
 //@Parameter(key = "fromNil")
 //@Parameter(key = "toNil")
-//@Parameter(key = "loss", itemIO = ItemIO.OUTPUT)
+//@Parameter(key = "loss")
 //public static class ArrayLossReporter<T extends Number, U extends Number> implements LossReporter<T[], U[]>{
 //
 //	@OpDependency(name = "lossReporter")

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/create/CreateOpCollection.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/create/CreateOpCollection.java
@@ -29,6 +29,6 @@ public class CreateOpCollection {
 	};
 	
 	@OpField(names = "create", priority = Priority.HIGH)
-	@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "output")
 	public static final Producer<Double> doubleSource = () -> 0.0;
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/Computers.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 
 import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
-import org.scijava.param.Mutable;
+import org.scijava.param.Container;
 import org.scijava.types.Types;
 
 /**
@@ -207,7 +207,7 @@ public final class Computers {
 		Consumer<O>
 	{
 
-		void compute(@Mutable O out);
+		void compute(@Container O out);
 
 		@Override
 		default void accept(final O out)
@@ -221,7 +221,7 @@ public final class Computers {
 		BiConsumer<I, O>
 	{
 
-		void compute(I in, @Mutable O out);
+		void compute(I in, @Container O out);
 
 		@Override
 		default void accept(final I in, final O out)
@@ -235,7 +235,7 @@ public final class Computers {
 		Consumers.Arity3<I1, I2, O>
 	{
 
-		void compute(I1 in1, I2 in2, @Mutable O out);
+		void compute(I1 in1, I2 in2, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final O out)
@@ -249,7 +249,7 @@ public final class Computers {
 		Consumers.Arity4<I1, I2, I3, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final O out)
@@ -263,7 +263,7 @@ public final class Computers {
 		Consumers.Arity5<I1, I2, I3, I4, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final O out)
@@ -277,7 +277,7 @@ public final class Computers {
 		Consumers.Arity6<I1, I2, I3, I4, I5, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final O out)
@@ -291,7 +291,7 @@ public final class Computers {
 		Consumers.Arity7<I1, I2, I3, I4, I5, I6, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final O out)
@@ -305,7 +305,7 @@ public final class Computers {
 		Consumers.Arity8<I1, I2, I3, I4, I5, I6, I7, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final O out)
@@ -319,7 +319,7 @@ public final class Computers {
 		Consumers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final O out)
@@ -333,7 +333,7 @@ public final class Computers {
 		Consumers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final O out)
@@ -347,7 +347,7 @@ public final class Computers {
 		Consumers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final O out)
@@ -361,7 +361,7 @@ public final class Computers {
 		Consumers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final O out)
@@ -375,7 +375,7 @@ public final class Computers {
 		Consumers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final I12 in12, final O out)
@@ -389,7 +389,7 @@ public final class Computers {
 		Consumers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final I12 in12, final I13 in13, final O out)
@@ -403,7 +403,7 @@ public final class Computers {
 		Consumers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final I12 in12, final I13 in13, final I14 in14, final O out)
@@ -417,7 +417,7 @@ public final class Computers {
 		Consumers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final I12 in12, final I13 in13, final I14 in14, final I15 in15, final O out)
@@ -431,7 +431,7 @@ public final class Computers {
 		Consumers.Arity17<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>
 	{
 
-		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, I16 in16, @Mutable O out);
+		void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, I16 in16, @Container O out);
 
 		@Override
 		default void accept(final I1 in1, final I2 in2, final I3 in3, final I4 in4, final I5 in5, final I6 in6, final I7 in7, final I8 in8, final I9 in9, final I10 in10, final I11 in11, final I12 in12, final I13 in13, final I14 in14, final I15 in15, final I16 in16, final O out)

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/function/OpWrappers.java
@@ -10,7 +10,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.scijava.ops.util.OpWrapper;
-import org.scijava.param.Mutable;
 import org.scijava.plugin.Plugin;
 import org.scijava.types.GenericTyped;
 
@@ -556,7 +555,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(@Mutable O out) //
+				public void compute(O out) //
 				{
 					op.compute(out);
 				}
@@ -587,7 +586,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I in, @Mutable O out) //
+				public void compute(I in, O out) //
 				{
 					op.compute(in, out);
 				}
@@ -618,7 +617,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, O out) //
 				{
 					op.compute(in1, in2, out);
 				}
@@ -649,7 +648,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, O out) //
 				{
 					op.compute(in1, in2, in3, out);
 				}
@@ -680,7 +679,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, O out) //
 				{
 					op.compute(in1, in2, in3, in4, out);
 				}
@@ -711,7 +710,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, out);
 				}
@@ -742,7 +741,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, out);
 				}
@@ -773,7 +772,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, out);
 				}
@@ -804,7 +803,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, out);
 				}
@@ -835,7 +834,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, out);
 				}
@@ -866,7 +865,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, out);
 				}
@@ -897,7 +896,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, out);
 				}
@@ -928,7 +927,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, out);
 				}
@@ -959,7 +958,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, out);
 				}
@@ -990,7 +989,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, out);
 				}
@@ -1021,7 +1020,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, out);
 				}
@@ -1052,7 +1051,7 @@ public class OpWrappers {
 			{
 
 				@Override
-				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, I16 in16, @Mutable O out) //
+				public void compute(I1 in1, I2 in2, I3 in3, I4 in4, I5 in5, I6 in6, I7 in7, I8 in8, I9 in9, I10 in10, I11 in11, I12 in12, I13 in13, I14 in14, I15 in15, I16 in16, O out) //
 				{
 					op.compute(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, out);
 				}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -638,8 +638,8 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 		if (fmts == null)
 			return null;
 
-		EnumSet<ItemIO> inIos = EnumSet.of(ItemIO.BOTH, ItemIO.INPUT);
-		EnumSet<ItemIO> outIos = EnumSet.of(ItemIO.BOTH, ItemIO.OUTPUT);
+		EnumSet<ItemIO> inIos = EnumSet.of(ItemIO.INPUT, ItemIO.CONTAINER, ItemIO.MUTABLE);
+		EnumSet<ItemIO> outIos = EnumSet.of(ItemIO.OUTPUT, ItemIO.CONTAINER, ItemIO.MUTABLE);
 
 		Type[] inputs = fmts.stream().filter(fmt -> inIos.contains(fmt.itemIO())).map(fmt -> fmt.type())
 				.toArray(Type[]::new);

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/math/Normalize.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/math/Normalize.java
@@ -16,7 +16,7 @@ public class Normalize {
 	@Parameter(key = "numbers")
 	@Parameter(key = "newMin")
 	@Parameter(key = "newMax")
-	@Parameter(key = "normalized", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "normalized")
 	public static class MathMinMaxNormalizeFunction implements Functions.Arity3<double[], Double, Double, double[]> {
 
 		@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/math/Zero.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/math/Zero.java
@@ -7,7 +7,6 @@ import org.scijava.ops.core.OpCollection;
 import org.scijava.ops.function.Computers;
 import org.scijava.param.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.struct.ItemIO;
 
 @Plugin(type = OpCollection.class)
 public class Zero {
@@ -17,7 +16,7 @@ public class Zero {
 	// --------- Computers ---------
 
 	@OpField(names = NAMES)
-	@Parameter(key = "resultArray", itemIO = ItemIO.BOTH)
+	@Parameter(key = "resultArray")
 	public static final Computers.Arity0<double[]> MathParallelPointwiseZeroDoubleArrayComputer = out -> {
 		IntStream.range(0, out.length).parallel().forEach(i -> {
 			out[i] = 0.0;

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/Identity.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/Identity.java
@@ -10,7 +10,7 @@ import org.scijava.struct.ItemIO;
 @Unsimplifiable
 @Plugin(type = Op.class, name = "simplify, focus")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 public class Identity<T> implements Function<T, T> {
 
 	public Identity() {

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/PrimitiveListSimplifier.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/PrimitiveListSimplifier.java
@@ -15,7 +15,7 @@ import org.scijava.struct.ItemIO;
  */
 @Plugin(type = Op.class, name = "simplify")
 @Parameter(key = "inList")
-@Parameter(key = "simpleList", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "simpleList")
 public class PrimitiveListSimplifier<T extends Number> implements Function<List<T>, List<Number>>{
 
 	@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplificationUtils.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplificationUtils.java
@@ -24,6 +24,7 @@ import org.scijava.ops.function.Computers;
 import org.scijava.ops.matcher.MatchingUtils;
 import org.scijava.ops.matcher.OpRef;
 import org.scijava.ops.util.AnnotationUtils;
+import org.scijava.param.Container;
 import org.scijava.param.Mutable;
 import org.scijava.param.ParameterStructs;
 import org.scijava.types.Nil;
@@ -120,21 +121,23 @@ public class SimplificationUtils {
 	}
 
 	/**
-	 * Finds the {@link Mutable} argument of a {@link FunctionalInterface}'s
-	 * singular abstract method. If there is no argument annotated with
-	 * {@code Mutable}, then it is assumed that no arguments are mutable and that
-	 * the output of the functional {@link Method} is its output. We also assume
-	 * that only one argument is annotated.
+	 * Finds the {@link Mutable} or {@link Container} argument of a
+	 * {@link FunctionalInterface}'s singular abstract method. If there is no
+	 * argument annotated with {@code Mutable} or {@code Container}, then it is
+	 * assumed that no arguments are mutable and that the output of the functional
+	 * {@link Method} is its output. We also assume that only one argument is
+	 * annotated.
 	 * 
 	 * @param c - the {@link Class} extending a {@link FunctionalInterface}
-	 * @return the index of the mutable argument (or -1 iff the output is
-	 *         returned).
+	 * @return the index of the mutable argument (or -1 iff the output is returned).
 	 */
 	public static int findMutableArgIndex(Class<?> c) {
 		Method fMethod = findFMethod(c);
 		for (int i = 0; i < fMethod.getParameterCount(); i++) {
 			if (AnnotationUtils.getMethodParameterAnnotation(fMethod, i,
 				Mutable.class) != null) return i;
+			if (AnnotationUtils.getMethodParameterAnnotation(fMethod, i,
+				Container.class) != null) return i;
 		}
 		return -1;
 	}

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpInfo.java
@@ -15,7 +15,6 @@ import org.scijava.ops.core.Op;
 import org.scijava.ops.matcher.OpMatchingException;
 import org.scijava.param.ParameterStructs;
 import org.scijava.param.ValidityException;
-import org.scijava.struct.ItemIO;
 import org.scijava.struct.Member;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
@@ -81,12 +80,10 @@ public class SimplifiedOpInfo implements OpInfo {
 	 * <li>a penalty defined as a lossiness heuristic of this simplification. This
 	 * penalty is the sum of:
 	 * <ul>
-	 * <li>the loss undertaken by converting each of the Op's inputs (as defined
-	 * by an {@link ItemIO#INPUT} or {@link ItemIO#BOTH} annotation) from the ref
+	 * <li>the loss undertaken by converting each of the Op's inputs from the ref
 	 * type to the info type
-	 * <li>the loss undertaken by converting each of the Op's outputs (as defined
-	 * by an {@link ItemIO#OUTPUT} or {@link ItemIO#BOTH} annotation) from the
-	 * info type to the ref type
+	 * <li>the loss undertaken by converting each of the Op's outputs from the info
+	 * type to the ref type
 	 * </ul>
 	 * </ul>
 	 */

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/stats/Mean.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/stats/Mean.java
@@ -13,7 +13,7 @@ public class Mean {
 
 	@Plugin(type = Op.class, name = "stats.mean")
 	@Parameter(key = "iterable")
-	@Parameter(key = "mean", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "mean")
 	public static class MeanFunction <N, O> implements Function<Iterable<N>, O>{
 
 		@OpDependency(name = "math.add")

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/stats/Size.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/stats/Size.java
@@ -12,7 +12,7 @@ public class Size {
 
 	@Plugin(type = Op.class, name = "stats.size")
 	@Parameter(key = "iterable")
-	@Parameter(key = "size", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "size")
 	public static class StatsSizeFunction<T> implements Function<Iterable<T>, Long>{
 
 		@Override
@@ -23,7 +23,7 @@ public class Size {
 	
 	   @Plugin(type = Op.class, name = "stats.size")
 	    @Parameter(key = "iterable")
-	    @Parameter(key = "size", itemIO = ItemIO.OUTPUT)
+	    @Parameter(key = "size")
 	    public static class StatsSizeFunctionDouble<T> implements Function<Iterable<T>, Double>{
 
 	        @Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/util/Inject.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/util/Inject.java
@@ -33,14 +33,14 @@ public class Inject {
 		public static void inputs(StructInstance<?> instance, Object... objs) {
 			unsafe(filterAccessibles(getAccessibles(instance), m -> {
 				ItemIO ioType = m.member().getIOType();
-				return EnumSet.of(ItemIO.BOTH, ItemIO.INPUT).contains(ioType);
+				return EnumSet.of(ItemIO.INPUT, ItemIO.CONTAINER, ItemIO.MUTABLE).contains(ioType);
 			}), objs);
 		}
 
 		public static void outputs(StructInstance<?> instance, Object... objs) {
 			unsafe(filterAccessibles(getAccessibles(instance), m -> {
 				ItemIO ioType = m.member().getIOType();
-				return EnumSet.of(ItemIO.BOTH, ItemIO.OUTPUT).contains(ioType);
+				return EnumSet.of(ItemIO.OUTPUT, ItemIO.CONTAINER, ItemIO.MUTABLE).contains(ioType);
 			}), objs);
 		}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/Container.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/Container.java
@@ -1,0 +1,18 @@
+package org.scijava.param;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a parameter as a container: the value of the given
+ * argument will be populated by the algorithm during execution.
+ * 
+ * @see Computers
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+public @interface Container {
+
+}

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/Mutable.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/Mutable.java
@@ -5,7 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**Annotation to mark a method parameter as mutable.  */
+/**
+ * Annotation to mark a parameter as mutable: the value of the given argument
+ * will be altered by the algorithm during execution.
+ * 
+ * @see Inplaces
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE_USE)
 public @interface Mutable {

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
@@ -4,7 +4,6 @@ package org.scijava.param;
 import io.leangen.geantyref.AnnotationFormatException;
 import io.leangen.geantyref.TypeFactory;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -325,14 +324,16 @@ public final class ParameterStructs {
 	}
 	
 	/**
-	 * Returns a list of {@link FunctionalMethodType}s describing the input and output
-	 * types of the functional method of the specified functional type. In doing so,
-	 * the return type of the method will me marked as {@link ItemIO#OUTPUT} and the
-	 * all method parameters as {@link ItemIO#OUTPUT}, except for parameters annotated
-	 * with {@link Mutable} which will be marked as {@link ItemIO#BOTH}. If the specified
-	 * type does not have a functional method in its hierarchy, null will be
-	 * returned.<br>
-	 * The order will be the following: method parameters from left to right, return type
+	 * Returns a list of {@link FunctionalMethodType}s describing the input and
+	 * output types of the functional method of the specified functional type. In
+	 * doing so, the return type of the method will me marked as
+	 * {@link ItemIO#OUTPUT} and the all method parameters as {@link ItemIO#OUTPUT},
+	 * except for parameters annotated with {@link Container} or {@link Mutable}
+	 * which will be marked as {@link ItemIO#CONTAINER} or {@link ItemIO#MUTABLE}
+	 * respectively. If the specified type does not have a functional method in its
+	 * hierarchy, {@code null} will be returned.<br>
+	 * The order will be the following: method parameters from left to right, then
+	 * return type.
 	 * 
 	 * @param functionalType
 	 * @return
@@ -349,8 +350,14 @@ public final class ParameterStructs {
 		List<FunctionalMethodType> out = new ArrayList<>();
 		int i = 0;
 		for (Type t : Types.getExactParameterTypes(functionalMethod, paramfunctionalType)) {
-			boolean isMutable = AnnotationUtils.getMethodParameterAnnotation(functionalMethod, i, Mutable.class) != null;
-			out.add(new FunctionalMethodType(t, isMutable ? ItemIO.BOTH : ItemIO.INPUT));
+			final ItemIO ioType;
+			if (AnnotationUtils.getMethodParameterAnnotation(functionalMethod, i, Container.class) != null)
+				ioType = ItemIO.CONTAINER;
+			else if (AnnotationUtils.getMethodParameterAnnotation(functionalMethod, i, Mutable.class) != null)
+				ioType = ItemIO.MUTABLE;
+			else
+				ioType = ItemIO.INPUT;
+			out.add(new FunctionalMethodType(t, ioType));
 			i++;
 		}
 		
@@ -391,9 +398,10 @@ public final class ParameterStructs {
 	/**
 	 * Create new instances of {@link Parameter} annotations having default names (key) and the {@link ItemIO}
 	 * from the specified list of {@link FunctionalMethodType}s. Default names will be:<br><br>
-	 * 'mutable{index}' for {@link ItemIO#BOTH}<br>
 	 * 'input{index}' for {@link ItemIO#INPUT}<br>
-	 * 'output{index}' for {@link ItemIO#OUTPUT}<br><br>
+	 * 'output{index}' for {@link ItemIO#OUTPUT}<br>
+	 * 'container{index}' for {@link ItemIO#CONTAINER}<br>
+	 * 'mutable{index}' for {@link ItemIO#MUTABLE}<br><br>
 	 * with {index} being counted individually.
 	 * 
 	 * This is used to infer the annotations for {@link FunctionalParameterMember}s if the {@link Parameter} is not
@@ -405,25 +413,25 @@ public final class ParameterStructs {
 	private static Parameter[] synthesizeParameterAnnotations(final List<FunctionalMethodType> fmts) {
 		List<Parameter> params = new ArrayList<>();
 		
-		int ins, outs, insOuts;
-		ins = outs = insOuts = 1;
+		int ins, outs, containers, mutables;
+		ins = outs = containers = mutables = 1;
 		for (FunctionalMethodType fmt : fmts) {
 			Map<String, Object> paramValues = new HashMap<>();
 			paramValues.put(Parameter.ITEMIO_FIELD_NAME, fmt.itemIO());
 			
 			String key;
 			switch (fmt.itemIO()) {
-			case BOTH:
-				key = "mutable" + insOuts;
-				insOuts++;
-				break;
 			case INPUT:
-				key = "input" + ins;
-				ins++;
+				key = "input" + ins++;
 				break;
 			case OUTPUT:
-				key = "output" + outs;
-				outs++;
+				key = "output" + outs++;
+				break;
+			case CONTAINER:
+				key = "container" + containers++;
+				break;
+			case MUTABLE:
+				key = "mutable" + mutables++;
 				break;
 			default:
 				throw new RuntimeException("Unexpected ItemIO type encountered!");
@@ -639,11 +647,11 @@ public final class ParameterStructs {
 			valid = false;
 		}
 
-		if (param.itemIO() == ItemIO.BOTH && isImmutable(type)) {
-			// NB: The BOTH type signifies that the parameter will be changed
-			// in-place somehow. But immutable parameters cannot be changed in
-			// such a manner, so it makes no sense to label them as BOTH.
-			final String error = "Immutable BOTH parameter: " + name + " (" + type.getName() + " is immutable)";
+		if ((param.itemIO() == ItemIO.MUTABLE || param.itemIO() == ItemIO.CONTAINER) && isImmutable(type)) {
+			// NB: The MUTABLE and CONTAINER types signify that the parameter
+			// will be written to, but immutable parameters cannot be changed in
+			// such a manner, so it makes no sense to label them as such.
+			final String error = "Immutable " + param.itemIO() + " parameter: " + name + " (" + type.getName() + " is immutable)";
 			problems.add(new ValidityProblem(error));
 			valid = false;
 		}

--- a/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/param/ParameterStructs.java
@@ -340,7 +340,9 @@ public final class ParameterStructs {
 	 */
 	public static List<FunctionalMethodType> findFunctionalMethodTypes(Type functionalType) {
 		Method functionalMethod = findFunctionalMethod(Types.raw(functionalType));
-		if (functionalMethod == null) return null;
+		if (functionalMethod == null) throw new IllegalArgumentException("Type " +
+			functionalType +
+			" is not a functional type, thus its functional method types cannot be determined");
 		
 		Type paramfunctionalType = functionalType;
 		if (functionalType instanceof Class) {
@@ -491,9 +493,13 @@ public final class ParameterStructs {
 	private static void parseFunctionalParameters(final ArrayList<Member<?>> items, final Set<String> names, final ArrayList<ValidityProblem> problems,
 			AnnotatedElement annotationBearer, Type type, final boolean synthesizeAnnotations) {
 		//Search for the functional method of 'type' and map its signature to ItemIO
-		List<FunctionalMethodType> fmts = findFunctionalMethodTypes(type);
-		if (fmts == null) {
-			problems.add(new ValidityProblem("Could not find functional method of " + type.getTypeName()));
+		List<FunctionalMethodType> fmts;
+		try {
+			fmts = findFunctionalMethodTypes(type);
+		}
+		catch (IllegalArgumentException e) {
+			problems.add(new ValidityProblem("Could not find functional method of " +
+				type.getTypeName()));
 			return;
 		}
 		

--- a/scijava/scijava-ops/src/main/java/org/scijava/struct/ItemIO.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/struct/ItemIO.java
@@ -32,38 +32,49 @@
 
 package org.scijava.struct;
 
-import org.scijava.param.Mutable;
-
 /**
- * Defines the input/output type of a module.
+ * Defines the input/output type of a struct {@link Member}.
  *
  * @author Curtis Rueden
  * @author David Kolb
  */
 public enum ItemIO {
 	/**
-	 * The item is an input for the module.
+	 * The item is an input for the operation.
 	 */
 	INPUT, 
 	/**
-	 * The item is an output for the module.
+	 * The item is an output for the operation.
 	 */
 	OUTPUT,
 	/**
-	 * The item is both an input and an output for the module. This type is
-	 * used to indicate an object that is mutated somehow during execution.
+	 * The item is a hybrid input/output for the operation, whose structure is fixed
+	 * but whose content will be populated during execution of the operation.
+	 * 
+	 * @see org.scijava.param.Container
+	 * @see org.scijava.ops.function.Computers
 	 */
-	BOTH, 
+	CONTAINER,
 	/**
-	 * Marker to specify that one of the above should be inferred automatically 
-	 * during structification. I.e. the type can be inferred from the functional method 
-	 * signature of a functional type. The return type will always be ItemIO.Output and 
-	 * method parameters should be ItemIO.Input. If a method parameter is ItemIO.Both, 
-	 * it should be annotated with {@link Mutable}.
+	 * The item is a hybrid input/output for the operation, whose current value will
+	 * be used as input to the computation, but subsequently overwritten with a
+	 * result.
+	 * 
+	 * @see org.scijava.param.Mutable
+	 * @see org.scijava.ops.function.Inplaces
+	 */
+	MUTABLE,
+	/**
+	 * The type of the item should be inferred automatically during structification.
+	 * For instance, for methods of functional interfaces, the types can be inferred
+	 * as follows: the return type (if not {@code void}) is {@code ItemIO.OUTPUT}
+	 * and method parameters are typically {@code ItemIO.INPUT}, although method
+	 * parameters could be annotated to indicate they should be treated as
+	 * {@code ItemIO.CONTAINER} or {@code ItemIO.MUTABLE} type instead.
 	 */
 	AUTO,
 	/**
-	 * TODO
+	 * The type of the item is none of the above.
 	 */
 	NONE
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/struct/Member.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/struct/Member.java
@@ -39,12 +39,12 @@ public interface Member<T> {
 
 	/** Gets whether the member is an input. */
 	default boolean isInput() {
-		return getIOType() == ItemIO.INPUT || getIOType() == ItemIO.BOTH;
+		return getIOType() == ItemIO.INPUT || getIOType() == ItemIO.CONTAINER || getIOType() == ItemIO.MUTABLE;
 	}
 
 	/** Gets whether the member is an output. */
 	default boolean isOutput() {
-		return getIOType() == ItemIO.OUTPUT || getIOType() == ItemIO.BOTH;
+		return getIOType() == ItemIO.OUTPUT || getIOType() == ItemIO.CONTAINER || getIOType() == ItemIO.MUTABLE;
 	}
 
 	default boolean isStruct() {

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCachingTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpCachingTest.java
@@ -151,7 +151,7 @@ public class OpCachingTest extends AbstractTestEnvironment {
 }
 
 @Plugin(type = Op.class, name = "test.complicatedOp")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class ComplicatedOp implements Producer<String> {
 
 	@OpDependency(name = "test.basicOp")

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpEnvironmentTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpEnvironmentTest.java
@@ -77,7 +77,7 @@ public class OpEnvironmentTest extends AbstractTestEnvironment{
  *
  * @author Gabriel Selzer
  */
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class OpifyOp implements Producer<String> {
 
 	@Override

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTest.java
@@ -90,7 +90,7 @@ public class OpMethodTest extends AbstractTestEnvironment {
 //	// factory method.
 //	@Parameter(key = "numericString")
 //	// Refers to the output parameter of the function.
-//	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
+//	@Parameter(key = "parsedInteger")
 //	public static Integer createParseIntegerOp(String in) {
 //		return Integer.parseInt(in);
 //	}
@@ -98,7 +98,7 @@ public class OpMethodTest extends AbstractTestEnvironment {
 //	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
 //	@Parameter(key = "numericString1")
 //	@Parameter(key = "numericString2")
-//	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+//	@Parameter(key = "multipliedNumericStrings")
 //	public static Integer createMultiplyNumericStringsOp(final String in1,
 //		final String in2, @OpDependency(
 //			name = "test.parseInteger") Function<String, Integer> parseIntegerOp)

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpMethodTestOps.java
@@ -47,7 +47,7 @@ public class OpMethodTestOps {
 
 	// -- Functions -- //
 	@OpMethod(names = "test.multiplyNumericStrings", type = Producer.class)
-	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "multipliedNumericStrings")
 	public static Integer multiplyNumericStringsProducer() {
 		return Integer.valueOf(1);
 	}

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/OpPriorityTest.java
@@ -42,7 +42,7 @@ import org.scijava.struct.ItemIO;
 public class OpPriorityTest extends AbstractTestEnvironment {
 	
 	@Plugin(type = Op.class, name = "test.priority", priority = Priority.HIGH)
-	@Parameter(key = "result", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "result")
 	private static final class testDouble implements Producer<Number>{
 		@Override
 		public Number create() {
@@ -51,7 +51,7 @@ public class OpPriorityTest extends AbstractTestEnvironment {
 	}
 
 	@Plugin(type = Op.class, name = "test.priority", priority = Priority.LOW)
-	@Parameter(key = "result", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "result")
 	private static final class testFloat implements Producer<Number>{
 		@Override
 		public Number create() {

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/TestOps.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/TestOps.java
@@ -27,7 +27,7 @@ public class TestOps {
 
 	@Plugin(type = Op.class, name = "test.liftSqrt")
 	@Parameter(key = "in")
-	@Parameter(key = "out", itemIO = ItemIO.BOTH)
+	@Parameter(key = "out")
 	public static class LiftSqrt implements Computers.Arity1<double[], double[]> {
 
 		@Override
@@ -43,7 +43,7 @@ public class TestOps {
 	@Plugin(type = Op.class, name = "test.adaptersC")
 	@Parameter(key = "in1")
 	@Parameter(key = "in2")
-	@Parameter(key = "out", itemIO = ItemIO.BOTH)
+	@Parameter(key = "out")
 	public static class testAddTwoArraysComputer implements Computers.Arity2<double[], double[], double[]> {
 		@Override
 		public void compute(double[] arr1, double[] arr2, double[] out) {
@@ -55,7 +55,7 @@ public class TestOps {
 	@Plugin(type = Op.class, name = "test.adaptersF")
 	@Parameter(key = "in1")
 	@Parameter(key = "in2")
-	@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "out")
 	public static class testAddTwoArraysFunction implements BiFunction<double[], double[], double[]> {
 		@Override
 		public double[] apply(double[] arr1, double[] arr2) {
@@ -70,7 +70,7 @@ public class TestOps {
 
 	@Plugin(type = Op.class, name = "test.liftFunction")
 	@Parameter(key = "in")
-	@Parameter(key = "out", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "out")
 	public static class liftFunction implements Function<Double, Double> {
 		@Override
 		public Double apply(Double in) {
@@ -80,7 +80,7 @@ public class TestOps {
 
 	@Plugin(type = Op.class, name = "test.liftComputer")
 	@Parameter(key = "in")
-	@Parameter(key = "out", itemIO = ItemIO.BOTH)
+	@Parameter(key = "out")
 	public static class liftComputer implements Computers.Arity1<double[], double[]> {
 		@Override
 		public void compute(double[] in, double[] out) {

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/OpAdaptationPriorityTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/adapt/OpAdaptationPriorityTest.java
@@ -76,20 +76,20 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment {
 
 	@OpField(names = "test.priorityOp")
 	@Parameter(key = "input")
-	@Parameter(key = "output", itemIO = ItemIO.BOTH)
+	@Parameter(key = "output")
 	public static final Computers.Arity1<Double, PriorityThing> priorityOp = (in,
 		out) -> {
 		out.increasePriority(in);
 	};
 
 	@OpField(names = "create")
-	@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "output")
 	public static final Producer<PriorityThing> priorityThingProducer =
 		() -> new PriorityThing(10000);
 
 	@OpField(names = "create")
 	@Parameter(key = "input")
-	@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "output")
 	public static final Function<Double, PriorityThing> priorityThingFunction = (
 		in) -> new PriorityThing(in);
 

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
@@ -90,7 +90,7 @@ public class MatchingWithAnyTest extends AbstractTestEnvironment {
 @Plugin(type = Op.class, name = "test.functionAndLongToLong")
 @Parameter(key = "input")
 @Parameter(key = "op")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class FunctionAndLongToLong implements BiFunction<Function<Long, Long>, Long, Long> {
 
 	@Override
@@ -103,7 +103,7 @@ class FunctionAndLongToLong implements BiFunction<Function<Long, Long>, Long, Lo
 @Plugin(type = Op.class, name = "test.integerAndLongAndNotAnyComputer")
 @Parameter(key = "input1")
 @Parameter(key = "input2")
-@Parameter(key = "output", itemIO = ItemIO.BOTH)
+@Parameter(key = "output")
 class IntegerAndLongAndNotAnyComputer implements Computers.Arity2<Integer, Long, MutableNotAny> {
 
 	@Override
@@ -126,7 +126,7 @@ class MutableNotAny {
 }
 
 @Plugin(type = Op.class, name = "create, create.mutableNotAny")
-@Parameter(key = "mutableNotAny", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "mutableNotAny")
 class MutableNotAnyCreator implements Producer<MutableNotAny> {
 
 	@Override
@@ -168,7 +168,7 @@ class NestedThing<U, V extends Thing<?>> {
 
 @Plugin(type = Op.class, name = "test.any")
 @Parameter(key = "thing")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class ThingFunction implements Function<Thing<String>, Double> {
 
 	@Override
@@ -180,7 +180,7 @@ class ThingFunction implements Function<Thing<String>, Double> {
 
 @Plugin(type = Op.class, name = "test.exceptionalAny")
 @Parameter(key = "thing")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class ExceptionalThingFunction implements Function<ExceptionalThing<String>, Double> {
 
 	@Override
@@ -193,7 +193,7 @@ class ExceptionalThingFunction implements Function<ExceptionalThing<String>, Dou
 
 @Plugin(type = Op.class, name = "test.nestedAny")
 @Parameter(key = "nestedThing")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class NestedThingFunction implements Function<NestedThing<String, Thing<String>>, Double> {
 
 	@Override

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/matcher/MatchingWithAnyTest.java
@@ -81,7 +81,7 @@ public class MatchingWithAnyTest extends AbstractTestEnvironment {
 	public void testRunAnyFunction1FromComputer2() {
 		final int in1 = 11;
 		final long in2 = 31;
-		final MutableNotAny out = ops.op("test.integerAndLongAndNotAnyComputer").input(in1, in2).outType(MutableNotAny.class).apply();
+		final StringContainer out = ops.op("test.integerAndLongAndNotAnyComputer").input(in1, in2).outType(StringContainer.class).apply();
 		assertEquals(Long.toString(in1 + in2), out.getValue());
 	}
 	
@@ -104,15 +104,15 @@ class FunctionAndLongToLong implements BiFunction<Function<Long, Long>, Long, Lo
 @Parameter(key = "input1")
 @Parameter(key = "input2")
 @Parameter(key = "output")
-class IntegerAndLongAndNotAnyComputer implements Computers.Arity2<Integer, Long, MutableNotAny> {
+class IntegerAndLongAndNotAnyComputer implements Computers.Arity2<Integer, Long, StringContainer> {
 
 	@Override
-	public void compute(Integer in1, Long in2, @Mutable MutableNotAny out) {
+	public void compute(Integer in1, Long in2, StringContainer out) {
 		out.setValue(Long.toString(in1 + in2));
 	}
 }
 
-class MutableNotAny {
+class StringContainer {
 
 	private String value;
 
@@ -125,13 +125,13 @@ class MutableNotAny {
 	}
 }
 
-@Plugin(type = Op.class, name = "create, create.mutableNotAny")
-@Parameter(key = "mutableNotAny")
-class MutableNotAnyCreator implements Producer<MutableNotAny> {
+@Plugin(type = Op.class, name = "create, create.stringContainer")
+@Parameter(key = "stringContainer")
+class StringContainerCreator implements Producer<StringContainer> {
 
 	@Override
-	public MutableNotAny create() {
-		return new MutableNotAny();
+	public StringContainer create() {
+		return new StringContainer();
 	}
 }
 

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/monitor/OpMonitorTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/monitor/OpMonitorTest.java
@@ -86,7 +86,7 @@ public class OpMonitorTest extends AbstractTestEnvironment {
 
 @Plugin(type = Op.class, name = "test.opMonitor")
 @Parameter(key = "monitor")
-@Parameter(key = "bigInteger", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "bigInteger")
 class InfiniteOp implements Function<OpMonitor, BigInteger> {
 
 	@Override
@@ -107,7 +107,7 @@ class InfiniteOp implements Function<OpMonitor, BigInteger> {
 @Plugin(type = Op.class, name = "test.progress")
 @Parameter(key = "monitor")
 @Parameter(key = "target")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class CountingOp implements BiFunction<OpMonitor, BigInteger, BigInteger> {
 
 	@Override

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/util/OpsAsParametersTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/util/OpsAsParametersTest.java
@@ -22,13 +22,13 @@ public class OpsAsParametersTest extends AbstractTestEnvironment {
 
 	@OpField(names = "test.parameter.computer")
 	@Parameter(key = "input")
-	@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "output")
 	public final Function<Number, Double> func = (x) -> x.doubleValue();
 
 	@OpField(names = "test.parameter.op")
 	@Parameter(key = "inputList")
 	@Parameter(key = "op")
-	@Parameter(key = "outputList", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "outputList")
 	public final BiFunction<List<Number>, Function<Number, Double>, List<Double>> biFunc = (x, op) -> {
 		List<Double> output = new ArrayList<>();
 		for (Number n : x)
@@ -87,7 +87,7 @@ public class OpsAsParametersTest extends AbstractTestEnvironment {
 
 @Plugin(type = Op.class, name = "test.parameter.class")
 @Parameter(key = "input")
-@Parameter(key = "output", itemIO = ItemIO.OUTPUT)
+@Parameter(key = "output")
 class FuncClass implements Function<Number, Double> {
 
 	@Override

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Computers.vm
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 
 import org.scijava.ops.OpEnvironment;
 import org.scijava.types.Nil;
-import org.scijava.param.Mutable;
+import org.scijava.param.Container;
 import org.scijava.types.Types;
 
 /**

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Globals.list
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/Globals.list
@@ -99,7 +99,7 @@ applyArgs = ```
 computeParams = ```
 { arity ->
   typeParams = typeParamsList(arity)
-  typeParams.set(arity, "@Mutable " + typeParams.get(arity))
+  typeParams.set(arity, "@Container " + typeParams.get(arity))
   String.join(', ', typeParams)
 }
 ```

--- a/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/OpWrappers.vm
+++ b/scijava/scijava-ops/templates/main/java/org/scijava/ops/function/OpWrappers.vm
@@ -10,7 +10,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.scijava.ops.util.OpWrapper;
-import org.scijava.param.Mutable;
 import org.scijava.plugin.Plugin;
 import org.scijava.types.GenericTyped;
 

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTest.vm
@@ -90,7 +90,7 @@ public class OpMethodTest extends AbstractTestEnvironment {
 //	// factory method.
 //	@Parameter(key = "numericString")
 //	// Refers to the output parameter of the function.
-//	@Parameter(key = "parsedInteger", itemIO = ItemIO.OUTPUT)
+//	@Parameter(key = "parsedInteger")
 //	public static Integer createParseIntegerOp(String in) {
 //		return Integer.parseInt(in);
 //	}
@@ -98,7 +98,7 @@ public class OpMethodTest extends AbstractTestEnvironment {
 //	@OpMethod(names = "test.multiplyNumericStrings", type = BiFunction.class)
 //	@Parameter(key = "numericString1")
 //	@Parameter(key = "numericString2")
-//	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+//	@Parameter(key = "multipliedNumericStrings")
 //	public static Integer createMultiplyNumericStringsOp(final String in1,
 //		final String in2, @OpDependency(
 //			name = "test.parseInteger") Function<String, Integer> parseIntegerOp)

--- a/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
+++ b/scijava/scijava-ops/templates/test/java/org/scijava/ops/OpMethodTestOps.vm
@@ -47,7 +47,7 @@ public class OpMethodTestOps {
 
 	// -- Functions -- //
 	@OpMethod(names = "test.multiplyNumericStrings", type = Producer.class)
-	@Parameter(key = "multipliedNumericStrings", itemIO = ItemIO.OUTPUT)
+	@Parameter(key = "multipliedNumericStrings")
 	public static Integer multiplyNumericStringsProducer() {
 		return Integer.valueOf(1);
 	}


### PR DESCRIPTION
Computer outputs aren't exactly mutable in the same way as inplace arguments are. Rather, they are preallocated empty containers whose contents will be filled in by the invoked computation.

My strong intuition is that having this distinction baked into the type annotations, and accessible at runtime, may be somehow helpful later.
    
This also adds a corresponding `ItemIO.CONTAINER` value for struct members; the `ItemIO.BOTH` value is retired in favor of `ItemIO.MUTABLE`, which corresponds to the `@Mutable` annotation for the `Inplace` interfaces.
