### PR TITLE
Handle OpMethods that the SciJava Ops Engine module cannot read

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/Converters.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/convert/Converters.java
@@ -44,8 +44,8 @@ public class Converters<I, O extends Type<O>> {
 	 * @output outputII
 	 * @implNote op names='convert'
 	 */
-	public final Functions.Arity3<RandomAccessible<I>, Converter<? super I, ? super O>, O, RandomAccessible<O>> generalConverterRA = (
-			inputRA, converter, type) -> net.imglib2.converter.Converters.convert(inputRA, converter, type);
+	public final Functions.Arity3<RandomAccessible<I>, Converter<? super I, ? super O>, O, RandomAccessible<O>> generalConverterRA =
+			net.imglib2.converter.Converters::convert;
 
 	/**
 	 * @input inputII
@@ -54,7 +54,7 @@ public class Converters<I, O extends Type<O>> {
 	 * @output outputII
 	 * @implNote op names='convert'
 	 */
-	public final Functions.Arity3<IterableInterval<I>, Converter<? super I, ? super O>, O, IterableInterval<O>> generalConverterII = (
-			inputII, converter, type) -> net.imglib2.converter.Converters.convert(inputII, converter, type);
+	public final Functions.Arity3<IterableInterval<I>, Converter<? super I, ? super O>, O, IterableInterval<O>> generalConverterII =
+			net.imglib2.converter.Converters::convert;
 
 }

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
@@ -32,6 +32,8 @@ package net.imagej.ops2.filter.gauss;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 
+import org.scijava.ops.spi.OpCollection;
+
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.gauss3.Gauss3;
@@ -45,74 +47,78 @@ import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.Views;
 
-import org.scijava.function.Computers;
-import org.scijava.ops.spi.OpCollection;
-
 /**
  * {@link OpCollection} containing various wrappings of Gaussian operations.
  * 
  * @author Gabriel Selzer
- *
- * @param <T>
- *            the input type
  */
-public class Gaussians<T extends NumericType<T> & NativeType<T>> {
+public class Gaussians {
 
 	/**
-	 * Gaussian filter, wrapping {@link Gauss3} of imglib2-algorithms. Note that we
-	 * put this at a lower priority so then if the input is a
+	 * Gaussian filter, wrapping {@link Gauss3} of imglib2-algorithms. Note that
+	 * we put this at a lower priority so then if the input is a
 	 * {@link RandomAccessibleInterval} we match to
 	 * {@link Gaussians#defaultGaussRAISimple} instead.
 	 *
 	 * @author Stephan Saalfeld
 	 * @author Christian Dietz (University of Konstanz)
-	 * @param <T>
-	 *            type of input and output
-	 * @input input
-	 * @input executorService
-	 * @input sigmas
-	 * @container output
-	 * @implNote op names='filter.gauss', priority='-100.'
+	 * @param <T> type of input and output
+	 * @param input the input image
+	 * @param es the {@link ExecutorService}
+	 * @param sigmas the sigmas for the Gaussian
+	 * @param output the pre-allocated output image
+	 * @implNote op names='filter.gauss', priority='-100.',
+	 *           type='org.scijava.function.Computers$Arity3'
 	 */
-	public final Computers.Arity3<RandomAccessible<T>, ExecutorService, double[], RandomAccessibleInterval<T>> defaultGaussRA = (input,
-			es, sigmas, output) -> {
+	public static <T extends NumericType<T> & NativeType<T>> void defaultGaussRA(
+		final RandomAccessible<T> input, //
+		final ExecutorService es, //
+		final double[] sigmas, //
+		final RandomAccessibleInterval<T> output //
+	) {
 		try {
-			SeparableSymmetricConvolution.convolve(Gauss3.halfkernels(sigmas), input, output,
-					es);
-		} catch (final IncompatibleTypeException e) {
+			SeparableSymmetricConvolution.convolve(Gauss3.halfkernels(sigmas), input,
+				output, es);
+		}
+		catch (final IncompatibleTypeException e) {
 			throw new RuntimeException(e);
 		}
-	};
+	}
 
 	/**
 	 * Gaussian filter, wrapping {@link Gauss3} of imglib2-algorithms.
 	 *
 	 * @author Christian Dietz (University of Konstanz)
 	 * @author Stephan Saalfeld
-	 * @param <T>
-	 *            type of input and output
-	 * @input input
-	 * @input executorService
-	 * @input sigmas
-	 * @input outOfBoundsFactory
-	 * @container output
-	 * @implNote op names='filter.gauss'
+	 * @param <T> type of input and output
+	 * @param input the input image
+	 * @param es the {@link ExecutorService}
+	 * @param sigmas the sigmas for the gaussian
+	 * @param outOfBounds the {@link OutOfBoundsFactory} that defines how the
+	 *          calculation is affected outside the input bounds.
+	 * @param output the output image
+	 * @implNote op names='filter.gauss',
+	 *           type='org.scijava.function.Computers$Arity4'
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public final Computers.Arity4<RandomAccessibleInterval<T>, ExecutorService, double[], //
-			OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>> defaultGaussRAI = (input,
-					es, sigmas, outOfBounds, output) -> {
+	public static <T extends NumericType<T> & NativeType<T>> void defaultGaussRAI(
+		final RandomAccessibleInterval<T> input, //
+		final ExecutorService es, //
+		final double[] sigmas, //
+		final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds, //
+		final RandomAccessibleInterval<T> output //
+	) {
+		final RandomAccessible<FloatType> eIn = //
+			(RandomAccessible) Views.extend(input, outOfBounds);
 
-				final RandomAccessible<FloatType> eIn = //
-						(RandomAccessible) Views.extend(input, outOfBounds);
-
-				try {
-					SeparableSymmetricConvolution.convolve(Gauss3.halfkernels(sigmas), eIn, output,
-							es);
-				} catch (final IncompatibleTypeException e) {
-					throw new RuntimeException(e);
-				}
-			};
+		try {
+			SeparableSymmetricConvolution.convolve(Gauss3.halfkernels(sigmas), eIn,
+				output, es);
+		}
+		catch (final IncompatibleTypeException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 	// -- Convenience Ops -- //
 
@@ -121,58 +127,76 @@ public class Gaussians<T extends NumericType<T> & NativeType<T>> {
 	 * {@link OutOfBoundsFactory}, in the case that the user does not provide one.
 	 * 
 	 * @author Gabriel Selzer
-	 *
-	 * @param <T>
-	 *            type of input
-	 * @input input
-	 * @input executorService
-	 * @input sigmas
-	 * @container output
-	 * @implNote op names='filter.gauss'
+	 * @param <T> type of input
+	 * @param input the input image
+	 * @param es the {@link ExecutorService}
+	 * @param sigmas the sigmas for the gaussian
+	 * @param output the output image
+	 * @implNote op names='filter.gauss',
+	 *           type='org.scijava.function.Computers$Arity3'
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public final Computers.Arity3<RandomAccessibleInterval<T>, ExecutorService, double[], RandomAccessibleInterval<T>> defaultGaussRAISimple = (
-			input, es, sigmas, output) -> defaultGaussRAI.compute(input, es, sigmas,
-					new OutOfBoundsMirrorFactory<>(Boundary.SINGLE), output);
+	public static <T extends NumericType<T> & NativeType<T>> void
+		defaultGaussRAISimple( //
+			final RandomAccessibleInterval<T> input, //
+			final ExecutorService es, //
+			final double[] sigmas, //
+			final RandomAccessibleInterval<T> output //
+	) {
+		defaultGaussRAI(input, es, sigmas, new OutOfBoundsMirrorFactory<>(
+			Boundary.SINGLE), output);
+	}
 
 	/**
-	 * Gaussian filter which can be called with single sigma, i.e. the sigma is the
-	 * same in each dimension.
+	 * Gaussian filter which can be called with single sigma, i.e. the sigma is
+	 * the same in each dimension.
 	 *
 	 * @author Christian Dietz (University of Konstanz)
 	 * @author Stephan Saalfeld
-	 * @param <T>
-	 *            type of input
-	 * @input input
-	 * @input executorService
-	 * @input sigma
-	 * @input outOfBoundsFactory
-	 * @container output
-	 * @implNote op names='filter.gauss'
+	 * @param <T> type of input
+	 * @param input the input image
+	 * @param es the {@link ExecutorService}
+	 * @param sigma the sigmas for the Gaussian
+	 * @param outOfBounds the {@link OutOfBoundsFactory} that defines how the
+	 *          calculation is affected outside the input bounds.
+	 * @param output the preallocated output image
+	 * @implNote op names='filter.gauss',
+	 *           type='org.scijava.function.Computers$Arity4'
 	 */
-	public final Computers.Arity4<RandomAccessibleInterval<T>, ExecutorService, Double, //
-			OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>> //
-	gaussRAISingleSigma = (input, es, sigma, outOfBounds, output) -> { //
+	public static <T extends NumericType<T> & NativeType<T>> void
+		gaussRAISingleSigma( //
+			final RandomAccessibleInterval<T> input, //
+			final ExecutorService es, //
+			final Double sigma, //
+			final OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds, //
+			final RandomAccessibleInterval<T> output //
+	) {
 		final double[] sigmas = new double[input.numDimensions()];
 		Arrays.fill(sigmas, sigma);
-		defaultGaussRAI.compute(input, es, sigmas, outOfBounds, output);
+		defaultGaussRAI(input, es, sigmas, outOfBounds, output);
 	};
 
 	/**
-	 * Gaussian filter which can be called with single sigma, i.e. the sigma is the
-	 * same in each dimension. Used when the user does not provide an
+	 * Gaussian filter which can be called with single sigma, i.e. the sigma is
+	 * the same in each dimension. Used when the user does not provide an
 	 * {@link OutOfBoundsFactory}
 	 *
 	 * @author Gabriel Selzer
-	 * @param <T>
-	 *            type of input
-	 * @input input
-	 * @input executorService
-	 * @input sigma
-	 * @container output
-	 * @implNote op names='filter.gauss'
+	 * @param <T> type of input
+	 * @param input the input image
+	 * @param es the {@link ExecutorService}
+	 * @param sigma the sigmas for the gaussian
+	 * @param output the output image
+	 * @implNote op names='filter.gauss',
+	 *           type='org.scijava.function.Computers$Arity3'
 	 */
-	public final Computers.Arity3<RandomAccessibleInterval<T>, ExecutorService, Double, RandomAccessibleInterval<T>> gaussRAISingleSigmaSimple = (
-			input, es, sigma, output) -> gaussRAISingleSigma.compute(input, es, sigma,
-					new OutOfBoundsMirrorFactory<>(Boundary.SINGLE), output);
+	public static <T extends NumericType<T> & NativeType<T>> void
+		gaussRAISingleSigmaSimple( //
+			final RandomAccessibleInterval<T> input, //
+			final ExecutorService es, //
+			final Double sigma, //
+			final RandomAccessibleInterval<T> output //
+	) {
+		gaussRAISingleSigma(input, es, sigma, new OutOfBoundsMirrorFactory<>(
+			Boundary.SINGLE), output);
+	}
 }


### PR DESCRIPTION
SciJava Ops Engine employs two different pathways for turning `public static Method`s into Ops. Both of these pathways try to obtain the `Method` by loading the owning `Class`, which fails when the `org.scijava.ops.engine` module does not `require` the module containing the `Method`. This is the case for ImageJ Ops2, and for all Op-containing modules we'd like to create in the future. This escaped our attention because we hadn't *actually* created any `OpMethod`s in ImageJ Ops2 :facepalm:

Well, fortunately for us, we don't *need* to import the Class, because `Discovery` will *always* give us an instance of that `Method` anyways, *and we don't need an owner instance because `OpMethod`s must be static*. For that reason, we can modify our javassist pathway to call [`Method.invoke`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/Method.html#invoke(java.lang.Object,java.lang.Object...)) on the `Method` instance we already have.

Points of discussion:
* What do we want to do with the other pathway,  which will no longer work (unless the engine `requires` its module, which is only the case for the engine itself right now). Should we get rid of it? Should we add a Module access check to the conditional?
* How do we want to test that this is fixed? We would have to change an Op outside of the engine to test this....

TODO:
* [x] Test this...somehow
* [x] Clean up the Javassist code