### PR TITLE
Create API for global progress listeners

### DIFF
--- a/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/ReportingProgress.java
+++ b/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/ReportingProgress.java
@@ -119,18 +119,22 @@ public class ReportingProgress implements OpCollection {
 		// This ProgressListener simply prints out the status of the Op
 		// to the console, but we could print out something else,
 		// or pass this information somewhere else.
-		ProgressListener l = //
-			task -> System.out.printf("Op progress: %.2f\n", task.progress());
+		ProgressListener l = task -> //
+			 System.out.printf("Progress of %s: %.2f\n", task.description(), task.progress());
+		// To listen to Op progress updates, the ProgressListener must be registered
+		// through the Progress API. To listen to all Op executions, use the
+		// following call:
+		Progress.addGlobalListener(l);
+		// If listening to every Op would be overwhelming, the Progress API also
+		// allows ProgressListeners to be registered for a specific Op, using the
+		// following call:
+		// Progress.addListener(op, l);
 
 		// Get the function.
 		var op = ops.unary("tutorial.long.op") //
 			.inType(Integer.class) //
 			.outType(new Nil<List<Long>>() {}) //
 			.function();
-		// Listening to every Op would be overwhelming.
-		// Ops must be deliberately linked to a ProgressListener through the
-		// Progress API.
-		Progress.addListener(op, l);
 
 		// When we apply the Op, we will automatically print the progress out to
 		// the console, thanks to our ProgressListener above.

--- a/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/ReportingProgress.java
+++ b/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/ReportingProgress.java
@@ -37,6 +37,7 @@ import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
 import org.scijava.progress.Progress;
 import org.scijava.progress.ProgressListener;
+import org.scijava.progress.StandardOutputProgressLogger;
 import org.scijava.types.Nil;
 
 /**
@@ -116,11 +117,9 @@ public class ReportingProgress implements OpCollection {
 		OpEnvironment ops = OpEnvironment.getEnvironment();
 
 		// ProgressListeners consume task updates.
-		// This ProgressListener simply prints out the status of the Op
-		// to the console, but we could print out something else,
-		// or pass this information somewhere else.
-		ProgressListener l = task -> //
-			 System.out.printf("Progress of %s: %.2f\n", task.description(), task.progress());
+		// This ProgressListener simply logs to standard output, but we could print
+		// out something else, or pass this information somewhere else.
+		ProgressListener l = new StandardOutputProgressLogger();
 		// To listen to Op progress updates, the ProgressListener must be registered
 		// through the Progress API. To listen to all Op executions, use the
 		// following call:

--- a/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInstance.java
+++ b/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInstance.java
@@ -91,4 +91,9 @@ public class OpInstance<T> implements GenericTyped {
 		return reifiedType;
 	}
 
+	@Override
+	public String toString() {
+		return infoTree().info().implementationName();
+	}
+
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -100,4 +100,9 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 		this.record = record;
 	}
 
+	@Override
+	public String toString() {
+		return instance().toString();
+	}
+
 }

--- a/scijava/scijava-progress/pom.xml
+++ b/scijava/scijava-progress/pom.xml
@@ -105,7 +105,6 @@
 		<allowedDuplicateClasses>${scijava-progress.allowedDuplicateClasses}</allowedDuplicateClasses>
 	</properties>
 	<dependencies>
-		<!-- SciJava dependencies -->
 		<!-- Test scope dependencies -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
@@ -48,7 +48,8 @@ public final class Progress {
 	 * A record of all listeners interested in the progress of all Object
 	 * executions
 	 */
-	private static final List<ProgressListener> globalListeners = new ArrayList<>();
+	private static final List<ProgressListener> globalListeners =
+		new ArrayList<>();
 
 	/**
 	 * A record of all listeners interested in the progress of a given Object's
@@ -108,7 +109,7 @@ public final class Progress {
 		}
 		addListenerToList(progressible, l);
 	}
-	
+
 	private static void addListenerToList(Object progressible,
 		ProgressListener l)
 	{
@@ -125,7 +126,8 @@ public final class Progress {
 
 	/**
 	 * Completes the current task on this {@link Thread}'s execution hierarchy,
-	 * removing it in the process. This method also takaes care to ping relevant {@link ProgressListener}s.
+	 * removing it in the process. This method also takaes care to ping relevant
+	 * {@link ProgressListener}s.
 	 * 
 	 * @see Task#complete()
 	 */
@@ -148,7 +150,8 @@ public final class Progress {
 	 * {@link Progress}' progress-reporting API between the time this method is
 	 * called and the time when {@link Progress#complete()} is called.
 	 *
-	 * @param progressible an {@link Object} that would like to report its progress.
+	 * @param progressible an {@link Object} that would like to report its
+	 *          progress.
 	 */
 	public static void register(final Object progressible) {
 		register(progressible, progressible.toString());
@@ -160,10 +163,13 @@ public final class Progress {
 	 * {@link Progress}' progress-reporting API between the time this method is
 	 * called and the time when {@link Progress#complete()} is called.
 	 * 
-	 * @param progressible an {@link Object} that would like to report its progress.
+	 * @param progressible an {@link Object} that would like to report its
+	 *          progress.
 	 * @param description a {@link String} describing {@code progressible}
 	 */
-	public static void register(final Object progressible, final String description) {
+	public static void register(final Object progressible,
+		final String description)
+	{
 		Task t;
 		if (progressibleStack.get().size() == 0) {
 			// completely new execution hierarchy

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
@@ -171,16 +171,17 @@ public final class Progress {
 		final String description)
 	{
 		Task t;
-		if (progressibleStack.get().size() == 0) {
+		var deque = progressibleStack.get();
+		var parent = deque.peek();
+		if (parent == null) {
 			// completely new execution hierarchy
 			t = new Task(description);
 		}
 		else {
 			// part of an existing execution hierarchy
-			ProgressibleObject parent = progressibleStack.get().peek();
-			t = parent.task().createSubtask();
+			t = parent.task().createSubtask(description);
 		}
-		progressibleStack.get().push(new ProgressibleObject(progressible, t));
+		deque.push(new ProgressibleObject(progressible, t));
 	}
 
 	/**
@@ -247,7 +248,7 @@ public final class Progress {
 	/**
 	 * Defines the total progress of the current {@link Task}
 	 * 
-	 * @see Task#defineTotalProgress(int)
+	 * @see Task#defineTotalProgress(long)
 	 */
 	public static void defineTotalProgress(long numStages) {
 		currentTask().defineTotalProgress(numStages);
@@ -256,7 +257,7 @@ public final class Progress {
 	/**
 	 * Defines the total progress of the current {@link Task}
 	 * 
-	 * @see Task#defineTotalProgress(int, int)
+	 * @see Task#defineTotalProgress(long, long)
 	 */
 	public static void defineTotalProgress(long numStages, long numSubTasks) {
 		currentTask().defineTotalProgress(numStages, numSubTasks);

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
@@ -108,7 +108,7 @@ public final class Progress {
 		}
 		addListenerToList(progressible, l);
 	}
-
+	
 	private static void addListenerToList(Object progressible,
 		ProgressListener l)
 	{
@@ -132,12 +132,26 @@ public final class Progress {
 	public static void complete() {
 		// update completed task
 		ProgressibleObject completed = progressibleStack.get().pop();
-		completed.task().complete();
-		// ping relevant listeners
-		pingListeners(completed);
-		if (progressibleStack.get().peek() != null) {
-			pingListeners(progressibleStack.get().peek());
+		if (!completed.task().isComplete()) {
+			completed.task().complete();
+			// ping relevant listeners
+			pingListeners(completed);
+			if (progressibleStack.get().peek() != null) {
+				pingListeners(progressibleStack.get().peek());
+			}
 		}
+	}
+
+	/**
+	 * Creates a new {@link Task} for {@code progressible}. This method makes the
+	 * assumption that {@code progressible} is responsible for any calls to
+	 * {@link Progress}' progress-reporting API between the time this method is
+	 * called and the time when {@link Progress#complete()} is called.
+	 *
+	 * @param progressible an {@link Object} that would like to report its progress.
+	 */
+	public static void register(final Object progressible) {
+		register(progressible, progressible.toString());
 	}
 
 	/**
@@ -147,12 +161,13 @@ public final class Progress {
 	 * called and the time when {@link Progress#complete()} is called.
 	 * 
 	 * @param progressible an {@link Object} that would like to report its progress.
+	 * @param description a {@link String} describing {@code progressible}
 	 */
-	public static void register(Object progressible) {
+	public static void register(final Object progressible, final String description) {
 		Task t;
 		if (progressibleStack.get().size() == 0) {
 			// completely new execution hierarchy
-			t = new Task();
+			t = new Task(description);
 		}
 		else {
 			// part of an existing execution hierarchy
@@ -228,7 +243,7 @@ public final class Progress {
 	 * 
 	 * @see Task#defineTotalProgress(int)
 	 */
-	public static void defineTotalProgress(int numStages) {
+	public static void defineTotalProgress(long numStages) {
 		currentTask().defineTotalProgress(numStages);
 	}
 
@@ -237,7 +252,7 @@ public final class Progress {
 	 * 
 	 * @see Task#defineTotalProgress(int, int)
 	 */
-	public static void defineTotalProgress(int numStages, int numSubTasks) {
+	public static void defineTotalProgress(long numStages, long numSubTasks) {
 		currentTask().defineTotalProgress(numStages, numSubTasks);
 	}
 

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Progress.java
@@ -45,6 +45,12 @@ import java.util.WeakHashMap;
 public final class Progress {
 
 	/**
+	 * A record of all listeners interested in the progress of all Object
+	 * executions
+	 */
+	private static final List<ProgressListener> globalListeners = new ArrayList<>();
+
+	/**
 	 * A record of all listeners interested in the progress of a given Object's
 	 * executions
 	 */
@@ -74,6 +80,19 @@ public final class Progress {
 				return new ArrayDeque<>();
 			}
 		};
+
+	/**
+	 * Records {@link ProgressListener} {@code l} as a callback for all
+	 * progressible {@link Object}s
+	 *
+	 * @param l a {@link ProgressListener} that would like to know about the
+	 *          progress of {@code progressible} {@link Object}s
+	 */
+	public static void addGlobalListener(ProgressListener l) {
+		if (!globalListeners.contains(l)) {
+			globalListeners.add(l);
+		}
+	}
 
 	/**
 	 * Records {@link ProgressListener} {@code l} as a callback for progressible
@@ -150,10 +169,15 @@ public final class Progress {
 	 * @param o an {@link Object} reporting its progress.
 	 */
 	private static void pingListeners(ProgressibleObject o) {
+		// Ping object-specific listeners
 		List<ProgressListener> list = progressibleListeners.getOrDefault(o.object(),
 			Collections.emptyList());
 		synchronized (list) {
 			list.forEach(l -> l.acknowledgeUpdate(o.task()));
+		}
+		// Ping global listeners
+		synchronized (globalListeners) {
+			globalListeners.forEach(l -> l.acknowledgeUpdate(o.task()));
 		}
 	}
 

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/StandardOutputProgressLogger.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/StandardOutputProgressLogger.java
@@ -1,0 +1,24 @@
+
+package org.scijava.progress;
+
+/**
+ * Simple {@link ProgressListener} logging updates to standard output.
+ *
+ * @author Gabriel Selzer
+ */
+public class StandardOutputProgressLogger implements ProgressListener {
+
+	@Override
+	public void acknowledgeUpdate(Task task) {
+		if (task.isComplete()) {
+			System.out.printf("Progress of %s: Complete\n", task.description());
+		}
+		else {
+			System.out.printf( //
+				"Progress of %s: %.2f\n", //
+				task.description(), //
+				task.progress() //
+			);
+		}
+	}
+}

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Task.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Task.java
@@ -72,7 +72,8 @@ public class Task {
 	private final AtomicLong subTasksCompleted = new AtomicLong(0);
 
 	/**
-	 * True iff a call to {@link Task#defineTotalProgress(long, long)} has been made
+	 * True iff a call to {@link Task#defineTotalProgress(long, long)} has been
+	 * made
 	 */
 	private boolean tasksDefined = false;
 
@@ -117,7 +118,8 @@ public class Task {
 	 * @return the subtask.
 	 */
 	public synchronized Task createSubtask() {
-		final Task sub = new Task(this, "Subtask " + subTasks.size() + 1 + " of Task \"" + id + "\"");
+		final Task sub = new Task(this, "Subtask " + subTasks.size() + 1 +
+			" of Task \"" + id + "\"");
 		subTasks.add(sub);
 		return sub;
 	}
@@ -169,8 +171,8 @@ public class Task {
 	/**
 	 * Calculates and returns the progress of the associated progressible
 	 * {@link Object}. If the total progress is defined using
-	 * {@link Task#defineTotalProgress(long, long)}, then this method will return a
-	 * {@code double} within the range [0, 1]. If the progress is <b>not</b>
+	 * {@link Task#defineTotalProgress(long, long)}, then this method will return
+	 * a {@code double} within the range [0, 1]. If the progress is <b>not</b>
 	 * defined, then this task will return {@code 0} until {@link #complete()} is
 	 * called; after that call this method will return {@code 1.}.
 	 *

--- a/scijava/scijava-progress/src/main/java/org/scijava/progress/Task.java
+++ b/scijava/scijava-progress/src/main/java/org/scijava/progress/Task.java
@@ -80,20 +80,20 @@ public class Task {
 	/** True iff {@link Task#max} has been defined for the current stage */
 	private boolean updateDefined = false;
 
-	/** Computation status as defined by the task */
-	private final String id;
+	/** String identifying the task */
+	private final String description;
 
 	/** Computation status as defined by the task */
 	private String status = "Executing...";
 
-	public Task(final String id) {
+	public Task(final String description) {
 		this.parent = null;
-		this.id = id;
+		this.description = description;
 	}
 
-	public Task(final Task parent, final String id) {
+	public Task(final Task parent, final String description) {
 		this.parent = parent;
-		this.id = id;
+		this.description = description;
 	}
 
 	/**
@@ -117,9 +117,8 @@ public class Task {
 	 *
 	 * @return the subtask.
 	 */
-	public synchronized Task createSubtask() {
-		final Task sub = new Task(this, "Subtask " + subTasks.size() + 1 +
-			" of Task \"" + id + "\"");
+	public synchronized Task createSubtask(String description) {
+		final Task sub = new Task(this, description);
 		subTasks.add(sub);
 		return sub;
 	}
@@ -242,8 +241,8 @@ public class Task {
 	 *
 	 * @return the id
 	 */
-	public String id() {
-		return id;
+	public String description() {
+		return description;
 	}
 
 	/**

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
@@ -44,7 +44,6 @@ public class DefaultProgressTest {
 	private static final long NUM_ITERATIONS = 100;
 	private static final long NUM_STAGES = 10;
 
-
 	/**
 	 * Tests progress listening when an progressible {@link Object} never
 	 * explicitly updates its own progress. We thus expect to be notified
@@ -172,8 +171,8 @@ public class DefaultProgressTest {
 	}
 
 	/**
-	 * Test that {@link ProgressListener}s added at a global level can listen to
-	 * a progressible object without being explicitly linked
+	 * Test that {@link ProgressListener}s added at a global level can listen to a
+	 * progressible object without being explicitly linked
 	 */
 	@Test
 	public void testGlobalProgressListener() {
@@ -190,7 +189,7 @@ public class DefaultProgressTest {
 		};
 		// Add the ProgressListener
 		var id = "This is a global listener";
-		var listener = new TestSuiteProgressListener(NUM_ITERATIONS,  id);
+		var listener = new TestSuiteProgressListener(NUM_ITERATIONS, id);
 		Progress.addGlobalListener(listener);
 		// Register the Task
 		Progress.register(progressible, id);
@@ -202,8 +201,8 @@ public class DefaultProgressTest {
 	}
 
 	/**
-	 * Test that {@link ProgressListener}s added at a global level can listen to
-	 * a progressible object without being explicitly linked
+	 * Test that {@link ProgressListener}s added at a global level can listen to a
+	 * progressible object without being explicitly linked
 	 */
 	@Test
 	public void testProgressListenerIdentifiers() {
@@ -220,13 +219,13 @@ public class DefaultProgressTest {
 		};
 		// Add a ProgressListener that should acknowledge this task
 		var goodId = "This one should be listened to";
-		var goodListener = new TestSuiteProgressListener(NUM_ITERATIONS,  goodId);
+		var goodListener = new TestSuiteProgressListener(NUM_ITERATIONS, goodId);
 		Progress.addGlobalListener(goodListener);
 		// Register the Task with goodId
 		Progress.register(progressible, goodId);
 		// Create a second global listener that will not acknowledge this task
 		var badId = "This one should not be listened to";
-		var badListener = new TestSuiteProgressListener(NUM_ITERATIONS,  badId);
+		var badListener = new TestSuiteProgressListener(NUM_ITERATIONS, badId);
 		Progress.addGlobalListener(badListener);
 		// Run the Task
 		progressible.get();

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
@@ -201,8 +201,8 @@ public class DefaultProgressTest {
 	}
 
 	/**
-	 * Test that {@link ProgressListener}s added at a global level can listen to a
-	 * progressible object without being explicitly linked
+	 * Test that {@link ProgressListener}s added at a global level can determine
+	 * whether to listen to a {@link Task} by looking at its description.
 	 */
 	@Test
 	public void testProgressListenerIdentifiers() {

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
@@ -178,4 +178,42 @@ public class DefaultProgressTest {
 		Progress.complete();
 	}
 
+	@Test
+	public void testGlobalProgressListener() {
+		BiFunction<Integer, Integer, Integer> progressible = doubleIterator;
+
+		int numIterations = 4;
+		int numStages = 2;
+
+
+		ProgressListener global = new ProgressListener() {
+
+			double currentIterations = 1;
+			final double maxIterations = numStages * numIterations;
+			boolean alreadyCompleted = false;
+
+			@Override
+			public void acknowledgeUpdate(final Task task) {
+				if (!task.isComplete()) {
+					var expected = currentIterations / maxIterations;
+					var actual = task.progress();
+					Assertions.assertEquals(expected, actual, 1e-6);
+					currentIterations++;
+				}
+				else {
+					// Assert complete listen only happens once, when iterations = max
+					Assertions.assertFalse(alreadyCompleted);
+					Assertions.assertEquals(currentIterations, maxIterations);
+					alreadyCompleted = true;
+				}
+			}
+		};
+		Progress.addGlobalListener(global);
+
+		Progress.register(progressible);
+		progressible.apply(numStages, numIterations);
+		Progress.complete();
+	}
+
+
 }

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/DefaultProgressTest.java
@@ -29,8 +29,7 @@
 
 package org.scijava.progress;
 
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,60 +41,9 @@ import org.junit.jupiter.api.Test;
  */
 public class DefaultProgressTest {
 
-	/**
-	 * Function that never operates its progress during its operation.
-	 * 
-	 * @input size the number of indices desired in the returned array
-	 * @output an {@code int[]} of size {@code size}
-	 */
-	public final Function<Integer, int[]> arrayCreator2 = (size) -> {
-		int[] arr = new int[size];
-		for (int i = 0; i < arr.length; i++) {
-			arr[i] = 1;
-		}
-		return arr;
-	};
+	private static final long NUM_ITERATIONS = 100;
+	private static final long NUM_STAGES = 10;
 
-	/**
-	 * BiFunction that updates its progress
-	 * {@code numIterations*iterationsPerStage} times during its operation.
-	 * 
-	 * @input numStages the number of defined stages this task should perform
-	 * @input iterationsPerStage the number of times the task should update its
-	 *        progress.
-	 * @output the number of <b>total</b> iterations performed
-	 */
-	public final BiFunction<Integer, Integer, Integer> doubleIterator = (
-		numStages, iterationsPerStage) -> {
-		// set up progress reporter
-		Progress.defineTotalProgress(numStages);
-		for (int j = 0; j < numStages; j++) {
-			Progress.setStageMax(iterationsPerStage);
-
-			for (int i = 0; i < iterationsPerStage; i++) {
-				Progress.update();
-			}
-		}
-		return numStages * iterationsPerStage;
-	};
-
-	/**
-	 * Function that updates its progress {@code iterations} times during its
-	 * operation.
-	 * 
-	 * @input iterations the number of times the task should update its progress.
-	 * @output the number of iterations performed
-	 */
-	public final Function<Integer, Integer> iterator = (iterations) -> {
-		// set up progress reporter
-		Progress.defineTotalProgress(1);
-		Progress.setStageMax(iterations);
-
-		for (int i = 0; i < iterations; i++) {
-			Progress.update();
-		}
-		return iterations;
-	};
 
 	/**
 	 * Tests progress listening when an progressible {@link Object} never
@@ -104,24 +52,23 @@ public class DefaultProgressTest {
 	 */
 	@Test
 	public void testUpdateWithoutDefinition() {
-		Function<Integer, int[]> progressible = arrayCreator2;
-
-		Progress.addListener(progressible, new ProgressListener() {
-
-			int timesUpdated = 0;
-
-			@Override
-			public void acknowledgeUpdate(Task task) {
-				if (timesUpdated > 0) Assertions.fail(
-					"If the Task doesn't call update, the listener should only be called upon the Task's completion!");
-				timesUpdated++;
-				Assertions.assertEquals(task.progress(), 1., 1e-6);
+		Supplier<Long> progressible = () -> {
+			int foo = 0;
+			for (int i = 0; i < NUM_ITERATIONS; i++) {
+				foo = foo + 1;
 			}
-
-		});
+			return NUM_ITERATIONS;
+		};
+		// Add the ProgressListener
+		var listener = new TestSuiteProgressListener(0);
+		Progress.addListener(progressible, listener);
+		// Register the Task
 		Progress.register(progressible);
-		progressible.apply(3);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
 		Progress.complete();
+		Assertions.assertTrue(listener.isComplete());
 	}
 
 	/**
@@ -129,26 +76,66 @@ public class DefaultProgressTest {
 	 * and no dependencies.
 	 */
 	@Test
-	public void testSimpleReporter() {
-		// obtain the task
-		Function<Integer, Integer> progressible = iterator;
+	public void testSingleStageReporter() {
+		// Define the task
+		Supplier<Long> progressible = () -> {
+			// set up progress reporter
+			Progress.defineTotalProgress(1);
+			Progress.setStageMax(NUM_ITERATIONS);
 
-		int numIterations = 100;
-		Progress.addListener(progressible, new ProgressListener() {
-
-			double currentIterations = 1;
-			double maxIterations = numIterations;
-
-			@Override
-			public void acknowledgeUpdate(Task task) {
-				Assertions.assertEquals(Math.min(1., currentIterations++ /
-					maxIterations), task.progress(), 1e-6);
+			for (int i = 0; i < NUM_ITERATIONS; i++) {
+				Progress.update();
 			}
-		});
-		Progress.register(progressible);
-		progressible.apply(numIterations);
-		Progress.complete();
+			return NUM_ITERATIONS;
+		};
 
+		// Add the ProgressListener
+		var listener = new TestSuiteProgressListener(NUM_ITERATIONS);
+		Progress.addListener(progressible, listener);
+		// Register the Task
+		Progress.register(progressible);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
+		Progress.complete();
+		Assertions.assertTrue(listener.isComplete());
+	}
+
+	/**
+	 * Tests running a progressible multiple times, and ensures progress is reset
+	 * each time.
+	 */
+	@Test
+	public void testMultipleExecutions() {
+		// Define the task
+		Supplier<Long> progressible = () -> {
+			// set up progress reporter
+			Progress.defineTotalProgress(1);
+			Progress.setStageMax(NUM_ITERATIONS);
+
+			for (int i = 0; i < NUM_ITERATIONS; i++) {
+				Progress.update();
+			}
+			return NUM_ITERATIONS;
+		};
+		// Add the ProgressListener
+		var listener = new TestSuiteProgressListener(NUM_ITERATIONS);
+		Progress.addListener(progressible, listener);
+		// Register the Task
+		Progress.register(progressible);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
+		Progress.complete();
+		Assertions.assertTrue(listener.isComplete());
+		// Reset the listener
+		listener.reset();
+		// Register the Task
+		Progress.register(progressible);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
+		Progress.complete();
 	}
 
 	/**
@@ -157,63 +144,97 @@ public class DefaultProgressTest {
 	 */
 	@Test
 	public void testMultiStageReporter() {
-		// obtain the task
-		BiFunction<Integer, Integer, Integer> progressible = doubleIterator;
+		// Define the task
+		Supplier<Long> progressible = () -> {
+			// set up progress reporter
+			Progress.defineTotalProgress(NUM_STAGES);
+			for (int j = 0; j < NUM_STAGES; j++) {
+				Progress.setStageMax(NUM_ITERATIONS);
 
-		int numIterations = 100;
-		int numStages = 10;
-		Progress.addListener(progressible, new ProgressListener() {
-
-			double currentIterations = 1;
-			double maxIterations = numStages * numIterations;
-
-			@Override
-			public void acknowledgeUpdate(Task task) {
-				Assertions.assertEquals(Math.min(1., currentIterations++ /
-					maxIterations), task.progress(), 1e-6);
+				for (int i = 0; i < NUM_ITERATIONS; i++) {
+					Progress.update();
+				}
 			}
-		});
+			return NUM_STAGES * NUM_ITERATIONS;
+		};
+
+		// Add the ProgressListener
+		var expected = NUM_ITERATIONS * NUM_STAGES;
+		var listener = new TestSuiteProgressListener(expected);
+		Progress.addListener(progressible, listener);
+		// Register the Task
 		Progress.register(progressible);
-		progressible.apply(numStages, numIterations);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
 		Progress.complete();
+		Assertions.assertTrue(listener.isComplete());
 	}
 
+	/**
+	 * Test that {@link ProgressListener}s added at a global level can listen to
+	 * a progressible object without being explicitly linked
+	 */
 	@Test
 	public void testGlobalProgressListener() {
-		BiFunction<Integer, Integer, Integer> progressible = doubleIterator;
+		// Define the task
+		Supplier<Long> progressible = () -> {
+			// set up progress reporter
+			Progress.defineTotalProgress(1);
+			Progress.setStageMax(NUM_ITERATIONS);
 
-		int numIterations = 4;
-		int numStages = 2;
-
-
-		ProgressListener global = new ProgressListener() {
-
-			double currentIterations = 1;
-			final double maxIterations = numStages * numIterations;
-			boolean alreadyCompleted = false;
-
-			@Override
-			public void acknowledgeUpdate(final Task task) {
-				if (!task.isComplete()) {
-					var expected = currentIterations / maxIterations;
-					var actual = task.progress();
-					Assertions.assertEquals(expected, actual, 1e-6);
-					currentIterations++;
-				}
-				else {
-					// Assert complete listen only happens once, when iterations = max
-					Assertions.assertFalse(alreadyCompleted);
-					Assertions.assertEquals(currentIterations, maxIterations);
-					alreadyCompleted = true;
-				}
+			for (int i = 0; i < NUM_ITERATIONS; i++) {
+				Progress.update();
 			}
+			return NUM_ITERATIONS;
 		};
-		Progress.addGlobalListener(global);
-
-		Progress.register(progressible);
-		progressible.apply(numStages, numIterations);
+		// Add the ProgressListener
+		var id = "This is a global listener";
+		var listener = new TestSuiteProgressListener(NUM_ITERATIONS,  id);
+		Progress.addGlobalListener(listener);
+		// Register the Task
+		Progress.register(progressible, id);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
 		Progress.complete();
+		Assertions.assertTrue(listener.isComplete());
 	}
 
+	/**
+	 * Test that {@link ProgressListener}s added at a global level can listen to
+	 * a progressible object without being explicitly linked
+	 */
+	@Test
+	public void testProgressListenerIdentifiers() {
+		// Define the task
+		Supplier<Long> progressible = () -> {
+			// set up progress reporter
+			Progress.defineTotalProgress(1);
+			Progress.setStageMax(NUM_ITERATIONS);
+
+			for (int i = 0; i < NUM_ITERATIONS; i++) {
+				Progress.update();
+			}
+			return NUM_ITERATIONS;
+		};
+		// Add a ProgressListener that should acknowledge this task
+		var goodId = "This one should be listened to";
+		var goodListener = new TestSuiteProgressListener(NUM_ITERATIONS,  goodId);
+		Progress.addGlobalListener(goodListener);
+		// Register the Task with goodId
+		Progress.register(progressible, goodId);
+		// Create a second global listener that will not acknowledge this task
+		var badId = "This one should not be listened to";
+		var badListener = new TestSuiteProgressListener(NUM_ITERATIONS,  badId);
+		Progress.addGlobalListener(badListener);
+		// Run the Task
+		progressible.get();
+		// Complete the Task
+		Progress.complete();
+		Assertions.assertTrue(goodListener.isComplete());
+		// Assert that badListener didn't hear anything
+		Assertions.assertEquals(0., badListener.progress(), 1e-6);
+	}
 
 }

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/SubtaskProgressTest.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/SubtaskProgressTest.java
@@ -134,7 +134,7 @@ public class SubtaskProgressTest {
  * <b>and</b> and does processing on its own.
  *
  * @author Gabriel Selzer
- * @see DefaultProgressTest#iterator
+ * @see DefaultProgressTest#singleStageProgressible
  */
 class DependentComplexProgressReportingTask implements
 	Function<Integer, Integer>
@@ -175,7 +175,7 @@ class DependentComplexProgressReportingTask implements
  * dependency, and does no processing on its own.
  *
  * @author Gabriel Selzer
- * @see DefaultProgressTest#iterator
+ * @see DefaultProgressTest#singleStageProgressible
  */
 class DependentProgressReportingTask implements Function<Integer, Integer> {
 

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
@@ -1,0 +1,48 @@
+package org.scijava.progress;
+
+import org.junit.jupiter.api.Assertions;
+
+public class TestSuiteProgressListener implements ProgressListener{
+
+	private final String id;
+	private final long expectedIterations;
+	private double currentIterations = 0;
+
+	private boolean completed = false;
+
+	public TestSuiteProgressListener(final long expectedIterations) {
+		this.id = null;
+		this.expectedIterations = expectedIterations;
+	}
+
+	public TestSuiteProgressListener(final long expectedIterations, final String id) {
+		this.id = id;
+		this.expectedIterations = expectedIterations;
+	}
+
+	@Override public void acknowledgeUpdate(Task task) {
+		if (id != null && !task.id().equals(id))
+			return;
+		if (!task.isComplete()) {
+			Assertions.assertEquals(++currentIterations / expectedIterations, task.progress(), 1e-6);
+		}
+		else {
+			Assertions.assertFalse(completed);
+			Assertions.assertEquals(1., task.progress(), 1e-6);
+			completed = true;
+		}
+	}
+
+	public boolean isComplete() {
+		return this.completed;
+	}
+
+	public void reset() {
+		this.currentIterations = 0;
+		this.completed = false;
+	}
+
+	public double progress() {
+		return this.currentIterations / this.expectedIterations;
+	}
+}

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
@@ -25,7 +25,7 @@ public class TestSuiteProgressListener implements ProgressListener {
 
 	@Override
 	public void acknowledgeUpdate(Task task) {
-		if (id != null && !task.id().equals(id)) return;
+		if (id != null && !task.description().equals(id)) return;
 		if (!task.isComplete()) {
 			Assertions.assertEquals(++currentIterations / expectedIterations, task
 				.progress(), 1e-6);

--- a/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
+++ b/scijava/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
@@ -1,8 +1,9 @@
+
 package org.scijava.progress;
 
 import org.junit.jupiter.api.Assertions;
 
-public class TestSuiteProgressListener implements ProgressListener{
+public class TestSuiteProgressListener implements ProgressListener {
 
 	private final String id;
 	private final long expectedIterations;
@@ -15,16 +16,19 @@ public class TestSuiteProgressListener implements ProgressListener{
 		this.expectedIterations = expectedIterations;
 	}
 
-	public TestSuiteProgressListener(final long expectedIterations, final String id) {
+	public TestSuiteProgressListener(final long expectedIterations,
+		final String id)
+	{
 		this.id = id;
 		this.expectedIterations = expectedIterations;
 	}
 
-	@Override public void acknowledgeUpdate(Task task) {
-		if (id != null && !task.id().equals(id))
-			return;
+	@Override
+	public void acknowledgeUpdate(Task task) {
+		if (id != null && !task.id().equals(id)) return;
 		if (!task.isComplete()) {
-			Assertions.assertEquals(++currentIterations / expectedIterations, task.progress(), 1e-6);
+			Assertions.assertEquals(++currentIterations / expectedIterations, task
+				.progress(), 1e-6);
 		}
 		else {
 			Assertions.assertFalse(completed);


### PR DESCRIPTION
This PR adds API for introducing global progress listeners, in anticipation of end-users or external framework wanting to monitor progress without registering every Op.

Beyond the new global API, this PR also introduces additional changes needed to make `Task`s more informative and robust. A list of the changes is provided below:
* A `description` field is added to the `Task` class to make it clearer which `Task`s describe a given execution. To support Ops, `AbstractRichOp.toString()` now provides a clear, more informative name.
* To prevent multiple pings on completion, a safeguard was introduced to ensure that a `Task` completes only once.
* Task updates now take a `long` defining the number of steps, instead of an `int` - this makes the step math more uniform.