### PR TITLE
Move `OpUtils` back into SciJava Ops Engine

### DIFF
--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpUtils.java
@@ -37,15 +37,12 @@ import java.util.stream.Collectors;
 import org.scijava.ops.api.OpCandidate;
 import org.scijava.common3.validity.ValidityException;
 import org.scijava.common3.validity.ValidityProblem;
-import org.scijava.ops.api.OpCandidate.StatusCode;
-import org.scijava.ops.api.OpDependencyMember;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpRef;
 import org.scijava.struct.Member;
 import org.scijava.struct.MemberInstance;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
-import org.scijava.struct.ValueAccessible;
 import org.scijava.types.Types;
 
 /**
@@ -114,48 +111,11 @@ public final class OpUtils {
 				.collect(Collectors.toList());
 	}
 
-	public static List<Member<?>> inputs(OpCandidate candidate) {
-		return inputs(candidate.struct());
-	}
-
-	public static List<Member<?>> inputs(final Struct struct) {
-		return struct.members().stream() //
-				.filter(member -> member.isInput()) //
-				.collect(Collectors.toList());
-	}
-	
-	public static Type[] inputTypes(OpCandidate candidate) {
-		return getTypes(inputs(candidate.struct()));
-	}
-
-	public static Type[] inputTypes(Struct struct) {
-		return getTypes(inputs(struct));
-	}
-
-	public static Member<?> output(OpCandidate candidate) {
-		return candidate.opInfo().output();
-	}
-
-	public static Type outputType(OpCandidate candidate) {
-		return output(candidate).getType();
-	}
-
-	public static List<Member<?>> outputs(final Struct struct) {
-		return struct.members().stream() //
-				.filter(member -> member.isOutput()) //
-				.collect(Collectors.toList());
-	}
-
-	public static List<MemberInstance<?>> outputs(StructInstance<?> op) {
-		return op.members().stream() //
-				.filter(memberInstance -> memberInstance.member().isOutput()) //
-				.collect(Collectors.toList());
-	}
-
 	public static void checkHasSingleOutput(Struct struct) throws
 			ValidityException
 	{
-		final int numOutputs = OpUtils.outputs(struct).size();
+		final long numOutputs = struct.members().stream() //
+			.filter(m -> m.isOutput()).count();
 		if (numOutputs != 1) {
 			final String error = numOutputs == 0 //
 				? "No output parameters specified. Must specify exactly one." //
@@ -237,7 +197,7 @@ public final class OpUtils {
 	 * @return the index of the mutable argument.
 	 */
 	public static int ioArgIndex(final OpInfo info) {
-		List<Member<?>> inputs = OpUtils.inputs(info.struct());
+		List<Member<?>> inputs = info.inputs();
 		Optional<Member<?>>
 				ioArg = inputs.stream().filter(m -> m.isInput() && m.isOutput()).findFirst();
 		if(ioArg.isEmpty()) return -1;

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/AbstractInfoReducer.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/AbstractInfoReducer.java
@@ -26,7 +26,7 @@ public abstract class AbstractInfoReducer implements InfoReducer {
 		int originalArity = arityOf(rawType);
 		int reducedArity = originalArity - numReductions;
 		Class<?> reducedRawType = ofArity(reducedArity);
-		Type[] inputTypes = OpUtils.inputTypes(info.struct());
+		Type[] inputTypes = info.inputTypes().toArray(Type[]::new);
 		Type outputType = info.output().getType();
 		Type[] newTypes = new Type[reducedArity + 1];
 		if (reducedArity >= 0) System.arraycopy(inputTypes, 0, newTypes, 0,

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfoGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfoGenerator.java
@@ -3,7 +3,6 @@ package org.scijava.ops.engine.reduce;
 
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpInfoGenerator;
-import org.scijava.ops.engine.OpUtils;
 import org.scijava.struct.Member;
 
 import java.util.*;
@@ -23,7 +22,7 @@ public class ReducedOpInfoGenerator implements OpInfoGenerator {
 		if (!(o instanceof OpInfo)) return false;
 		OpInfo info = (OpInfo) o;
 		// We only benefit from OpInfos with optional parameters
-		boolean allParamsRequired = OpUtils.inputs(info.struct()).parallelStream() //
+		boolean allParamsRequired = info.inputs().parallelStream() //
 			.allMatch(Member::isRequired); //
 		if (allParamsRequired) return false;
 		// If we have a InfoReducer, then we can reduce

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReductionUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReductionUtils.java
@@ -116,7 +116,7 @@ public class ReductionUtils {
 
 	private static String memberNames(ReducedOpInfo reducedInfo) {
 		Stream<String> memberNames = //
-			Streams.concat(Arrays.stream(OpUtils.inputTypes(reducedInfo.struct())), //
+			Streams.concat(reducedInfo.inputTypes().stream(), //
 				Stream.of(reducedInfo.output().getType())) //
 				.map(type -> getClassName(Types.raw(type)));
 		Iterable<String> iterableNames = (Iterable<String>) memberNames::iterator;
@@ -229,9 +229,9 @@ public class ReductionUtils {
 		}
 		sb.append("op." + srcM.getName() + "(");
 		int i;
-		List<Member<?>> totalArguments = OpUtils.inputs(info.srcInfo().struct());
-		int totalArgs = OpUtils.inputs(info.srcInfo().struct()).size();
-		long totalOptionals = OpUtils.inputs(info.srcInfo().struct())
+		List<Member<?>> totalArguments = info.srcInfo().inputs();
+		int totalArgs = totalArguments.size();
+		long totalOptionals = totalArguments
 			.parallelStream().filter(member -> !member.isRequired())
 			.count();
 		long neededOptionals = totalOptionals - info.paramsReduced();

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/InfoSimplificationGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/InfoSimplificationGenerator.java
@@ -13,7 +13,6 @@ import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpRef;
-import org.scijava.ops.engine.OpUtils;
 import org.scijava.types.Types;
 
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationMetadata.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationMetadata.java
@@ -1,4 +1,3 @@
-
 package org.scijava.ops.engine.simplify;
 
 import java.lang.reflect.Type;

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationUtils.java
@@ -170,12 +170,12 @@ public class SimplificationUtils {
 	}
 
 	/**
-	 * Obtains all {@link Simplifier}s known to the environment that can operate
+	 * Obtains all simplifiers known to the environment that can operate
 	 * on {@code t}. If no {@code Simplifier}s are known to explicitly work on
 	 * {@code t}, an {@link Identity} simplifier will be created.
 	 * 
 	 * @param t - the {@link Type} we are interested in simplifying.
-	 * @return a list of {@link Simplifier}s that can simplify {@code t}.
+	 * @return a list of simplifiers that can simplify {@code t}.
 	 */
 	public static List<OpInfo> getSimplifiers(OpEnvironment env, Type t) {
 		// TODO: optimize
@@ -199,12 +199,12 @@ public class SimplificationUtils {
 
 
 	/**
-	 * Obtains all {@link Simplifier}s known to the environment that can operate
+	 * Obtains all simplifiers known to the environment that can operate
 	 * on {@code t}. If no {@code Simplifier}s are known to explicitly work on
 	 * {@code t}, an {@link Identity} simplifier will be created.
 	 * 
 	 * @param t - the {@link Type} we are interested in simplifying.
-	 * @return a list of {@link Simplifier}s that can simplify {@code t}.
+	 * @return a list of simplifiers that can simplify {@code t}.
 	 */
 	public static List<OpInfo> getFocusers(OpEnvironment env, Type t) {
 		// TODO: optimize
@@ -217,7 +217,7 @@ public class SimplificationUtils {
 	}
 	
 	/**
-	 * Creates a Class given an Op and a set of {@link Simplifier}s. This class:
+	 * Creates a Class given an Op and a set of simplifiers. This class:
 	 * <ul>
 	 * <li>is of the same functional type as the given Op</li>
 	 * <li>has type arguments that are of the simplified form of the type

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/ClassParameterMemberParser.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/ClassParameterMemberParser.java
@@ -8,11 +8,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.scijava.common3.validity.ValidityException;
+import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.ops.engine.OpUtils;
 import org.scijava.struct.MemberParser;
 import org.scijava.struct.Structs;
-import org.scijava.common3.validity.ValidityException;
-import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.types.Types;
 
 public class ClassParameterMemberParser implements

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/LazilyGeneratedMethodParameterData.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/LazilyGeneratedMethodParameterData.java
@@ -16,7 +16,6 @@ import org.scijava.ops.engine.reduce.ReductionUtils;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.struct.FunctionalMethodType;
 import org.scijava.struct.ItemIO;
-import org.scijava.struct.Struct;
 
 import com.github.therapi.runtimejavadoc.MethodJavadoc;
 import com.github.therapi.runtimejavadoc.OtherJavadoc;


### PR DESCRIPTION
d521c62 moved `OpUtils` into SciJava Ops API because some API classes (`OpInfo` and `OpCandidate`, to name a few) used its functionality.

This PR moves `OpUtils` back into SciJava Ops Engine. This was made possible by the migration of relevant code into the API classes needing it. For example, `OpUtils.inputs(Struct struct)` became `OpInfo.inputs()`. With these migrations, no code in API depended on `OpUtils`, allowing it to move back into SciJava Ops Engine

Closes scijava/scijava#70