### PR TITLE
Prioritize a more powerful version of setHints

### DIFF
--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/Hints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/Hints.java
@@ -20,25 +20,25 @@ import java.util.Map;
  */
 public interface Hints {
 
-	default String setHint(String hint) {
-		int delimIndex = hint.indexOf(getDelimiter());
+	default String set(String hint) {
+		int delimIndex = hint.indexOf(hintDelimiter());
 		String hintType = hint.substring(0, delimIndex);
 		String setting = hint.substring(delimIndex + 1);
-		return setHint(hintType, setting);
+		return set(hintType, setting);
 	}
 
-	public String setHint(String hintType, Object setting);
+	public String set(String hintType, Object setting);
 
-	public String getHint(String hintType);
+	public String get(String hintType);
 
-	public boolean containsHint(String hint);
+	public boolean contains(String hint);
 
-	public boolean containsHintType(String hintType);
+	public boolean containsType(String hintType);
 
-	public Map<String, String> getHints();
+	public Map<String, String> all();
 
-	public Hints getCopy();
+	public Hints copy();
 
-	char getDelimiter();
+	char hintDelimiter();
 
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/Hints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/Hints.java
@@ -4,13 +4,30 @@ package org.scijava.ops.hints;
 import java.util.Map;
 
 /**
- * A basic interface for storing and accessing Hints.
- *
+ * A basic interface for storing and accessing Hints. Hints should always come
+ * in the form of
+ * <p>
+ * {@code hintType<delimiter>setting}
+ * <p>
+ * For example, suppose you have a hintType {@code Precision}, with settings
+ * {@code lossless} and {@code lossy}. Suppose also that the {@code delimiter}
+ * is ".". A possible Hint could be :
+ * <p>
+ * {@code Precision.lossless}
+ * <p>
+ * 
  * @author Gabriel Selzer
  */
 public interface Hints {
 
-	public String setHint(String hint);
+	default String setHint(String hint) {
+		int delimIndex = hint.indexOf(getDelimiter());
+		String hintType = hint.substring(0, delimIndex);
+		String setting = hint.substring(delimIndex + 1);
+		return setHint(hintType, setting);
+	}
+
+	public String setHint(String hintType, Object setting);
 
 	public String getHint(String hintType);
 
@@ -21,5 +38,7 @@ public interface Hints {
 	public Map<String, String> getHints();
 
 	public Hints getCopy();
+
+	char getDelimiter();
 
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AbstractHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AbstractHints.java
@@ -28,9 +28,9 @@ public abstract class AbstractHints implements Hints {
 	}
 
 	@Override
-	public String setHint(String hint) {
-		String prefix = getPrefix(hint);
-		return hints.put(prefix, hint);
+	public String setHint(String hintType, Object value) {
+		String hint = hintType + getDelimiter() + value;
+		return hints.put(hintType, hint);
 	}
 
 	@Override
@@ -58,6 +58,11 @@ public abstract class AbstractHints implements Hints {
 	@Override
 	public Map<String, String> getHints() {
 		return hints;
+	}
+
+	@Override
+	public char getDelimiter() {
+		return '.';
 	}
 
 	@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AbstractHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AbstractHints.java
@@ -20,7 +20,7 @@ public abstract class AbstractHints implements Hints {
 	public AbstractHints(String... startingHints) {
 		hints = new HashMap<>();
 		for(String hint : startingHints)
-			setHint(hint);
+			set(hint);
 	}
 
 	AbstractHints(Map<String, String> hints) {
@@ -28,24 +28,24 @@ public abstract class AbstractHints implements Hints {
 	}
 
 	@Override
-	public String setHint(String hintType, Object value) {
-		String hint = hintType + getDelimiter() + value;
+	public String set(String hintType, Object value) {
+		String hint = hintType + hintDelimiter() + value;
 		return hints.put(hintType, hint);
 	}
 
 	@Override
-	public boolean containsHintType(String prefix) {
+	public boolean containsType(String prefix) {
 		return hints.containsKey(prefix);
 	}
 
 	@Override
-	public boolean containsHint(String hint) {
+	public boolean contains(String hint) {
 		String prefix = getPrefix(hint);
 		return hints.containsKey(prefix) && hint.equals(hints.get(prefix));
 	}
 
 	@Override
-	public String getHint(String prefix) {
+	public String get(String prefix) {
 		if (!hints.containsKey(prefix)) throw new NoSuchElementException(
 			"No hint of type " + prefix + " is contained!");
 		return hints.get(prefix);
@@ -56,12 +56,12 @@ public abstract class AbstractHints implements Hints {
 	}
 
 	@Override
-	public Map<String, String> getHints() {
+	public Map<String, String> all() {
 		return hints;
 	}
 
 	@Override
-	public char getDelimiter() {
+	public char hintDelimiter() {
 		return '.';
 	}
 
@@ -69,7 +69,7 @@ public abstract class AbstractHints implements Hints {
 	public boolean equals(Object that) {
 		if(!(that instanceof AbstractHints)) return false;
 		AbstractHints thoseHints = (AbstractHints) that;
-		return getHints().equals(thoseHints.getHints());
+		return all().equals(thoseHints.all());
 	}
 
 	@Override

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AdaptationHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/AdaptationHints.java
@@ -16,13 +16,13 @@ public class AdaptationHints extends AbstractHints {
 
 	private AdaptationHints(Map<String, String> map) {
 		super(map);
-		setHint(Adaptation.IN_PROGRESS);
+		set(Adaptation.IN_PROGRESS);
 	}
 
 	public static AdaptationHints generateHints(Hints hints) {
 		// collect all old hints that are not Adaptable
 		Map<String, String> map = new HashMap<>();
-		hints.getHints().entrySet().parallelStream().filter(e -> e
+		hints.all().entrySet().parallelStream().filter(e -> e
 			.getKey() != Adaptation.prefix).forEach(e -> map.put(e.getKey(), e
 				.getValue()));
 
@@ -33,12 +33,12 @@ public class AdaptationHints extends AbstractHints {
 	}
 
 	@Override
-	public String setHint(String hint) {
-		return super.setHint(hint);
+	public String set(String hint) {
+		return super.set(hint);
 	}
 
 	@Override
-	public Hints getCopy() {
+	public Hints copy() {
 		return AdaptationHints.generateHints(this);
 	}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/DefaultHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/DefaultHints.java
@@ -23,8 +23,8 @@ public class DefaultHints extends AbstractHints {
 	}
 
 	@Override
-	public Hints getCopy() {
-		return new DefaultHints(new HashMap<>(getHints()));
+	public Hints copy() {
+		return new DefaultHints(new HashMap<>(all()));
 	}
 
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/ImmutableHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/ImmutableHints.java
@@ -24,13 +24,13 @@ public class ImmutableHints extends AbstractHints {
 	}
 
 	@Override
-	public String setHint(String hint) {
+	public String set(String hint) {
 		throw new UnsupportedOperationException("ImmutableHints cannot alter the original set of Hints!");
 	}
 
 	@Override
-	public Hints getCopy() {
-		return new ImmutableHints(new HashMap<>(getHints()));
+	public Hints copy() {
+		return new ImmutableHints(new HashMap<>(all()));
 	}
 
 }

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/SimplificationHints.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/hints/impl/SimplificationHints.java
@@ -11,13 +11,13 @@ public class SimplificationHints extends AbstractHints {
 
 	private SimplificationHints(Map<String, String> map) {
 		super(map);
-		setHint(Simplification.IN_PROGRESS);
+		set(Simplification.IN_PROGRESS);
 	}
 
 	public static SimplificationHints generateHints(Hints hints) {
 		// collect all old hints that are not Adaptable
 		Map<String, String> map = new HashMap<>();
-		hints.getHints().entrySet().parallelStream().filter(e -> e
+		hints.all().entrySet().parallelStream().filter(e -> e
 			.getKey() != Simplification.prefix).forEach(e -> map.put(e.getKey(), e
 				.getValue()));
 
@@ -28,14 +28,14 @@ public class SimplificationHints extends AbstractHints {
 	}
 
 	@Override
-	public String setHint(String hint) {
+	public String set(String hint) {
 		if (hint.equals(Simplification.ALLOWED)) throw new IllegalArgumentException(
 			"We cannot allow simplification during simplification; this would cause a recursive loop!");
-		return super.setHint(hint);
+		return super.set(hint);
 	}
 
 	@Override
-	public Hints getCopy() {
+	public Hints copy() {
 		return SimplificationHints.generateHints(this);
 	}
 

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/impl/DefaultOpEnvironment.java
@@ -171,15 +171,15 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 	}
 
 	private Set<OpInfo> filterInfos(Set<OpInfo> infos, Hints hints) {
-		boolean adapting = hints.containsHint(Adaptation.IN_PROGRESS);
-		boolean simplifying = hints.containsHint(Simplification.IN_PROGRESS);
+		boolean adapting = hints.contains(Adaptation.IN_PROGRESS);
+		boolean simplifying = hints.contains(Simplification.IN_PROGRESS);
 		// if we aren't doing any 
 		if (!(adapting || simplifying)) return infos;
 		return infos.parallelStream() //
 				// filter out unadaptable ops
-				.filter(info -> !adapting || !info.declaredHints().containsHint(Adaptation.FORBIDDEN)) //
+				.filter(info -> !adapting || !info.declaredHints().contains(Adaptation.FORBIDDEN)) //
 				// filter out unadaptable ops
-				.filter(info -> !simplifying || !info.declaredHints().containsHint(Simplification.FORBIDDEN)) //
+				.filter(info -> !simplifying || !info.declaredHints().contains(Simplification.FORBIDDEN)) //
 				.collect(Collectors.toSet());
 	}
 
@@ -354,13 +354,13 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 		catch (OpMatchingException e1) {
 			// no direct match; find an adapted match
 			try {
-				if (hints.containsHint(Adaptation.ALLOWED)) return adaptOp(ref, hints);
+				if (hints.contains(Adaptation.ALLOWED)) return adaptOp(ref, hints);
 				throw new OpMatchingException("No matching Op for request: " + ref +
 					"\n(adaptation is disabled)", e1);
 			}
 			catch (OpMatchingException e2) {
 				try {
-					if (hints.containsHint(Simplification.ALLOWED)) return findSimplifiedOp(
+					if (hints.contains(Simplification.ALLOWED)) return findSimplifiedOp(
 						ref, hints);
 					throw new OpMatchingException("No matching Op for request: " + ref +
 						"\n(simplification is disabled)", e1);
@@ -496,10 +496,10 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 		for (final OpDependencyMember<?> dependency : dependencies) {
 			final OpRef dependencyRef = inferOpRef(dependency, typeVarAssigns);
 			try {
-				Hints hintCopy = hints.getCopy();
-				hintCopy.setHint(Simplification.FORBIDDEN);
+				Hints hintCopy = hints.copy();
+				hintCopy.set(Simplification.FORBIDDEN);
 				if(!dependency.isAdaptable()) {
-					hintCopy.setHint(Adaptation.FORBIDDEN);
+					hintCopy.set(Adaptation.FORBIDDEN);
 				}
 				resolvedDependencies.add(findOpInstance(dependencyRef, hintCopy));
 			}
@@ -763,7 +763,7 @@ public class DefaultOpEnvironment extends AbstractContextual implements OpEnviro
 	 */
 	@Override
 	public void setHints(Hints hints) {
-		this.environmentHints = hints.getCopy();
+		this.environmentHints = hints.copy();
 	}
 
 	/**

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/DefaultOpMatcher.java
@@ -140,7 +140,7 @@ public class DefaultOpMatcher extends AbstractService implements OpMatcher {
 
 	private Iterable<OpInfo> getInfos(OpEnvironment env, OpRef ref, Hints hints) {
 		Iterable<OpInfo> suitableInfos = env.infos(ref.getName(), hints);
-		if(hints.containsHint(Simplification.IN_PROGRESS)) {
+		if(hints.contains(Simplification.IN_PROGRESS)) {
 			Set<OpInfo> simpleInfos = new HashSet<>();
 			for(OpInfo info: suitableInfos) {
 				boolean functionallyAssignable = Types.isAssignable(Types.raw(info.opType()), Types.raw(ref.getType()));

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpAdaptationInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/matcher/OpAdaptationInfo.java
@@ -50,7 +50,7 @@ public class OpAdaptationInfo implements OpInfo {
 			validityException = e;
 		}
 
-		List<String> hintList = new ArrayList<>(srcInfo.declaredHints().getHints().values());
+		List<String> hintList = new ArrayList<>(srcInfo.declaredHints().all().values());
 		hintList.remove(Adaptation.ALLOWED);
 		hintList.add(Adaptation.FORBIDDEN);
 		this.hints = new ImmutableHints(hintList.toArray(String[]::new));

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpInfo.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpInfo.java
@@ -55,7 +55,7 @@ public class SimplifiedOpInfo implements OpInfo {
 		}
 
 		this.priority = calculatePriority(info, metadata, env);
-		List<String> hintList = new ArrayList<>(srcInfo.declaredHints().getHints().values());
+		List<String> hintList = new ArrayList<>(srcInfo.declaredHints().all().values());
 		hintList.remove(Simplification.ALLOWED);
 		hintList.add(Simplification.FORBIDDEN);
 		this.hints = new ImmutableHints(hintList.toArray(String[]::new));

--- a/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpRef.java
+++ b/scijava/scijava-ops/src/main/java/org/scijava/ops/simplify/SimplifiedOpRef.java
@@ -104,9 +104,9 @@ public class SimplifiedOpRef extends OpRef {
 	 * @throws OpMatchingException
 	 */
 	private static Computers.Arity1<?, ?> simplifierCopyOp(OpEnvironment env, Type copyType, Hints hints) throws OpMatchingException{
-			Hints hintsCopy = hints.getCopy();
-			hintsCopy.setHint(Adaptation.FORBIDDEN);
-			hintsCopy.setHint(Simplification.FORBIDDEN);
+			Hints hintsCopy = hints.copy();
+			hintsCopy.set(Adaptation.FORBIDDEN);
+			hintsCopy.set(Simplification.FORBIDDEN);
 
 			Nil<?> copyNil = Nil.of(copyType);
 			Type copierType = Types.parameterize(Computers.Arity1.class, new Type[] {copyType, copyType});

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/hints/AdaptationHintTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/hints/AdaptationHintTest.java
@@ -24,14 +24,14 @@ public class AdaptationHintTest extends AbstractTestEnvironment {
 	public void testAdaptation() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Adaptation.ALLOWED);
+		hints.set(Adaptation.ALLOWED);
 		ops.env().setHints(hints);
 		@SuppressWarnings("unused")
 		Computers.Arity1<Double[], Double[]> adaptable = ops.op(
 			"test.adaptation.hints").inType(Double[].class).outType(Double[].class)
 			.computer();
 		// make sure we cannot find the Op when adaptation is not allowed
-		hints.setHint(Adaptation.FORBIDDEN);
+		hints.set(Adaptation.FORBIDDEN);
 		ops.env().setHints(hints);
 		try {
 			ops.op("test.adaptation.hints").inType(Double[].class).outType(
@@ -46,13 +46,13 @@ public class AdaptationHintTest extends AbstractTestEnvironment {
 	public void testAdaptationPerCallHints() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Adaptation.ALLOWED);
+		hints.set(Adaptation.ALLOWED);
 		@SuppressWarnings("unused")
 		Computers.Arity1<Double[], Double[]> adaptable = ops.op(
 			"test.adaptation.hints").inType(Double[].class).outType(Double[].class)
 			.computer(hints);
 		// make sure we cannot find the Op when adaptation is not allowed
-		hints.setHint(Adaptation.FORBIDDEN);
+		hints.set(Adaptation.FORBIDDEN);
 		try {
 			ops.op("test.adaptation.hints").inType(Double[].class).outType(
 				Double[].class).computer(hints);
@@ -70,7 +70,7 @@ public class AdaptationHintTest extends AbstractTestEnvironment {
 	public void testNonAdaptableOp() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Adaptation.ALLOWED);
+		hints.set(Adaptation.ALLOWED);
 		ops.env().setHints(hints);
 		@SuppressWarnings("unused")
 		Function<Double[], Double[]> adaptable = ops.op(
@@ -91,7 +91,7 @@ public class AdaptationHintTest extends AbstractTestEnvironment {
 	public void testNonAdaptableOpPerCallHints() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Adaptation.ALLOWED);
+		hints.set(Adaptation.ALLOWED);
 		@SuppressWarnings("unused")
 		Function<Double[], Double[]> adaptable = ops.op(
 			"test.adaptation.unadaptable").inType(Double[].class).outType(Double[].class)

--- a/scijava/scijava-ops/src/test/java/org/scijava/ops/hints/SimplificationHintTest.java
+++ b/scijava/scijava-ops/src/test/java/org/scijava/ops/hints/SimplificationHintTest.java
@@ -25,14 +25,14 @@ public class SimplificationHintTest extends AbstractTestEnvironment {
 	public void testSimplification() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Simplification.ALLOWED);
+		hints.set(Simplification.ALLOWED);
 		ops.env().setHints(hints);
 		@SuppressWarnings("unused")
 		Function<Integer[], Integer[]> adaptable = ops.op(
 			"test.simplification.hints").inType(Integer[].class).outType(
 				Integer[].class).function();
 		// make sure we cannot find the Op when adaptation is not allowed
-		hints.setHint(Simplification.FORBIDDEN);
+		hints.set(Simplification.FORBIDDEN);
 		ops.env().setHints(hints);
 		try {
 			ops.op("test.simplification.hints").inType(Integer[].class).outType(
@@ -50,13 +50,13 @@ public class SimplificationHintTest extends AbstractTestEnvironment {
 	public void testSimplificationPerCallHints() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Simplification.ALLOWED);
+		hints.set(Simplification.ALLOWED);
 		@SuppressWarnings("unused")
 		Function<Integer[], Integer[]> adaptable = ops.op(
 			"test.simplification.hints").inType(Integer[].class).outType(
 				Integer[].class).function(hints);
 		// make sure we cannot find the Op when adaptation is not allowed
-		hints.setHint(Simplification.FORBIDDEN);
+		hints.set(Simplification.FORBIDDEN);
 		try {
 			ops.op("test.simplification.hints").inType(Integer[].class).outType(
 				Integer[].class).function(hints);
@@ -78,7 +78,7 @@ public class SimplificationHintTest extends AbstractTestEnvironment {
 	public void testUnsimplifiableOp() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Simplification.ALLOWED);
+		hints.set(Simplification.ALLOWED);
 		ops.env().setHints(hints);
 		@SuppressWarnings("unused")
 		Function<Double[], Double[]> adaptable = ops.op(
@@ -103,7 +103,7 @@ public class SimplificationHintTest extends AbstractTestEnvironment {
 	public void testUnsimplifiableOpPerCallHints() {
 		// make sure we can find the Op when adaptation is allowed
 		Hints hints = new DefaultHints();
-		hints.setHint(Simplification.ALLOWED);
+		hints.set(Simplification.ALLOWED);
 		@SuppressWarnings("unused")
 		Function<Double[], Double[]> adaptable = ops.op(
 			"test.simplification.unsimplifiable").inType(Double[].class).outType(


### PR DESCRIPTION
Previously we prioritized a setHints taking only the whole Hint. Now we
prioritize a Hint composed of the String hintType and the Object value.
We also add a getDelimiter method to provide an
implementation-independent way to get the delimiter. In this way we no
longer tie ourselves to a single delimiter.

Inspired by a conversation with @ctrueden on Gitter

The singular commit builds with passing tests