### PR TITLE
Box primitive OpMethod parameters

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
@@ -114,7 +114,7 @@ public class Gaussians {
 		gaussRAISingleSigma( //
 			final RandomAccessibleInterval<T> input, //
 			final ExecutorService es, //
-			final Double sigma, //
+			final double sigma, //
 			@Optional OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds, //
 			final RandomAccessibleInterval<T> output //
 	) {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.scijava.common3.Classes;
 import org.scijava.common3.validity.ValidityException;
 import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.meta.Versions;
@@ -399,7 +400,7 @@ public class OpMethodInfo implements OpInfo {
 		Parameter[] mParams = m.getParameters();
 		for (Parameter mParam : mParams) {
 			Class<?> paramRawType = Types.raw(mParam.getParameterizedType());
-			String castClassName = paramRawType.getName();
+			String castClassName = Classes.box(paramRawType).getName();
 			if (paramRawType.isArray()) castClassName = paramRawType.getSimpleName();
 			sb.append("(") //
 				.append(castClassName) //

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/internal/OpMethodUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/internal/OpMethodUtils.java
@@ -1,12 +1,14 @@
 package org.scijava.ops.engine.util.internal;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.scijava.common3.Classes;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.types.Types;
 import org.scijava.types.inference.GenericAssignability;
@@ -36,9 +38,11 @@ public class OpMethodUtils {
 		GenericAssignability.inferTypeVariables(typeMethodParams, getOpParamTypes(
 			opMethodParams), typeVarAssigns);
 		if (abstractMethod.getReturnType() != void.class) {
+			Type returnType = opMethod.getGenericReturnType();
+			if (Types.raw(returnType).isPrimitive())
+				returnType = Classes.box(Types.raw(returnType));
 			GenericAssignability.inferTypeVariables(new Type[] { abstractMethod
-				.getGenericReturnType() }, new Type[] { opMethod
-					.getGenericReturnType() }, typeVarAssigns);
+				.getGenericReturnType() }, new Type[] {returnType}, typeVarAssigns);
 		}
 
 		// parameterize opClass
@@ -60,7 +64,9 @@ public class OpMethodUtils {
 		return Arrays //
 			.stream(methodParams) //
 			.filter(param -> param.getAnnotation(OpDependency.class) == null) //
-			.map(param -> param.getParameterizedType()).toArray(Type[]::new);
+			.map(Parameter::getParameterizedType) //
+			.map(param -> Types.raw(param).isPrimitive() ? Classes.box(Types.raw(param)) : param) //
+			.toArray(Type[]::new);
 	}
 
 }

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodBoxTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodBoxTest.java
@@ -1,0 +1,30 @@
+package org.scijava.ops.engine;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.spi.OpCollection;
+import org.scijava.ops.spi.OpMethod;
+
+public class OpMethodBoxTest extends AbstractTestEnvironment implements OpCollection {
+	@BeforeAll
+	public static void addNeededOps() {
+		ops.register(new OpMethodBoxTest());
+	}
+
+	@OpMethod(names = "test.box", type = Function.class)
+	public static int increment(final int i1) {
+		return i1 + 1;
+	}
+
+	@Test
+	public void testOpMethodBoxing(){
+		Integer result = ops.op("test.box").arity1().input(1) //
+			.outType(Integer.class).apply();
+		Assertions.assertEquals(2, result);
+	}
+
+
+}


### PR DESCRIPTION
This allows us to use LambdaMetaFactory/Javassist to call methods with primitive parameters as Ops!

To test this, I wrote `OpMethodBoxTest`, which ensures that `LambdaMetaFactory` works as intended, and I modified ImageJ Ops2's single-sigma gauss Op to run on a primitive double, which ensures Javassist works.

Closes scijava/scijava#107