### PR TITLE
Throw ValidityException instead of saving it

### DIFF
--- a/scijava/scijava-common3/src/main/java/org/scijava/common3/validity/ValidityException.java
+++ b/scijava/scijava-common3/src/main/java/org/scijava/common3/validity/ValidityException.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @author Curtis Rueden
  * @author Gabriel Selzer
  */
-public final class ValidityException extends Exception {
+public final class ValidityException extends RuntimeException {
 
 	private final List<ValidityProblem> problems;
 

--- a/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpCandidate.java
+++ b/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpCandidate.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.struct.Member;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
@@ -53,7 +52,6 @@ public class OpCandidate {
 
 	public static enum StatusCode {
 		MATCH, //
-		INVALID_STRUCT, //
 		OUTPUT_TYPES_DO_NOT_MATCH, //
 		TOO_MANY_ARGS, //
 		TOO_FEW_ARGS, //
@@ -182,13 +180,6 @@ public class OpCandidate {
 		switch (statusCode) {
 		case MATCH:
 			sb.append("MATCH");
-			break;
-		case INVALID_STRUCT:
-			sb.append("Invalid struct:");
-			for (ValidityProblem vp : opInfo().getValidityException().problems()) {
-				sb.append("\n\t");
-				sb.append(vp.getMessage());
-			}
 			break;
 		case OUTPUT_TYPES_DO_NOT_MATCH:
 			sb.append("Output types do not match");

--- a/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInfo.java
+++ b/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInfo.java
@@ -95,10 +95,6 @@ public interface OpInfo extends Comparable<OpInfo> {
 	/** Create a StructInstance using the Struct metadata backed by an object of the op itself. */
 	StructInstance<?> createOpInstance(List<?> dependencies);
 
-	// TODO Consider if we really want to keep the following methods.
-	boolean isValid();
-	ValidityException getValidityException();
-	
 	AnnotatedElement getAnnotationBearer();
 
 	@Override

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/DefaultOpEnvironment.java
@@ -44,7 +44,6 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -758,11 +757,6 @@ public class DefaultOpEnvironment implements OpEnvironment {
 		if (opInfo.names() == null || opInfo.names().size() == 0) {
 			log.error("Skipping Op " + opInfo.implementationName() + ":\n" +
 				"Op implementation must provide name.");
-			return;
-		}
-		if (!opInfo.isValid()) {
-			log.error("Skipping invalid Op " + opInfo.implementationName() + ":\n" +
-				opInfo.getValidityException().getMessage());
 			return;
 		}
 		for (String opName : opInfo.names()) {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpUtils.java
@@ -111,16 +111,14 @@ public final class OpUtils {
 				.collect(Collectors.toList());
 	}
 
-	public static void checkHasSingleOutput(Struct struct) throws
+	public static void ensureHasSingleOutput(Struct struct, List<ValidityProblem> problems) throws
 			ValidityException
 	{
 		final long numOutputs = struct.members().stream() //
-			.filter(m -> m.isOutput()).count();
-		if (numOutputs != 1) {
-			final String error = numOutputs == 0 //
-				? "No output parameters specified. Must specify exactly one." //
-				: "Multiple output parameters specified. Only a single output is allowed.";
-			throw new ValidityException(Collections.singletonList(new ValidityProblem(error)));
+			.filter(Member::isOutput).count();
+		if (numOutputs > 1) {
+			problems.add(new ValidityProblem(
+				"Multiple output parameters specified. Only a single output is allowed."));
 		}
 	}
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpClassOpInfoGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpClassOpInfoGenerator.java
@@ -4,6 +4,7 @@ package org.scijava.ops.engine.impl;
 import java.util.Collections;
 import java.util.List;
 
+import org.scijava.common3.validity.ValidityException;
 import org.scijava.meta.Versions;
 import org.scijava.ops.api.*;
 import org.scijava.ops.engine.OpUtils;
@@ -28,8 +29,13 @@ public class OpClassOpInfoGenerator implements OpInfoGenerator
 		String version = Versions.getVersion(c);
 		Hints hints = formHints(c.getAnnotation(OpHints.class));
 		double priority = p.priority();
-		return Collections.singletonList(new OpClassInfo(c, version, hints,
-			priority, parsedOpNames));
+		try {
+			return Collections.singletonList(
+					new OpClassInfo(c, version, hints, priority, parsedOpNames));
+		} catch (ValidityException e) {
+			// TODO: Log exception
+			return Collections.emptyList();
+		}
 	}
 
 	@Override public boolean canGenerateFrom(Object o) {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpCollectionInfoGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpCollectionInfoGenerator.java
@@ -6,9 +6,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.scijava.common3.validity.ValidityException;
 import org.scijava.ops.engine.OpUtils;
 import org.scijava.common3.Annotations;
 import org.scijava.meta.Versions;
@@ -41,14 +43,30 @@ public class OpCollectionInfoGenerator implements OpInfoGenerator {
 		if (instance.isPresent()) {
 			final List<OpFieldInfo> fieldInfos = //
 				fields.parallelStream() //
-					.map(f -> generateFieldInfo(f, instance.get(), version)) //
+					.map(f -> {
+						try {
+							return generateFieldInfo(f, instance.get(), version);
+						} catch(ValidityException e) {
+							// TODO: Log exception
+							return null;
+						}
+					}) //
+					.filter(Objects::nonNull) //
 					.collect(Collectors.toList());
 			collectionInfos.addAll(fieldInfos);
 		}
 		// add OpMethodInfos
 		final List<OpMethodInfo> methodInfos = //
 			Annotations.getAnnotatedMethods(cls, OpMethod.class).parallelStream() //
-				.map(m -> generateMethodInfo(m, version)) //
+				.map(m -> {
+					try {
+						return generateMethodInfo(m, version);
+					} catch(ValidityException e) {
+						// TODO: Log exception
+						return null;
+					}
+				}) //
+				.filter(Objects::nonNull) //
 				.collect(Collectors.toList());
 		collectionInfos.addAll(methodInfos);
 		return collectionInfos;

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/TherapiOpInfoGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/TherapiOpInfoGenerator.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
+import org.scijava.common3.validity.ValidityException;
 import org.scijava.discovery.therapi.TaggedElement;
 import org.scijava.discovery.therapi.TherapiDiscoveryUtils;
 import org.scijava.meta.Versions;
@@ -85,7 +86,12 @@ public class TherapiOpInfoGenerator implements OpInfoGenerator {
 
 	private static OpInfo opClassGenerator(Class<?> cls, double priority, String[] names) {
 		String version = Versions.getVersion(cls);
-		return new OpClassInfo(cls, version, new DefaultHints(), priority, names);
+		try {
+			return new OpClassInfo(cls, version, new DefaultHints(), priority, names);
+		} catch (ValidityException e) {
+			// TODO: Log exception
+			return null;
+		}
 	}
 
 	private static OpInfo opMethodGenerator(Method m, String opType, double priority, String[] names) {
@@ -96,7 +102,12 @@ public class TherapiOpInfoGenerator implements OpInfoGenerator {
 			return null;
 		}
 		String version = Versions.getVersion(m.getDeclaringClass());
-		return new OpMethodInfo(m, cls, version, new DefaultHints(), priority, names);
+		try {
+			return new OpMethodInfo(m, cls, version, new DefaultHints(), priority, names);
+		} catch (ValidityException e) {
+			// TODO: Log exception
+			return null;
+		}
 	}
 
 	private static OpInfo opFieldGenerator(Field f, double priority, String[] names) {
@@ -108,6 +119,11 @@ public class TherapiOpInfoGenerator implements OpInfoGenerator {
 				| NoSuchMethodException | SecurityException exc) {
 			return null;
 		}
-		return new OpFieldInfo(instance, f, version, new DefaultHints(), priority, names);
+		try {
+			return new OpFieldInfo(instance, f, version, new DefaultHints(), priority, names);
+		} catch (ValidityException e) {
+			// TODO: Log exception
+			return null;
+		}
 	}
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
@@ -64,8 +64,6 @@ public class OpFieldInfo implements OpInfo {
 	private final double priority;
 
 	private Struct struct;
-	private ValidityException validityException;
-
 	private final Hints hints;
 
 	public OpFieldInfo(final Object instance, final Field field, final Hints hints, final String... names) {
@@ -86,6 +84,7 @@ public class OpFieldInfo implements OpInfo {
 		this.field = field;
 		this.names = Arrays.asList(names);
 		this.priority = priority;
+		this.hints = hints;
 
 		if (Modifier.isStatic(field.getModifiers())) {
 			// Field is static; instance must be null.
@@ -108,20 +107,14 @@ public class OpFieldInfo implements OpInfo {
 
 		// NB: Subclassing a collection and inheriting its fields is NOT
 		// ALLOWED!
-		try {
-			Type structType = Types.fieldType(field, field.getDeclaringClass());
-			FieldInstance fieldInstance = new FieldInstance(field, instance);
-			struct = Structs.from(fieldInstance, structType, problems, new FieldParameterMemberParser());
-			OpUtils.checkHasSingleOutput(struct);
-			// NB: Contextual parameters not supported for now.
-		} catch (ValidityException e) {
-			problems.addAll(e.problems());
-		}
-		if (!problems.isEmpty()) {
-			validityException = new ValidityException(problems);
-		}
+		Type structType = Types.fieldType(field, field.getDeclaringClass());
+		FieldInstance fieldInstance = new FieldInstance(field, instance);
+		struct = Structs.from(fieldInstance, structType, problems, new FieldParameterMemberParser());
+		OpUtils.ensureHasSingleOutput(struct, problems);
 
-		this.hints = hints;
+		if (!problems.isEmpty()) {
+			throw new ValidityException(problems);
+		}
 	}
 
 	// -- OpInfo methods --
@@ -181,16 +174,6 @@ public class OpFieldInfo implements OpInfo {
 		}
 	}
 
-	@Override
-	public ValidityException getValidityException() {
-		return validityException;
-	}
-
-	@Override
-	public boolean isValid() {
-		return validityException == null;
-	}
-	
 	@Override
 	public AnnotatedElement getAnnotationBearer() {
 		return field;

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
@@ -73,7 +73,7 @@ public class OpFieldInfo implements OpInfo {
 	}
 
 	public OpFieldInfo(final Object instance, final Field field, final Hints hints, final double priority, final String... names) {
-		this(instance, field, Versions.getVersion(field.getDeclaringClass()), hints, Priority.NORMAL, names);
+		this(instance, field, Versions.getVersion(field.getDeclaringClass()), hints, priority, names);
 	}
 
 	public OpFieldInfo(final Object instance, final Field field, final String version, final Hints hints, final String... names) {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
@@ -69,7 +69,6 @@ public class OpMethodInfo implements OpInfo {
 	private final List<String> names;
 	private final Type opType;
 	private final Struct struct;
-	private final ValidityException validityException;
 	private final double priority;
 
 	private final Hints hints;
@@ -100,8 +99,9 @@ public class OpMethodInfo implements OpInfo {
 		this.opType = findOpType(opType, problems);
 		this.struct = generateStruct(method, opType, problems, new MethodParameterMemberParser(), new MethodOpDependencyMemberParser());
 
-		validityException = problems.isEmpty() ? null : new ValidityException(
-			problems);
+		if (!problems.isEmpty()) {
+			throw new ValidityException(problems);
+		}
 	}
 
 	@SafeVarargs
@@ -216,16 +216,6 @@ public class OpMethodInfo implements OpInfo {
 			throw new IllegalStateException("Failed to invoke Op method: " + method,
 					exc);
 		}
-	}
-
-	@Override
-	public boolean isValid() {
-		return validityException == null;
-	}
-
-	@Override
-	public ValidityException getValidityException() {
-		return validityException;
 	}
 
 	@Override

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/RuntimeSafeMatchingRoutine.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/RuntimeSafeMatchingRoutine.java
@@ -68,7 +68,6 @@ public class RuntimeSafeMatchingRoutine implements MatchingRoutine {
 	/**
 	 * Performs several checks, whether the specified candidate:</br>
 	 * </br>
-	 * * {@link #isValid(OpCandidate)}</br>
 	 * * {@link #outputsMatch(OpCandidate, HashMap)}</br>
 	 * * has a matching number of args</br>
 	 * * {@link #missArgs(OpCandidate, Type[])}</br>
@@ -83,7 +82,6 @@ public class RuntimeSafeMatchingRoutine implements MatchingRoutine {
 	{
 		final ArrayList<OpCandidate> validCandidates = new ArrayList<>();
 		for (final OpCandidate candidate : candidates) {
-			if (!isValid(candidate)) continue;
 			final Type[] args = candidate.paddedArgs();
 			if (args == null) continue;
 			if (missArgs(candidate, args)) continue;
@@ -200,20 +198,6 @@ public class RuntimeSafeMatchingRoutine implements MatchingRoutine {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * Determines if the specified candidate is valid and sets status code if not.
-	 *
-	 * @param candidate the candidate to check
-	 * @return whether the candidate is valid
-	 */
-	private boolean isValid(final OpCandidate candidate) {
-		if (candidate.opInfo().isValid()) {
-			return true;
-		}
-		candidate.setStatus(StatusCode.INVALID_STRUCT);
-		return false;
 	}
 
 	/**

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfo.java
@@ -29,8 +29,6 @@ public class ReducedOpInfo implements OpInfo {
 
 	private final Hints hints;
 	private final Struct struct;
-	private ValidityException validityException;
-
 	public ReducedOpInfo(OpInfo src, Type reducedOpType, int paramsReduced) {
 		this.srcInfo = src;
 		this.reducedOpType = reducedOpType;
@@ -41,8 +39,8 @@ public class ReducedOpInfo implements OpInfo {
 		RetypingRequest r = retypingRequest();
 		this.struct = Structs.from(r, reducedOpType, problems, new OpResizingMemberParser());
 
-		if (problems.size() > 0) {
-			validityException = new ValidityException(problems);
+		if (!problems.isEmpty()) {
+			throw new ValidityException(problems);
 		}
 	}
 
@@ -170,16 +168,6 @@ public class ReducedOpInfo implements OpInfo {
 					"\nProvided Op dependencies were: " + Objects.toString(dependencies),
 				ex);
 		}
-	}
-
-	@Override
-	public boolean isValid() {
-		return validityException == null;
-	}
-
-	@Override
-	public ValidityException getValidityException() {
-		return validityException;
 	}
 
 	@Override

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfoGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfoGenerator.java
@@ -1,6 +1,7 @@
 
 package org.scijava.ops.engine.reduce;
 
+import org.scijava.common3.validity.ValidityException;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpInfoGenerator;
 import org.scijava.struct.Member;
@@ -52,7 +53,15 @@ public class ReducedOpInfoGenerator implements OpInfoGenerator {
 		InfoReducer reducer = optionalReducer.get();
 		LongFunction<OpInfo> func = l -> reducer.reduce(info, (int) l);
 		return LongStream.range(1, numReductions + 1) //
-			.mapToObj(func) //
+			.mapToObj(i -> {
+				try {
+					return func.apply(i);
+				} catch(ValidityException e) {
+					// TODO: Log exception
+					return null;
+				}
+			}) //
+			.filter(Objects::nonNull) //
 			.collect(Collectors.toList());
 	}
 	

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplifiedOpInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplifiedOpInfo.java
@@ -44,7 +44,6 @@ public class SimplifiedOpInfo implements OpInfo {
 	private final Hints hints;
 
 	private Struct struct;
-	private ValidityException validityException;
 
 	public SimplifiedOpInfo(OpInfo info, OpEnvironment env, SimplificationMetadata metadata) {
 		this(info, metadata, calculatePriority(info, metadata, env));
@@ -76,7 +75,7 @@ public class SimplifiedOpInfo implements OpInfo {
 		this.hints = srcInfo.declaredHints().plus(Simplification.FORBIDDEN);
 
 		if(!problems.isEmpty()) {
-			validityException = new ValidityException(problems);
+			throw new ValidityException(problems);
 		}
 	}
 
@@ -187,16 +186,6 @@ public class SimplifiedOpInfo implements OpInfo {
 	@Override
 	public String implementationName() {
 		return srcInfo.implementationName() + " simplified to a " + opType();
-	}
-
-	@Override
-	public boolean isValid() {
-		return srcInfo.isValid();
-	}
-
-	@Override
-	public ValidityException getValidityException() {
-		return validityException;
 	}
 
 	@Override

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodDependencyPositionTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodDependencyPositionTest.java
@@ -1,6 +1,7 @@
 
 package org.scijava.ops.engine;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -65,16 +66,7 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 				Function.class, //
 				List.class //
 		);
-		var info = new OpMethodInfo( //
-					m, //
-					Computers.Arity1.class, //
-					new DefaultHints(), //
-					"test.dependencyAfterInput" //
-		);
-		ValidityException exc = info.getValidityException();
-		String expMsg = "java.lang.IllegalArgumentException: Op Dependencies in " +
-			"static methods must come before any other parameters!";
-		Assertions.assertEquals(expMsg, exc.problems().get(0).getMessage());
+		createInvalidInfo(m, Computers.Arity1.class, "test.dependencyAfterInput");
 	}
 
 	public static void goodThenBadDep( //
@@ -97,16 +89,24 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 				Function.class, //
 				List.class //
 		);
-		var info = new OpMethodInfo( //
-				m, //
-				Computers.Arity1.class, //
-				new DefaultHints(), //
-				"test.dependencyBeforeAndAfterInput" //
-		);
-		ValidityException exc = info.getValidityException();
-		String expMsg = "java.lang.IllegalArgumentException: Op Dependencies in " +
-				"static methods must come before any other parameters!";
-		Assertions.assertEquals(expMsg, exc.problems().get(0).getMessage());
+		createInvalidInfo(m, Computers.Arity1.class, "test.dependencyBeforeAndAfterInput");
 	}
 
+	/**
+	 * Helper method for testing ops with dependencies before other params
+	 */
+	private void createInvalidInfo(Method m, Class<?> arity, String... names) {
+		try {
+			new OpMethodInfo( //
+					m, //
+					arity, //
+					new DefaultHints(), //
+					names
+			);
+		} catch (ValidityException exc) {
+			String expMsg = "java.lang.IllegalArgumentException: Op Dependencies in " +
+					"static methods must come before any other parameters!";
+			Assertions.assertEquals(expMsg, exc.problems().get(0).getMessage());
+		}
+	}
 }

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodDependencyPositionTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodDependencyPositionTest.java
@@ -22,9 +22,9 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 		implements OpCollection {
 
 	public static void goodDep( //
-		@OpDependency(name = "someDep") Function<String, Long> op, //
-		List<String> in, //
-		List<Long> out //
+			@OpDependency(name = "someDep") Function<String, Long> op, //
+			List<String> in, //
+			List<Long> out //
 	) {
 		out.clear();
 		for (String s : in)
@@ -34,18 +34,17 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 	@Test
 	public void testOpDependencyBefore() throws NoSuchMethodException {
 		var m = this.getClass().getDeclaredMethod(//
-			"goodDep", //
-			Function.class, //
-			List.class, //
-			List.class //
+				"goodDep", //
+				Function.class, //
+				List.class, //
+				List.class //
 		);
 		var info = new OpMethodInfo( //
-			m, //
-			Computers.Arity1.class, //
-			new DefaultHints(), //
-			"test.dependencyBeforeInput" //
+				m, //
+				Computers.Arity1.class, //
+				new DefaultHints(), //
+				"test.dependencyBeforeInput" //
 		);
-		Assertions.assertEquals(null, info.getValidityException());
 	}
 
 	public static void badDep( //


### PR DESCRIPTION
This PR simplifies the `OpInfo` API around `ValidityException`s - instead of saving the `Exception`, the constructor now throws the `Exception`. Then, during `OpInfo` construction, we now catch these `Exceptions` and continue on.

We still have to figure out how to log the `Exceptions`, so that developers can determine how to make their ops valid - I'm tempted to just wait until #82 is merged, because logging would then be quite easy.

Question for the reviewer: Are failures getting tested? Should we add additional tests? What might those tests look like?