### PR TITLE
Wrap Numpy in Ops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 		<module>scijava/scijava-meta</module>
 		<module>scijava/scijava-ops-api</module>
 		<module>scijava/scijava-ops-engine</module>
+		<module>scijava/scijava-ops-python</module>
 		<module>scijava/scijava-ops-spi</module>
 		<module>scijava/scijava-parse2</module>
 		<module>scijava/scijava-persist</module>

--- a/scijava/scijava-ops-engine/src/main/java/module-info.java
+++ b/scijava/scijava-ops-engine/src/main/java/module-info.java
@@ -67,7 +67,8 @@ module org.scijava.ops.engine {
 	uses org.scijava.types.TypeExtractor;
 
 	provides org.scijava.discovery.Discoverer with
- 		org.scijava.ops.engine.impl.TherapiOpInfoDiscoverer;
+ 		org.scijava.ops.engine.impl.TherapiOpInfoDiscoverer,
+ 		org.scijava.ops.engine.yaml.YAMLOpInfoDiscoverer;
 
 	provides org.scijava.ops.api.InfoChainGenerator with
 		org.scijava.ops.engine.matcher.impl.AdaptationInfoChainGenerator,

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/YAMLOpInfoDiscoverer.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/YAMLOpInfoDiscoverer.java
@@ -41,7 +41,7 @@ public class YAMLOpInfoDiscoverer implements Discoverer {
 		List<OpInfo> opInfos = new ArrayList<>();
 		opFiles.asIterator().forEachRemaining(opFile -> {
 			try {
-				parse(opInfos, opFiles.nextElement());
+				parse(opInfos, opFile);
 			}
 			catch (IOException e) {
 				new IllegalArgumentException( //

--- a/scijava/scijava-ops-python/.gitignore
+++ b/scijava/scijava-ops-python/.gitignore
@@ -1,0 +1,2 @@
+/.apt_generated/
+/.apt_generated_tests/

--- a/scijava/scijava-ops-python/LICENSE.txt
+++ b/scijava/scijava-ops-python/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2016 - 2019, SciJava Ops developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/scijava/scijava-ops-python/README.md
+++ b/scijava/scijava-ops-python/README.md
@@ -1,0 +1,78 @@
+# SciJava Progress: an interrupt-based mechanism for progress reporting
+
+This component provides a mechanism for progress-recording operations to notify interested parties of updates to progress.
+
+## The `Progress` class
+
+The `Progress` class is designed to be the middle-man between an operation that wishes to report its progress and a listener that wishes to be notified of progress updates. **Both** of these parties will interface with each other through `Progress` class.
+
+### Accessing `Progress` as an operation
+
+Suppose we have a `Function` that does some heavy calculation on a `List`, and wants to notify callers when it finishes one element, before it moves to the next:
+
+```java
+public class Foo implements Function<List<Integer>, List<Integer>> {
+
+	@Override
+	public Integer apply(List<Integer> in) {
+		List<Integer> out = new ArrayList<>();
+		for(int i = 0; i < in.size(); i++) {
+			out.set(i, doTheComputation(in.get(i)));
+		}
+	}
+
+}
+
+```
+
+Firstly, we add the bookkeeping steps:
+1. Notify `Progress` that this Object wants to record its progress by calling `Progress.register(Object progressible)`. This can either be called within our `Function` (by passing `this`), or before the `apply` method is called (by passing our `Foo` instance).
+2. Define what total progress means using `Progress.defineTotalProgress(int numStages, int numSubTasks)`. We make the distinction between `numStages` and `numSubtasks`:
+
+  * `numStages` lets `Progress` know how many stages of computation will be performed within the current task
+  * `numSubTasks` lets `Progress` know how many progress-reporting tasks **will be called** by the current task. Since they will report their own progress to `Progress`, `Progress` will automatically update the progress of our current task as the subtasks progress.
+3. For each stage, `Progress.setStageMax(long max)` must be called so that `Progress` knows when each stage is completed, and moves onto the next.
+4. Once the computation is complete, notify `Progress` that the task has completed by calling `Progress.complete()`.
+
+Once these bookkeeping stages are added, we can then call `Progress.update`. Our `Function`, updating progress, would then look like:
+
+```java
+public class Foo implements Function<List<Integer>, List<Integer>> {
+
+	@Override
+	public Integer apply(List<Integer> in) {
+		Progress.register(this);
+		Progress.defineTotalProgress(1, 0);
+		Progress.setStageMax(in.size());
+		
+		// compute
+		List<Integer> out = new ArrayList<>();
+		for(int i = 0; i < in.size(); i++) {
+			out.set(i, doTheComputation(in.get(i)));
+			Progress.update();
+		}
+
+		Progress.complete();
+	}
+
+}
+
+```
+
+Ops can also set their `status` through the `Progress` framework, using the method `Progress.setStatus(String status)`. In these situations, out `Function` would not need to call `Progress.defineTotalProgress()` or `Progress.setStageMax()`. Progressible code is, of course, allowed to set both status and progress.
+
+### Accessing `Progress` as a listener
+
+Progress is accessed by listeners using the `Progress.addListener(Object progressible, ProgressListener l)` method. This method must be called **before** `progressible`'s code is executed, and all executions of `progressible` will then be sent to `l`.
+
+`ProgressListener` is, at its core, a `FunctionalInterface`, allowing `ProgressListener`s to be defined as lambdas. The functional method, `acknowledgeUpdate(Task t)`, is then called when **any execution** of `l` calls **either** `Progress.update()` or `Progress.setStatus()`. Below is an example of how one might write a `ProgressListener` for `Foo`:
+
+```java
+Foo f = new Foo();
+
+// register a listener that prints progress to console
+Progress.addListener(f, (t) -> System.out.println(t.progress()));
+
+// call Foo
+f.apply(Arrays.asList(1, 2, 3, 4);
+```

--- a/scijava/scijava-ops-python/environment.yml
+++ b/scijava/scijava-ops-python/environment.yml
@@ -3,6 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python >= 3.7
-  - jep
+  - python >= 3.11
+  - openjdk >= 11
+#  - jep
   - numpy
+  - pip
+  - pip:
+      - jep
+variables:
+  LD_PRELOAD: /home/gselzer/miniconda3/envs/scijava-ops-python/lib/libpython3.11.so

--- a/scijava/scijava-ops-python/environment.yml
+++ b/scijava/scijava-ops-python/environment.yml
@@ -1,0 +1,8 @@
+name: scijava-ops-python
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python >= 3.7
+  - jep
+  - numpy

--- a/scijava/scijava-ops-python/jep_path.py
+++ b/scijava/scijava-ops-python/jep_path.py
@@ -1,0 +1,5 @@
+import site;
+import os
+import glob
+for f in glob.glob(os.path.join(site.getsitepackages()[0], "jep/libjep.*")):
+    print(f)

--- a/scijava/scijava-ops-python/pom.xml
+++ b/scijava/scijava-ops-python/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.scijava</groupId>
+		<artifactId>scijava-incubator</artifactId>
+		<version>0-SNAPSHOT</version>
+		<relativePath>../..</relativePath>
+	</parent>
+
+	<artifactId>scijava-ops-python</artifactId>
+
+	<name>SciJava Ops Python</name>
+	<description>SciJava Ops Python: Python-based Ops</description>
+	<url>https://github.com/scijava/scijava</url>
+	<inceptionYear>2021</inceptionYear>
+	<organization>
+		<name>SciJava</name>
+		<url>https://scijava.org/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>Simplified BSD License</name>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>ctrueden</id>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/people/ctrueden</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>gselzer</id>
+			<name>Gabriel Selzer</name>
+			<roles>
+				<role>founder</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Christian Dietz</name>
+			<url>https://imagej.net/people/dietzc</url>
+			<roles>
+				<role>founder</role>
+			</roles>
+			<properties>
+				<id>dietzc</id>
+			</properties>
+		</contributor>
+		<contributor>
+			<name>David Kolb</name>
+			<roles>
+				<role>founder</role>
+			</roles>
+			<properties>
+				<id>Treiblesschorle</id>
+			</properties>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tag/scijava</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/scijava/incubator</connection>
+		<developerConnection>scm:git:git@github.com:scijava/incubator</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/scijava/incubator</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/scijava/scijava/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>GitHub Actions</system>
+		<url>https://github.com/scijava/incubator/actions</url>
+	</ciManagement>
+
+	<properties>
+		<main-class>org.scijava.ops.python.Main</main-class>
+		<package-name>org.scijava.ops.python</package-name>
+
+		<license.licenseName>bsd_2</license.licenseName>
+		<license.copyrightOwners>SciJava developers.</license.copyrightOwners>
+		<scijava-ops-python.allowedDuplicateClasses>${scijava.allowedDuplicateClasses}</scijava-ops-python.allowedDuplicateClasses>
+		<allowedDuplicateClasses>${scijava-ops-python.allowedDuplicateClasses}</allowedDuplicateClasses>
+		<jep.version>4.1.0</jep.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-ops-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- Third-party dependencies -->
+		<dependency>
+			<groupId>black.ninia</groupId>
+			<artifactId>jep</artifactId>
+			<version>4.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.javassist</groupId>
+			<artifactId>javassist</artifactId>
+		</dependency>
+		<!-- Test scope dependencies -->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-ops-engine</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-ops-engine</artifactId>
+			<version>0-SNAPSHOT</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/scijava/scijava-ops-python/src/main/java/module-info.java
+++ b/scijava/scijava-ops-python/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module org.scijava.ops.python {
+
+	requires jep;
+
+	requires org.scijava.ops.api;
+	requires org.scijava.ops.engine; // TODO: Remove
+	requires org.scijava.common3;
+	requires org.scijava.types;
+	requires javassist;
+
+	provides org.scijava.ops.api.features.YAMLOpInfoCreator with
+			org.scijava.ops.python.PythonYAMLOpInfoCreator;
+
+}

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/OpsPythonInterpreter.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/OpsPythonInterpreter.java
@@ -1,0 +1,61 @@
+package org.scijava.ops.python;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import jep.Interpreter;
+import jep.MainInterpreter;
+import jep.SharedInterpreter;
+
+public class OpsPythonInterpreter {
+
+	private static OpsPythonInterpreter instance;
+	private final Interpreter interp;
+
+	private OpsPythonInterpreter() {
+		// TODO: To use Numpy, I have to set the environment variable
+		// LD_PRELOAD=~/miniconda3/envs/scijava-ops-python/lib/libpython3.11.so
+		// Can we automate this?
+		// See https://github.com/ninia/jep/issues/338
+		try {
+			MainInterpreter.setJepLibraryPath(getJepPath());
+		} catch(IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		interp = new SharedInterpreter();
+	}
+
+	public static Interpreter interpreter() {
+		if (instance == null) {
+			instance = new OpsPythonInterpreter();
+		}
+		return instance.interp;
+	}
+
+	private static String getJepPath() throws IOException, InterruptedException {
+		ProcessBuilder processBuilder = new ProcessBuilder("conda",
+				"run", "-n", "scijava-ops-python", "python", "jep_path.py");
+		processBuilder.redirectErrorStream(true);
+
+		Process process = processBuilder.start();
+		StringBuilder processOutput = new StringBuilder();
+
+		try (BufferedReader processOutputReader = new BufferedReader(
+				new InputStreamReader(process.getInputStream()));)
+		{
+			String readLine;
+
+			while ((readLine = processOutputReader.readLine()) != null)
+			{
+				processOutput.append(readLine + System.lineSeparator());
+			}
+
+			process.waitFor();
+		}
+
+		return processOutput.toString().trim();
+
+	}
+
+}

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonOpInfo.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonOpInfo.java
@@ -1,0 +1,253 @@
+
+package org.scijava.ops.python;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.scijava.common3.validity.ValidityException;
+import org.scijava.ops.api.Hints;
+import org.scijava.ops.api.OpDependencyMember;
+import org.scijava.ops.api.OpInfo;
+import org.scijava.struct.ItemIO;
+import org.scijava.struct.Member;
+import org.scijava.struct.Struct;
+import org.scijava.struct.StructInstance;
+import org.scijava.types.Types;
+
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtConstructor;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.CtNewConstructor;
+import javassist.CtNewMethod;
+import javassist.NotFoundException;
+
+public class PythonOpInfo implements OpInfo {
+
+	private final List<String> names;
+	private final double priority;
+	private final String version;
+	private final String source;
+	private final Hints hints = new TempHints();
+	private final Type opType;
+
+	private final Struct struct;
+
+	public PythonOpInfo(List<String> names, final Class<?> opType,
+		double priority, String version, String source,
+		List<Map<String, Object>> parameters)
+	{
+		this.names = names;
+		this.priority = priority;
+		this.version = version;
+		this.source = source;
+
+		List<Member<?>> members;
+		try {
+			members = parseParams(parameters);
+		}
+		catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+		this.opType = Types.parameterize(opType, members.stream().map(
+			Member::getType).toArray(Type[]::new));
+
+		struct = () -> members;
+	}
+
+	@Override
+	public List<String> names() {
+		return names;
+	}
+
+	@Override
+	public Type opType() {
+		return opType;
+	}
+
+	@Override
+	public Struct struct() {
+		return struct;
+	}
+
+	@Override
+	public Hints declaredHints() {
+		return hints;
+	}
+
+	@Override
+	public double priority() {
+		return priority;
+	}
+
+	@Override
+	public String implementationName() {
+		return source;
+	}
+
+	@Override
+	public StructInstance<?> createOpInstance(List<?> dependencies) {
+		try {
+			return struct().createInstance(javassistOp(source));
+		}
+		catch (Throwable ex) {
+			throw new IllegalStateException("Failed to invoke Op method: " + source +
+				". Provided Op dependencies were: " + Objects.toString(dependencies),
+				ex);
+		}
+
+	}
+
+	@Override
+	public boolean isValid() {
+		return true;
+	}
+
+	@Override
+	public ValidityException getValidityException() {
+		return null;
+	}
+
+	@Override
+	public AnnotatedElement getAnnotationBearer() {
+		return null;
+	}
+
+	@Override
+	public String version() {
+		return version;
+	}
+
+	@Override
+	public String id() {
+		return null;
+	}
+
+	/**
+	 * TODO: This is SUPER hacky. Yeehaw!
+	 * 
+	 */
+	private static List<Member<?>> parseParams(List<Map<String, Object>> params)
+		throws ClassNotFoundException
+	{
+		List<Member<?>> members = new ArrayList<>();
+		final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		for (Map<String, Object> map : params) {
+			Class<?> type = cl.loadClass((String) map.get("type"));
+			String description = (String) map.getOrDefault("description", "");
+			List<String> keys = new ArrayList<>(map.keySet());
+			keys.remove("type");
+			keys.remove("description");
+			String ioType = keys.get(0);
+			String key = (String) map.get(ioType);
+			members.add(new Member<>() {
+
+				@Override
+				public String getKey() {
+					return key;
+				}
+
+				@Override
+				public Type getType() {
+					return type;
+				}
+
+				@Override
+				public ItemIO getIOType() {
+					switch (ioType) {
+						case "input":
+							return ItemIO.INPUT;
+						case "output":
+							return ItemIO.OUTPUT;
+						case "container":
+							return ItemIO.CONTAINER;
+						case "mutable":
+							return ItemIO.MUTABLE;
+						default:
+							throw new IllegalStateException("Invalid IO type");
+					}
+				}
+
+				@Override
+				public String getDescription() {
+					return description;
+				}
+			});
+
+		}
+		return members;
+	}
+
+	private Object javassistOp(String source) throws Throwable {
+		ClassPool pool = ClassPool.getDefault();
+
+		// Create wrapper class
+		String className = formClassName(source);
+		Class<?> c;
+		try {
+			CtClass cc = pool.makeClass(className);
+
+			// Add implemented interface
+			CtClass jasOpType = pool.get(Types.raw(opType).getName());
+			cc.addInterface(jasOpType);
+
+			// Add constructor
+			CtConstructor constructor = CtNewConstructor.make(createConstructor(cc), cc);
+			cc.addConstructor(constructor);
+
+			// add functional interface method
+			CtMethod functionalMethod = CtNewMethod.make(createFunctionalMethod(
+				source), cc);
+			cc.addMethod(functionalMethod);
+			c = cc.toClass(MethodHandles.lookup());
+		}
+		catch (Exception e) {
+			c = this.getClass().getClassLoader().loadClass(className);
+		}
+
+		// Return Op instance
+		return c.getDeclaredConstructor().newInstance();
+	}
+
+	private String formClassName(String source) {
+		// package name
+		String packageName = PythonOpInfo.class.getPackageName();
+
+		// class name -> OwnerName_PythonFunction
+		List<String> nameElements = List.of(source.split("\\."));
+		String className = packageName + "." + String.join("_", nameElements);
+		return className;
+	}
+
+	private String createConstructor(CtClass cc)
+	{
+		// constructor signature
+		return "public " + cc.getSimpleName() + "() {}";
+	}
+
+	private String createFunctionalMethod(String source) {
+		StringBuilder sb = new StringBuilder();
+		return sb.toString();
+	}
+
+	/**
+	 * Returns a "simple" name for {@code Class<?> c}.
+	 * <p>
+	 * Since this should be a java identifier, it cannot have illegal characters;
+	 * thus we replace illegal characters with an underscore.
+	 *
+	 * @param c the {@link Class} for which we need an identifier
+	 * @return a {@link String} that can identify the class
+	 */
+	private String getParameterName(Class<?> c) {
+		return c.getSimpleName().replaceAll("[^a-zA-Z0-9_]", "_");
+	}
+}

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonYAMLOpInfoCreator.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonYAMLOpInfoCreator.java
@@ -1,5 +1,6 @@
 package org.scijava.ops.python;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -9,11 +10,11 @@ import org.scijava.ops.api.features.YAMLOpInfoCreator;
 
 public class PythonYAMLOpInfoCreator implements YAMLOpInfoCreator {
 
-	@Override public boolean canCreateFrom(String source, String identifier) {
-		return source.toLowerCase().trim().equals("python");
+	@Override public boolean canCreateFrom(URI identifier) {
+		return identifier.getScheme().equals("pythonFunction");
 	}
 
-	@Override public OpInfo create(Map<String, Object> yaml, String version)
+	@Override public OpInfo create(URI identifier, Map<String, Object> yaml)
 			throws Exception
 	{
 		final String[] names;
@@ -29,11 +30,16 @@ public class PythonYAMLOpInfoCreator implements YAMLOpInfoCreator {
 		Class<?> opType = cl.loadClass(typeString);
 
 		double priority = (double) yaml.get("priority");
-		String source = (String) yaml.get("source");
+		// Parse path - start after the leading slash
+		final String path = identifier.getPath().substring(1);
+		// Parse source
+		final String srcString = path.substring(0, path.indexOf('/'));
+		// Parse version
+		final String version = path.substring(path.indexOf('/') + 1);
 
 		List<Map<String, Object>> params =
 				(List<Map<String, Object>>) yaml.get("parameters");
 
-		return new PythonOpInfo(Arrays.asList(names), opType, priority, version, source, params);
+		return new PythonOpInfo(Arrays.asList(names), opType, priority, version, srcString, params);
 	}
 }

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonYAMLOpInfoCreator.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/PythonYAMLOpInfoCreator.java
@@ -1,0 +1,39 @@
+package org.scijava.ops.python;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.scijava.ops.api.OpInfo;
+import org.scijava.ops.api.features.YAMLOpInfoCreator;
+
+public class PythonYAMLOpInfoCreator implements YAMLOpInfoCreator {
+
+	@Override public boolean canCreateFrom(String source, String identifier) {
+		return source.toLowerCase().trim().equals("python");
+	}
+
+	@Override public OpInfo create(Map<String, Object> yaml, String version)
+			throws Exception
+	{
+		final String[] names;
+		if (yaml.containsKey("name")) {
+			names = new String[]{(String) yaml.get("name")};
+		} else {
+			String namesString = (String) yaml.get("names");
+			names = namesString.split("\\s*,\\s*");
+		}
+		// parse op type
+		final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		String typeString = (String) yaml.get("type");
+		Class<?> opType = cl.loadClass(typeString);
+
+		double priority = (double) yaml.get("priority");
+		String source = (String) yaml.get("source");
+
+		List<Map<String, Object>> params =
+				(List<Map<String, Object>>) yaml.get("parameters");
+
+		return new PythonOpInfo(Arrays.asList(names), opType, priority, version, source, params);
+	}
+}

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/TempHints.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/TempHints.java
@@ -1,0 +1,63 @@
+package org.scijava.ops.python;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.scijava.ops.api.Hints;
+
+public class TempHints  implements Hints {
+
+	// Hints are stored by their hint type (the middle term)
+	final Set<String> hints;
+
+	public TempHints(final String... startingHints) {
+		this(Arrays.asList(startingHints));
+	}
+
+	private TempHints(final Collection<String> hints) {
+		this.hints = new HashSet<>(hints);
+	}
+
+	@Override
+	public boolean contains(String hint) {
+		return hints.contains(hint);
+	}
+
+	@Override
+	public Hints copy() {
+		return new TempHints(hints);
+	}
+
+	/**
+	 * {@link Hints} should be equal iff their {@link Map}s of hints are equal.
+	 */
+	@Override
+	public boolean equals(Object that) {
+		if (!(that instanceof TempHints)) return false;
+		TempHints thoseHints = (TempHints) that;
+		return hints.equals(thoseHints.hints);
+	}
+
+	@Override
+	public int hashCode() {
+		return hints.hashCode();
+	}
+
+	@Override
+	public Hints minus(String... h) {
+		Set<String> newHints = new HashSet<>(this.hints);
+		newHints.removeAll(Arrays.asList(h));
+		return new TempHints(newHints);
+	}
+
+	@Override
+	public Hints plus(String... h) {
+		Set<String> newHints = new HashSet<>(this.hints);
+		newHints.addAll(Arrays.asList(h));
+		return new TempHints(newHints);
+	}
+
+}

--- a/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/YAMLOpCollection.java
+++ b/scijava/scijava-ops-python/src/main/java/org/scijava/ops/python/YAMLOpCollection.java
@@ -1,0 +1,11 @@
+package org.scijava.ops.python;
+
+import java.util.Map;
+
+public class YAMLOpCollection {
+
+	public YAMLOpCollection(final Map<String, Object> yaml) {
+
+	}
+
+}

--- a/scijava/scijava-ops-python/src/main/resources/ops.yaml
+++ b/scijava/scijava-ops-python/src/main/resources/ops.yaml
@@ -1,13 +1,8 @@
-info:
-  source: Python
-  package: SciJava Ops Numpy
-  version: 0-SNAPSHOT
-
 ops:
   - op:
       name: create.img
       priority: 0.0
-      source: numpy.zeros
+      source: pythonFunction:/numpy.zeros/v0.0
       type: java.util.function.Function
       parameters:
         - input: in1
@@ -19,7 +14,7 @@ ops:
   - op:
       name: numpy.linalg.det
       priority: 0.0
-      source: numpy.linalg.det
+      source: pythonFunction:/numpy.linalg.det/v0.0
       type: java.util.function.Function
       parameters:
         - input: in1

--- a/scijava/scijava-ops-python/src/main/resources/ops.yaml
+++ b/scijava/scijava-ops-python/src/main/resources/ops.yaml
@@ -8,14 +8,23 @@ ops:
       name: create.img
       priority: 0.0
       source: numpy.zeros
-      type: java.util.function.BiFunction
+      type: java.util.function.Function
       parameters:
         - input: in1
-          type: java.lang.Integer
-          description: The first input
-        - input: in2
-          type: java.lang.Integer
-          description: The second input
+          type: java.util.List<java.lang.Integer>
+          description: The shape of the output
         - output: out
           type: jep.NDArray
           description: The image
+  - op:
+      name: numpy.linalg.det
+      priority: 0.0
+      source: numpy.linalg.det
+      type: java.util.function.Function
+      parameters:
+        - input: in1
+          type: jep.AbstractNDArray
+          description: The shape of the output
+        - output: out
+          type: java.lang.Float
+          description: The output

--- a/scijava/scijava-ops-python/src/main/resources/ops.yaml
+++ b/scijava/scijava-ops-python/src/main/resources/ops.yaml
@@ -1,0 +1,21 @@
+info:
+  source: Python
+  package: SciJava Ops Numpy
+  version: 0-SNAPSHOT
+
+ops:
+  - op:
+      name: create.img
+      priority: 0.0
+      source: numpy.zeros
+      type: java.util.function.BiFunction
+      parameters:
+        - input: in1
+          type: java.lang.Integer
+          description: The first input
+        - input: in2
+          type: java.lang.Integer
+          description: The second input
+        - output: out
+          type: jep.NDArray
+          description: The image

--- a/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
+++ b/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
@@ -1,0 +1,28 @@
+package org.scijava.ops.python;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.api.OpEnvironment;
+import org.scijava.ops.engine.DefaultOpEnvironment;
+
+import jep.NDArray;
+
+public class PythonOpsTest {
+
+	private static OpEnvironment env;
+
+	/**
+	 * Create an {@link OpEnvironment} that discovers only YAML-declared Ops
+	 */
+	@BeforeAll
+	public static void setup() {
+		env = new DefaultOpEnvironment();
+	}
+
+	@Test
+	public void opsTest() {
+		NDArray sum = env.op("create.img").input(2, 3).outType(NDArray.class)
+				.apply();
+	}
+
+}

--- a/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
+++ b/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
@@ -1,11 +1,8 @@
 package org.scijava.ops.python;
 
-import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-import jep.DirectNDArray;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
+++ b/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonOpsTest.java
@@ -1,5 +1,12 @@
 package org.scijava.ops.python;
 
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import jep.DirectNDArray;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.api.OpEnvironment;
@@ -21,8 +28,17 @@ public class PythonOpsTest {
 
 	@Test
 	public void opsTest() {
-		NDArray sum = env.op("create.img").input(2, 3).outType(NDArray.class)
+		List<Integer> size = Arrays.asList(2, 2);
+		NDArray sum = env.op("create.img").input(size).outType(NDArray.class)
 				.apply();
+		Assertions.assertArrayEquals(sum.getDimensions(), new int[] { 2, 2 });
+
+		float[] f = new float[] {2.0f, 1.0f, 1.0f, 2.0f};
+		NDArray<float[]> input = new NDArray<>(f, 2, 2);
+		Float output = env.op("numpy.linalg.det").input(input).outType(Float.class)
+				.apply();
+		Assertions.assertEquals(3.0, output,1e-6);
+
 	}
 
 }

--- a/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonTest.java
+++ b/scijava/scijava-ops-python/src/test/java/org/scijava/ops/python/PythonTest.java
@@ -1,0 +1,23 @@
+
+package org.scijava.ops.python;
+
+import org.junit.jupiter.api.Test;
+
+import jep.Interpreter;
+
+/**
+ * Tests that we have access to the Python interpreter
+ *
+ * @author Gabriel Selzer
+ */
+public class PythonTest {
+
+	@Test
+	public void testOpsInterpreter() {
+		Interpreter interp = OpsPythonInterpreter.interpreter();
+		interp.exec("from java.lang import System");
+		interp.exec("s = 'Hello World'");
+		Object result = interp.getValue("s");
+		System.out.println(result);
+	}
+}


### PR DESCRIPTION
This PR is a hacky first cut at exposing Python functionality through Ops.

Fundamentally, Python access is provided through [jep](https://github.com/ninia/jep). This PR creates a single `jep.Interpreter`, configured within a utility class. This ensures that we have control over the configuration, and only have to do it once (although there is still more configuration that needs to be done.)

Ops themselves are declared in the `ops.yaml` resource file, and are discovered by an extension of the `YAMLOpInfoDiscoverer` created in #67. The discovered `PythonOpInfo`s use javassist to create a `FunctionalInterface` implementation that:
* Transfers the input data into Python
* Executes the Python functionality
* Transfers the output data from Python

What this PR does (currently):
* Shows what it might look like to wrap Python functionality in Ops
* Creates the foundations for actually wrapping it

What this PR doesn't do:
* Wrap NumPy extensively - it includes only a couple of functions as a proof-of-concept. We'd eventually want to come up with a way (Python script?) to automate the YAML generation, and also to provide a configuration mechanism (especially aliases - I think it would be nice to e.g. alias `numpy.zeros` to `create.img`, `numpy.add` to `math.add`, etc.). It might also be cool to add a `LANGUAGE` preference to `Hints`.
* Access Python cleanly - there are many bugs in this code, and it is very much a draft.
* Add any conversions - we can only call Python Ops on Python data structures, which, right now isn't very much. 

Benefits to this approach:
* It's internal to Java - Java users get access to Python!

Drawbacks to this approach: 
* We do not (currently) share/use any scyjava functionality - the converters, especially, could be useful for simplification fallbacks. It might be a good idea to port the scyjava conversion functionality to ops somewhere down the line, if we like this approach.