### PR TITLE
Improve raw type support

### DIFF
--- a/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/mean/MeanFilterTest.java
+++ b/imagej/imagej-ops2/src/test/java/net/imagej/ops2/filter/mean/MeanFilterTest.java
@@ -55,4 +55,13 @@ public class MeanFilterTest extends AbstractOpTest{
 		ops.op("filter.mean").arity2().input(img, shape).output(output).compute();
 	}
 
+	@Test
+	public void rawTypeAdaptationTest() {
+
+		Img<ByteType> img = ops.op("create.img").arity2().input(new FinalInterval(5, 5), new ByteType()).outType(new Nil<Img<ByteType>>() {}).apply();
+		RectangleShape shape = new RectangleShape(1, false);
+		OutOfBoundsFactory<ByteType, RandomAccessibleInterval<ByteType>> oobf = new OutOfBoundsBorderFactory<>();
+		var result = ops.op("filter.mean").arity3().input(img, shape, oobf).outType(Img.class).apply();
+
+	}
 }

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/RawTypeMatchingTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/RawTypeMatchingTest.java
@@ -1,0 +1,32 @@
+package org.scijava.ops.engine.matcher;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.spi.OpCollection;
+import org.scijava.ops.spi.OpField;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class RawTypeMatchingTest  extends AbstractTestEnvironment implements
+		OpCollection
+{
+
+	@BeforeAll
+	public static void addNeededOps() {
+		ops.register(new RawTypeMatchingTest());
+	}
+
+	@OpField(names = "test.match.raw")
+	public final  Function<Number, List<Number>> func = (x) -> List.of(x);
+
+	@Test
+	public void rawTypeAdaptationTest() {
+		Double d = 25.;
+		var list = ops.op("test.match.raw").arity1().input(d).outType(List.class).apply();
+		assertNotNull(list);
+	}
+}

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/OpsAsParametersTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/OpsAsParametersTest.java
@@ -1,23 +1,22 @@
 package org.scijava.ops.engine.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.api.OpBuilder;
-import org.scijava.ops.api.features.OpMatchingException;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
 import org.scijava.types.Nil;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OpsAsParametersTest extends AbstractTestEnvironment implements OpCollection {
 
@@ -40,16 +39,13 @@ public class OpsAsParametersTest extends AbstractTestEnvironment implements OpCo
 
 	@Test
 	public void TestOpWithNonReifiableFunction() {
-
-		List<Number> list = new ArrayList<>();
-		list.add(40l);
-		list.add(20.5);
-		list.add(4.0d);
-
-		assertThrows(OpMatchingException.class, //
-				() -> ops.op("test.parameter.op").arity2().input(list, func).outType(new Nil<List<Double>>() {
-				}).apply() //
-		);
+		var list = Arrays.asList(40L, 20.5, 4.0d);
+		var actual = ops//
+			.op("test.parameter.op") //
+			.arity2().input(list, func) //
+			.outType(List.class) //
+			.apply();
+		assertEquals(Arrays.asList(40.0, 20.5, 4.0), actual);
 	}
 
 	@Test

--- a/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -588,6 +588,11 @@ public final class Types {
 		final ParameterizedType param,
 		final HashMap<TypeVariable<?>, TypeVarInfo> typeBounds)
 	{
+		if (arg instanceof Class) {
+			Class<?> paramRaw = Types.raw(param);
+			return Types.isAssignable(arg, paramRaw);
+		}
+
 		// get an array of the destination parameter types
 		Type[] destTypes = param.getActualTypeArguments();
 		Type[] srcTypes = new Type[destTypes.length];
@@ -596,7 +601,7 @@ public final class Types {
 		Type argType = arg;
 		Type superType = Types
 				.getExactSuperType(argType, Types.raw(param));
-		if (superType == null || !(superType instanceof ParameterizedType)) return false;
+		if (!(superType instanceof ParameterizedType)) return false;
 		srcTypes = ((ParameterizedType)superType).getActualTypeArguments();
 		
 		// List to collect the indices of destination parameters that are type vars

--- a/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
+++ b/scijava/scijava-types/src/test/java/org/scijava/types/TypesTest.java
@@ -218,6 +218,7 @@ public class TypesTest {
 	@Test
 	public <T extends Number> void testIsAssignableT() {
 		final Type t = new Nil<T>() {}.getType();
+		final Type listRaw = List.class;
 		final Type listT = new Nil<List<T>>() {}.getType();
 		final Type listNumber = new Nil<List<Number>>() {}.getType();
 		final Type listInteger = new Nil<List<Integer>>() {}.getType();
@@ -227,19 +228,29 @@ public class TypesTest {
 		final Type listListInteger = new Nil<List<List<Integer>>>(){}.getType();
 
 		assertTrue(Types.isAssignable(t, t));
+		assertTrue(Types.isAssignable(listRaw, listRaw));
 		assertTrue(Types.isAssignable(listT, listT));
 		assertTrue(Types.isAssignable(listNumber, listNumber));
 		assertTrue(Types.isAssignable(listInteger, listInteger));
 		assertTrue(Types.isAssignable(listExtendsNumber, listExtendsNumber));
 
+		assertTrue(Types.isAssignable(listRaw, listExtendsNumber));
 		assertTrue(Types.isAssignable(listT, listExtendsNumber));
 		assertTrue(Types.isAssignable(listNumber, listExtendsNumber));
 		assertTrue(Types.isAssignable(listInteger, listExtendsNumber));
 
+		assertTrue(Types.isAssignable(listRaw, listT));
 		assertTrue(Types.isAssignable(listNumber, listT));
 		assertTrue(Types.isAssignable(listInteger, listT));
 		assertTrue(Types.isAssignable(listExtendsNumber, listT));
 		assertFalse(Types.isAssignable(listExtendsNumber, listNumber));
+
+		assertTrue(Types.isAssignable(listT, listRaw));
+		assertTrue(Types.isAssignable(listNumber, listRaw));
+		assertTrue(Types.isAssignable(listInteger, listRaw));
+		assertTrue(Types.isAssignable(listExtendsNumber, listRaw));
+		assertTrue(Types.isAssignable(listListRaw, listRaw));
+		assertTrue(Types.isAssignable(listListInteger, listRaw));
 
 		// Nested Type Variables must be EXACTLY the same to be assignable
 		assertFalse(Types.isAssignable(listListInteger, listListRaw));


### PR DESCRIPTION
Raw types can be compile-time casted into any generic type. Let's make sure we can handle that case in the matcher!

This allows you to make Op calls like
```java
ops.op("filter.mean")
  .inType(RandomAccessibleInterval.class, Shape.class, OutOfBoundsFactory.class)
  .outType(Img.class)
  .function();
```