### PR TITLE
Add fallback to parameterize raw types

### DIFF
--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -1757,7 +1757,12 @@ public final class Types {
 					// check for anys
 					if (fromResolved instanceof Any || toResolved instanceof Any)
 						continue;
-					if (fromResolved instanceof ParameterizedType && Types.raw(fromResolved) == Types.raw(toResolved)) {
+					if (fromResolved instanceof ParameterizedType &&
+						toResolved instanceof ParameterizedType)
+					{
+						if (Types.raw(fromResolved) != Types.raw(toResolved)) {
+							return false;
+						}
 						Type[] fromTypes = ((ParameterizedType) fromResolved).getActualTypeArguments();
 						Type[] toTypes = ((ParameterizedType) toResolved).getActualTypeArguments();
 						for(int i = 0; i < fromTypes.length; i++) {

--- a/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
@@ -223,6 +223,8 @@ public class TypesTest {
 		final Type listInteger = new Nil<List<Integer>>() {}.getType();
 		final Type listExtendsNumber = new Nil<List<? extends Number>>() {}
 			.getType();
+		final Type listListRaw = new Nil<List<List>>(){}.getType();
+		final Type listListInteger = new Nil<List<List<Integer>>>(){}.getType();
 
 		assertTrue(Types.isAssignable(t, t));
 		assertTrue(Types.isAssignable(listT, listT));
@@ -238,6 +240,10 @@ public class TypesTest {
 		assertTrue(Types.isAssignable(listInteger, listT));
 		assertTrue(Types.isAssignable(listExtendsNumber, listT));
 		assertFalse(Types.isAssignable(listExtendsNumber, listNumber));
+
+		// Nested Type Variables must be EXACTLY the same to be assignable
+		assertFalse(Types.isAssignable(listListInteger, listListRaw));
+		assertTrue(Types.isAssignable(listListRaw, listListRaw));
 	}
 
 	/** Tests {@link Types#isAssignable(Type, Type)} against {@link Object} */


### PR DESCRIPTION
This PR fixes a `ClassCastException` arising from passing raw `Classes` to matcher calls instead of parameterized types. This would allow you to say, for example,
```java
ops.op("copy").input(img).outType(Img.class).apply();
```
The fix is made by adding another `instanceof ParameterizedType` check in `Types.isAssignable`. With this check, we ensure that that `toResolved` is also a `ParameterizedType`, meaning that `Class`es can no longer get into that code block.

This PR also adds a couple of tests to ensure exception-free behavior.