### PR TITLE
Clean up OpInfo.toString implementations

### DIFF
--- a/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpDescription.java
+++ b/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpDescription.java
@@ -1,5 +1,6 @@
 package org.scijava.ops.api;
 
+import org.scijava.struct.ItemIO;
 import org.scijava.struct.Member;
 
 import java.util.ArrayList;
@@ -30,20 +31,26 @@ public final class OpDescription {
      */
     public static String basic(final OpInfo info, final Member<?> special) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(info.implementationName()).append("(\n\t Inputs:\n");
+        final List<String> names = info.names();
+        sb.append(names.get(0)).append("(\n\t Inputs:\n");
         List<Member<?>> containers = new ArrayList<>();
         for (final Member<?> arg : info.inputs()) {
-            if (arg.getKey().contains("container")) containers.add(arg);
-            else appendParam(sb, arg, special);
+            if (arg.getIOType() == ItemIO.INPUT) appendParam(sb, arg, special);
+            else containers.add(arg);
         }
         if (containers.isEmpty()) {
             sb.append("\t Outputs:\n");
             appendParam(sb, info.output(), special);
         } else {
             sb.append("\t Containers (I/O):\n");
-            containers.stream().forEach(c -> appendParam(sb, c, special));
+            containers.forEach(c -> appendParam(sb, c, special));
         }
         sb.append(")\n");
+        if (names.size() > 1) {
+            sb.append("Aliases: [");
+            sb.append(String.join(", ", names.subList(1, names.size())));
+            sb.append("]\n");
+        }
         return sb.toString();
     }
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/DefaultOpEnvironment.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/DefaultOpEnvironment.java
@@ -134,7 +134,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	 *
 	 * @see MatchingConditions#equals(Object)
 	 */
-	private Map<MatchingConditions, OpInstance<?>> opCache;
+	private final Map<MatchingConditions, OpInstance<?>> opCache = new HashMap<>();
 
 	/**
 	 * Data structure storing all known {@link OpWrapper}s. Each {@link OpWrapper}
@@ -474,9 +474,6 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	}
 
 	private OpInstance<?> getInstance(MatchingConditions conditions) {
-		if (opCache == null) {
-			opCache = new HashMap<>();
-		}
 		return opCache.get(conditions);
 	}
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpAdaptationInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpAdaptationInfo.java
@@ -12,6 +12,7 @@ import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.InfoChain;
 import org.scijava.ops.api.OpDependencyMember;
+import org.scijava.ops.api.OpDescription;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpInstance;
 import org.scijava.ops.engine.OpUtils;
@@ -155,4 +156,8 @@ public class OpAdaptationInfo implements OpInfo {
 		return IMPL_DECLARATION + ADAPTOR + adaptorChain.signature() + ORIGINAL + srcInfo.id();
 	}
 
+	@Override
+	public String toString() {
+		return OpDescription.basic(this);
+	}
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/reduce/ReducedOpInfo.java
@@ -11,6 +11,7 @@ import org.scijava.common3.validity.ValidityException;
 import org.scijava.common3.validity.ValidityProblem;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpDependencyMember;
+import org.scijava.ops.api.OpDescription;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.features.BaseOpHints;
 import org.scijava.ops.engine.struct.OpResizingMemberParser;
@@ -207,6 +208,11 @@ public class ReducedOpInfo implements OpInfo {
 
 	public int paramsReduced() {
 		return paramsReduced;
+	}
+
+	@Override
+	public String toString() {
+		return OpDescription.basic(this);
 	}
 
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/InfoSimplificationGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/InfoSimplificationGenerator.java
@@ -44,12 +44,12 @@ public class InfoSimplificationGenerator {
 		return info;
 	}
 
-	public OpInfo generateSuitableInfo(OpEnvironment env, OpRef originalRef, Hints hints) {
+	public SimplifiedOpInfo generateSuitableInfo(OpEnvironment env, OpRef originalRef, Hints hints) {
 		SimplifiedOpRef simpleRef = SimplifiedOpRef.simplificationOf(env, originalRef, hints);
 		return generateSuitableInfo(simpleRef);
 	}
 
-	public OpInfo generateSuitableInfo(SimplifiedOpRef ref) {
+	public SimplifiedOpInfo generateSuitableInfo(SimplifiedOpRef ref) {
 		if(!Types.isAssignable(Types.raw(info.opType()), ref.rawType()))
 				throw new IllegalArgumentException("OpInfo and OpRef do not share an Op type");
 		TypePair[] argPairings = generatePairings(ref);

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplificationUtils.java
@@ -62,8 +62,6 @@ public class SimplificationUtils {
 	 */
 	public static ParameterizedType retypeOpType(Type originalOpType, Type[] newArgs, Type newOutType) {
 			// only retype types that we know how to retype
-			if (!(originalOpType instanceof ParameterizedType))
-				throw new IllegalStateException("We hadn't thought about this yet.");
 			Class<?> opType = Types.raw(originalOpType);
 			Method fMethod = OpUtils.findFunctionalMethod(opType);
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplifiedOpInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/simplify/SimplifiedOpInfo.java
@@ -66,6 +66,7 @@ public class SimplifiedOpInfo implements OpInfo {
 			fmts.add(new FunctionalMethodType(newType, m.getIOType()));
 		}
 		// generate new output fmt
+
 		this.opType = SimplificationUtils.retypeOpType(info.opType(), inputTypes,
 			outputType);
 		RetypingRequest r = new RetypingRequest(info.struct(), fmts);

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/JavadocParameterTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/JavadocParameterTest.java
@@ -424,8 +424,7 @@ public class JavadocParameterTest extends AbstractTestEnvironment implements OpC
 
 		// test standard op string
 		String expected =
-			"org.scijava.ops.engine.JavadocParameterTest." +
-				"OpMethodPR(java.util.List<java.lang.String>,java.util.List<java.lang.String>)(\n" +
+			"test.javadoc.methodPR(\n" +
 				"	 Inputs:\n" +
 				"		java.util.List<java.lang.String> foo -> the first input\n" +
 				"		java.util.List<java.lang.String> bar -> the second input\n" +
@@ -436,8 +435,7 @@ public class JavadocParameterTest extends AbstractTestEnvironment implements OpC
 
 		// test special op string
 		expected =
-			"org.scijava.ops.engine.JavadocParameterTest." +
-				"OpMethodPR(java.util.List<java.lang.String>,java.util.List<java.lang.String>)(\n" +
+			"test.javadoc.methodPR(\n" +
 				"	 Inputs:\n" +
 				"		java.util.List<java.lang.String> foo -> the first input\n" +
 				"==> 	java.util.List<java.lang.String> bar -> the second input\n" +

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
@@ -1,0 +1,157 @@
+
+package org.scijava.ops.engine.matcher.impl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.function.Computers;
+import org.scijava.ops.api.OpRef;
+import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.copy.CopyOpCollection;
+import org.scijava.ops.engine.hint.DefaultHints;
+import org.scijava.ops.engine.reduce.ReducedOpInfo;
+import org.scijava.ops.engine.simplify.Identity;
+import org.scijava.ops.engine.simplify.InfoSimplificationGenerator;
+import org.scijava.ops.engine.simplify.PrimitiveArraySimplifiers;
+import org.scijava.ops.engine.simplify.PrimitiveSimplifiers;
+import org.scijava.ops.engine.simplify.SimplifiedOpInfo;
+import org.scijava.types.Types;
+
+public class OpDescriptionTest extends AbstractTestEnvironment {
+
+	@BeforeAll
+	public static void addNeededOps() {
+		ops.registerInfosFrom(new PrimitiveSimplifiers());
+		ops.registerInfosFrom(new PrimitiveArraySimplifiers());
+		ops.registerInfosFrom(new CopyOpCollection<>());
+		ops.register(new Identity<>());
+	}
+
+	static class ClassOp implements BiFunction<Double, Double, Double> {
+
+		@Override
+		public Double apply(Double t, Double u) {
+			return t + u;
+		}
+	}
+
+	@Test
+	public void testOpClassDescription() {
+		OpClassInfo info = new OpClassInfo(ClassOp.class, new DefaultHints(),
+			"test.classDescription");
+
+		String expected = "test.classDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Double output1\n)\n";
+		String actual = info.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	public static Double methodOp(Double in1, Double in2) {
+		return in1 + in2;
+	}
+
+	@Test
+	public void testOpMethodDescription() throws NoSuchMethodException {
+		Method method = OpDescriptionTest.class.getMethod("methodOp", Double.class,
+			Double.class);
+		OpMethodInfo info = new OpMethodInfo(method, BiFunction.class,
+			new DefaultHints(), "test.methodDescription");
+		String expected = "test.methodDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Double output1\n)\n";
+		String actual = info.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	public final BiFunction<Double, Double, Double> fieldOp = Double::sum;
+
+	@Test
+	public void testOpFieldDescription() throws NoSuchFieldException {
+		Field field = OpDescriptionTest.class.getDeclaredField("fieldOp");
+		OpFieldInfo info = new OpFieldInfo(this, field, new DefaultHints(),
+			"test.fieldDescription");
+		String expected = "test.fieldDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Double output1\n)\n";
+		String actual = info.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testAdaptedDescription() {
+		OpClassInfo info = new OpClassInfo(ClassOp.class, new DefaultHints(),
+			"test.adaptationDescription");
+		Type opType = Types.parameterize(Computers.Arity2.class, new Type[] {
+			Double.class, Double.class, Double.class });
+		OpAdaptationInfo adapted = new OpAdaptationInfo(info, opType, null);
+		String expected = "test.adaptationDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
+			+ "Containers (I/O):\n\t\tjava.lang.Double output1\n)\n";
+		String actual = adapted.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	static class SimpleOp implements BiFunction<Double, Double, Double[]> {
+
+		@Override
+		public Double[] apply(Double t, Double u) {
+			return new Double[] { t, u };
+		}
+	}
+
+	@Test
+	public void testSimplifiedDescription() {
+		OpClassInfo info = new OpClassInfo(SimpleOp.class, new DefaultHints(),
+			"test.simplifiedDescription");
+		// NB it's a lot easier to let the framework create our SimplifiedOpInfo
+		Type opType = Types.parameterize(BiFunction.class, new Type[] {
+			Integer.class, Integer.class, Integer[].class });
+		OpRef simpleRef = new DefaultOpRef("test.adaptationDescription", opType,
+			Integer[].class, new Type[] { Integer.class, Integer.class });
+		SimplifiedOpInfo simplified = new InfoSimplificationGenerator(info, ops)
+			.generateSuitableInfo(ops, simpleRef, new DefaultHints());
+		String expected = "test.simplifiedDescription(\n\t " //
+			+
+			"Inputs:\n\t\tjava.lang.Integer input1\n\t\tjava.lang.Integer input2\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Integer[] output1\n)\n";
+		String actual = simplified.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testReducedDescription() {
+		OpClassInfo info = new OpClassInfo(ClassOp.class, new DefaultHints(),
+			"test.reductionDescription");
+
+		Type opType = Types.parameterize(Function.class, new Type[] { Double.class,
+			Double.class });
+		ReducedOpInfo reduced = new ReducedOpInfo(info, opType, 1);
+		String expected = "test.reductionDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Double output1\n)\n";
+		String actual = reduced.toString();
+		Assertions.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testMultiNameOp() {
+		OpClassInfo info = new OpClassInfo(ClassOp.class, new DefaultHints(),
+			"test.classDescription", "test.otherName");
+
+		String expected = "test.classDescription(\n\t " //
+			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
+			+ "Outputs:\n\t\tjava.lang.Double output1\n)\n" //
+			+ "Aliases: [test.otherName]\n";
+		String actual = info.toString();
+		Assertions.assertEquals(expected, actual);
+
+	}
+
+}


### PR DESCRIPTION
This PR refactors `OpDescription.basic()`, replacing the `implementationName` of each Op with its name. Thus, where we before had
```java
net.imagej.ops2.filter.gauss.Gaussians.defaultGaussRAI(net.imglib2.RandomAccessibleInterval<T>,java.util.concurrent.ExecutorService,double[],net.imglib2.outofbounds.OutOfBoundsFactory<T, net.imglib2.RandomAccessibleInterval<T>>,net.imglib2.RandomAccessibleInterval<T>)(
	 Inputs:
		net.imglib2.RandomAccessibleInterval<T> input1
		java.util.concurrent.ExecutorService input2
		double[] input3
		net.imglib2.outofbounds.OutOfBoundsFactory<T, net.imglib2.RandomAccessibleInterval<T>> input4?
	 Containers (I/O):
		net.imglib2.RandomAccessibleInterval<T> container1
)
```
we now have
```java
filter.gauss(
	 Inputs:
		net.imglib2.RandomAccessibleInterval<T> input1
		java.util.concurrent.ExecutorService input2
		double[] input3
		net.imglib2.outofbounds.OutOfBoundsFactory<T, net.imglib2.RandomAccessibleInterval<T>> input4?
	 Containers (I/O):
		net.imglib2.RandomAccessibleInterval<T> container1
)

```

Closes scijava/scijava#129, scijava/scijava#130