### PR TITLE
Convert SciJava Types Tests to JUnit 5

### DIFF
--- a/scijava/scijava-types/pom.xml
+++ b/scijava/scijava-types/pom.xml
@@ -116,13 +116,13 @@
 
 		<!-- Test scope dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/scijava/scijava-types/src/test/java/org/scijava/types/DefaultTypeReifierTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/DefaultTypeReifierTest.java
@@ -29,9 +29,6 @@
 
 package org.scijava.types;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +39,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.scijava.discovery.Discoverer;
@@ -77,14 +75,14 @@ public class DefaultTypeReifierTest {
 	@Test
 	public void testClass() {
 		final Type stringType = types.reify("Hello");
-		assertEquals(String.class, stringType);
+		Assertions.assertEquals(String.class, stringType);
 	}
 
 	/** Tests type extraction for {@code null} objects. */
 	@Test
 	public void testNull() {
 		final Type nullType = types.reify(null);
-		assertTrue(Any.class.isInstance(nullType));
+		Assertions.assertTrue(Any.class.isInstance(nullType));
 	}
 
 	/** Tests type extraction for {@link Nil} objects. */
@@ -92,7 +90,7 @@ public class DefaultTypeReifierTest {
 	public void testNil() {
 		final Nil<List<Float>> nilFloatList = new Nil<List<Float>>() {};
 		final Type nilFloatListType = types.reify(nilFloatList);
-		assertEquals(nilFloatList.getType(), nilFloatListType);
+		Assertions.assertEquals(nilFloatList.getType(), nilFloatListType);
 	}
 
 	/** Tests type extraction for {@link GenericTyped} objects. */
@@ -105,7 +103,7 @@ public class DefaultTypeReifierTest {
 				return Number.class;
 			}
 		};
-		assertEquals(Number.class, types.reify(numberThing));
+		Assertions.assertEquals(Number.class, types.reify(numberThing));
 	}
 
 	/** Tests type extraction for {@link Iterable} objects. */
@@ -114,7 +112,7 @@ public class DefaultTypeReifierTest {
 		final List<String> stringList = //
 			new ArrayList<>(Collections.singletonList("Hi"));
 		final Type stringListType = types.reify(stringList);
-		assertEquals(new Nil<ArrayList<String>>() {}.getType(), stringListType);
+		Assertions.assertEquals(new Nil<ArrayList<String>>() {}.getType(), stringListType);
 	}
 
 	/** Tests type extraction for {@link Map} objects. */
@@ -123,7 +121,7 @@ public class DefaultTypeReifierTest {
 		final Map<String, Integer> mapSI = //
 			new HashMap<>(Collections.singletonMap("Curtis", 37));
 		final Type mapSIType = types.reify(mapSI);
-		assertEquals(new Nil<HashMap<String, Integer>>() {}.getType(), mapSIType);
+		Assertions.assertEquals(new Nil<HashMap<String, Integer>>() {}.getType(), mapSIType);
 	}
 
 	/** Tests nested type extraction of a complex object. */
@@ -144,7 +142,7 @@ public class DefaultTypeReifierTest {
 		testScores.add(highlights);
 
 		final Type testScoresType = types.reify(testScores);
-		assertEquals(new Nil<ArrayList<HashMap<String, ArrayList<Integer>>>>() {}
+		Assertions.assertEquals(new Nil<ArrayList<HashMap<String, ArrayList<Integer>>>>() {}
 			.getType(), testScoresType);
 	}
 
@@ -158,12 +156,12 @@ public class DefaultTypeReifierTest {
 		blueBag.add(new BlueThing());
 
 		final Type blueBagType = types.reify(blueBag);
-		assertEquals(new Nil<Bag<BlueThing>>() {}.getType(), blueBagType);
+		Assertions.assertEquals(new Nil<Bag<BlueThing>>() {}.getType(), blueBagType);
 
 		final Bag<RedThing> redBag = new Bag<>();
 		redBag.add(new RedThing());
 
 		final Type redBagType = types.reify(redBag);
-		assertEquals(new Nil<Bag<RedThing>>() {}.getType(), redBagType);
+		Assertions.assertEquals(new Nil<Bag<RedThing>>() {}.getType(), redBagType);
 	}
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/NilConverterTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/NilConverterTest.java
@@ -29,14 +29,13 @@
 
 package org.scijava.types;
 
-import static org.junit.Assert.assertTrue;
-
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Observer;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.scijava.Context;
@@ -91,27 +90,27 @@ public class NilConverterTest {
 		// support generic types. Right now, CastingConverter steals this.
 //		assertConvert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType());
 		final Converter<?, ?> converter = convert.getHandler(nil, Observer.class);
-		assertTrue(converter instanceof NilConverter);
+		Assertions.assertTrue(converter instanceof NilConverter);
 		// TODO: Enable after Nil proxying is improved to support non-interfaces.
-//		assertTrue(converter.convert(nil, String.class) instanceof String);
-		assertTrue(converter.convert(nil, List.class) instanceof List);
-		assertTrue(converter.convert(nil, new Nil<Map<?, ?>>() {}.getType()) instanceof Map);
+//		Assertions.assertTrue(converter.convert(nil, String.class) instanceof String);
+		Assertions.assertTrue(converter.convert(nil, List.class) instanceof List);
+		Assertions.assertTrue(converter.convert(nil, new Nil<Map<?, ?>>() {}.getType()) instanceof Map);
 		// TODO: Enable after ConvertService is rewritten to fully
 		// support generic types. Right now, CastingConverter steals this.
-//		assertTrue(converter.convert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType()) instanceof Nil);
+//		Assertions.assertTrue(converter.convert(nil, new Nil<Nil<Map<?, ?>>>() {}.getType()) instanceof Nil);
 	}
 
 	private void assertCanConvert(final Nil<?> nil, final Type destType) {
 		final Converter<?, ?> converter = convert.getHandler(nil, destType);
-		assertTrue(converter instanceof NilConverter);
-		assertTrue(converter.canConvert(nil, destType));
+		Assertions.assertTrue(converter instanceof NilConverter);
+		Assertions.assertTrue(converter.canConvert(nil, destType));
 	}
 
 	private void assertConvert(final Nil<?> nil, final Type destType) {
 		final Converter<?, ?> converter = convert.getHandler(nil, destType);
-		assertTrue(converter instanceof NilConverter);
+		Assertions.assertTrue(converter instanceof NilConverter);
 		final Object o = converter.convert(nil, destType);
-		assertTrue(Types.raw(destType).isAssignableFrom(o.getClass()));
+		Assertions.assertTrue(Types.raw(destType).isAssignableFrom(o.getClass()));
 	}
 
 }

--- a/scijava/scijava-types/src/test/java/org/scijava/types/inference/InferTypeVariablesTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/inference/InferTypeVariablesTest.java
@@ -1,8 +1,6 @@
 
 package org.scijava.types.inference;
 
-import static org.junit.Assert.assertEquals;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -13,7 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.scijava.types.Any;
 import org.scijava.types.Nil;
 
@@ -50,7 +49,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
 		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, false));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -74,7 +73,7 @@ public class InferTypeVariablesTest {
 		expected.put(typeVarT, new WildcardTypeMapping(typeVarT, mappedWildcard,
 			true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -95,7 +94,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarT = (TypeVariable<?>) t;
 		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, false));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -114,7 +113,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -133,7 +132,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Double.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -151,7 +150,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -169,7 +168,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -187,7 +186,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -205,7 +204,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarO, new TypeMapping(typeVarO, new Any(), true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -221,7 +220,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarO, new TypeMapping(typeVarO, FooThing.class, false));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -240,7 +239,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarT = (TypeVariable<?>) new Nil<T>() {}.getType();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -260,7 +259,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
 		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -282,7 +281,7 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -305,7 +304,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVarT = (TypeVariable<?>) t.getType();
 		expected.put(typeVarT, new TypeMapping(typeVarT, Number.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 	}
 
 	@Test
@@ -332,7 +331,7 @@ public class InferTypeVariablesTest {
 			.getActualTypeArguments()[0];
 		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, false));
 
-		assertEquals(typeAssigns, expected);
+		Assertions.assertEquals(typeAssigns, expected);
 	}
 
 	@Test
@@ -354,7 +353,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVar = (TypeVariable<?>) t;
 		expected.put(typeVar, new TypeMapping(typeVar, Number.class, true));
 
-		assertEquals(expected, typeAssigns);
+		Assertions.assertEquals(expected, typeAssigns);
 
 		final Type[] types2 = { t, t };
 		final Type listWildcardNumber = new Nil<List<? extends Number>>() {}
@@ -377,7 +376,7 @@ public class InferTypeVariablesTest {
 		TypeVariable<?> typeVar2 = (TypeVariable<?>) t;
 		expected2.put(typeVar2, new TypeMapping(typeVar, Number.class, true));
 
-		assertEquals(expected2, typeAssigns2);
+		Assertions.assertEquals(expected2, typeAssigns2);
 	}
 
 }


### PR DESCRIPTION
This PR does what it says above.

The POM only listed `org.junit` and `org.junit.jupiter.api` as dependencies, which is very strange. Furthermore, it would only run JUnit 4 tests, which represented very few of this project's tests. This PR replaces `org.junit` with `org.junit.jupiter.engine`, and converts all tests still running JUnit 4.

TODO:
* [ ] Merge #49, the PR this one is built on top of.