### PR TITLE
Write wiki-like documentation pages

### DIFF
--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -1,6 +1,6 @@
 # Calling Ops
 
-Ops are designed to be called from the Op matcher, using the `OpBuilder` syntax - this page describes that syntax in detail.
+Ops are designed to be called from the Op matcher, using the `OpBuilder` syntax. OpBuilder chains follow the [builder pattern](https://refactoring.guru/design-patterns/builder), allowing users to create complex Op calls by "chaining" or appending consecutive, simpler method calls.
 
 On this page, we will be constructing an `OpBuilder` call on an `OpEnvironment ops` to execute a Gaussian Blur on an input image `inImage`, with our output buffer `outImage`.
 

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -1,0 +1,66 @@
+# Calling Ops
+
+Ops are designed to be called from the Op matcher, using the `OpBuilder` syntax - this page describes that syntax in detail.
+
+On this page, we will be constructing an `OpBuilder` call on an `OpEnvironment ops` to execute a Gaussian Blur on an input image `inImage`, with our output buffer `outImage`.
+
+# Specifying the name with `.op()`
+
+From the `OpEnvironment`, an `OpBuilder` call is initialized with the method `OpEnvironment.op(String)`, which is used to describe the name of the Op that the `OpBuilder` must return:
+
+```groovy
+ops.op("filter.gauss")
+```
+
+# Specifying the arity with `.arityX()`
+
+After providing the name, the `OpBuilder` syntax requires the number of inputs. If you intend to pass `X` inputs to the Op, you then chain the `arityX()` method:
+
+In doing a basic gaussian blur, we will pass through the input image `inImage`, and a sigma parameter - therefore, we will call `arity2()`:
+
+```groovy
+ops.op("filter.gauss").arity2()
+```
+
+# Passing the inputs with `.input()`
+
+With the arity defined in the `OpBuilder` call, we can then chain the inputs with the `input()` method.
+
+For our gaussian blur, we will pass as inputs our input image `inImage`, and a `double` as our sigma parameter:
+
+```groovy
+ops.op("filter.gauss").arity2().input(inImage, 2.0)
+```
+
+# Passing an output buffer with `.output()`
+
+Now that the inputs are specified, we can chain the output buffer using the `output()` method.
+
+For our gaussian blur, we will pass as the output buffer our output image `outImage`:
+
+```groovy
+ops.op("filter.gauss").arity2().input(inImage, 2.0).output(outImage)
+```
+
+## Computing with `.compute()`
+
+With all of the components of the needed Op specified, we can begin computation with the `.compute()` method.
+
+```groovy
+ops.op("filter.gauss").arity2().input(inImage, 2.0).output(outImage).compute()
+```
+
+In the call to `compute()`, the `OpEnvironment` will use the components of the `OpBuilder` syntax to:
+* Match an Op based on the name provided, as well as the types of the provided input and output `Object`s
+* Execute the Op on the provided input and output `Object`s.
+
+## Additions: Repeating execution
+
+When an Op should be executed many times on different inputs, the `OpBuilder` syntax can be modified to return the *Op* instead. Instead of calling the `.compute()` function at the end of our `OpBuilder` call, we can instead call the `.computer()` method to get back the matched Op:
+
+If, instead of having a single image `inImage` we had Y images `inImage1`, `inImage2`, ..., `inImageY`, we 
+
+```groovy
+var gaussOp = ops.op("filter.gauss").arity2().input(inImage, 2.0).output(outImage).computer()
+gaussOp.comput(inImage)
+```

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -62,5 +62,5 @@ If, instead of having a single image `inImage` we had Y images `inImage1`, `inIm
 
 ```groovy
 var gaussOp = ops.op("filter.gauss").arity2().input(inImage, 2.0).output(outImage).computer()
-gaussOp.compute(inImage)
+gaussOp.compute(inImage, 2.0, outImage)
 ```

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -12,9 +12,9 @@ From the `OpEnvironment`, an `OpBuilder` call is initialized with the method `Op
 ops.op("filter.gauss")
 ```
 
-# Specifying the arity with `.arityX()`
+# Specifying the number of inputs with `.arityX()`
 
-After providing the name, the `OpBuilder` syntax requires the number of inputs. If you intend to pass `X` inputs to the Op, you then chain the `arityX()` method:
+After providing the name, the `OpBuilder` syntax requires the user to define the **number** of inputs to the Op call; we do this by adding one of the `arityX()` methods to the chain - `arity1()` tells the `OpBuilder` chain to expect one input, `arity2()` expects two inputs, and so on.
 
 In doing a basic gaussian blur, we will pass through the input image `inImage`, and a sigma parameter - therefore, we will call `arity2()`:
 

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -4,7 +4,7 @@ Ops are designed to be called from the Op matcher, using the `OpBuilder` syntax.
 
 On this page, we will be constructing an `OpBuilder` call on an `OpEnvironment ops` to execute a Gaussian Blur on an input image `inImage`, with our output buffer `outImage`.
 
-# Specifying the name with `.op()`
+## Specifying the name with `.op()`
 
 From the `OpEnvironment`, an `OpBuilder` call is initialized with the method `OpEnvironment.op(String)`, which is used to describe the name of the Op that the `OpBuilder` must return:
 
@@ -12,7 +12,7 @@ From the `OpEnvironment`, an `OpBuilder` call is initialized with the method `Op
 ops.op("filter.gauss")
 ```
 
-# Specifying the number of inputs with `.arityX()`
+## Specifying the number of inputs with `.arityX()`
 
 After providing the name, the `OpBuilder` syntax requires the user to define the **number** of inputs to the Op call; we do this by adding one of the `arityX()` methods to the chain - `arity1()` tells the `OpBuilder` chain to expect one input, `arity2()` expects two inputs, and so on.
 
@@ -22,7 +22,7 @@ In doing a basic gaussian blur, we will pass through the input image `inImage`, 
 ops.op("filter.gauss").arity2()
 ```
 
-# Passing the inputs with `.input()`
+## Passing the inputs with `.input()`
 
 With the arity defined in the `OpBuilder` call, we can then chain the inputs with the `input()` method.
 
@@ -32,7 +32,7 @@ For our gaussian blur, we will pass as inputs our input image `inImage`, and a `
 ops.op("filter.gauss").arity2().input(inImage, 2.0)
 ```
 
-# Passing an output buffer with `.output()`
+## Passing an output buffer with `.output()`
 
 Now that the inputs are specified, we can chain the output buffer using the `output()` method.
 

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -62,5 +62,5 @@ If, instead of having a single image `inImage` we had Y images `inImage1`, `inIm
 
 ```groovy
 var gaussOp = ops.op("filter.gauss").arity2().input(inImage, 2.0).output(outImage).computer()
-gaussOp.comput(inImage)
+gaussOp.compute(inImage)
 ```

--- a/imagej/imagej-ops2-tutorial/docs/CallingOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/CallingOps.md
@@ -12,9 +12,9 @@ From the `OpEnvironment`, an `OpBuilder` call is initialized with the method `Op
 ops.op("filter.gauss")
 ```
 
-## Specifying the number of inputs with `.arityX()`
+## Specifying the number of inputs with `.arity*()`
 
-After providing the name, the `OpBuilder` syntax requires the user to define the **number** of inputs to the Op call; we do this by adding one of the `arityX()` methods to the chain - `arity1()` tells the `OpBuilder` chain to expect one input, `arity2()` expects two inputs, and so on.
+After providing the name, the `OpBuilder` syntax requires the user to define the **number** of inputs to the Op call; we do this by adding one of the `arity*()` methods to the chain - `arity1()` tells the `OpBuilder` chain to expect one input, `arity2()` expects two inputs, and so on.
 
 In doing a basic gaussian blur, we will pass through the input image `inImage`, and a sigma parameter - therefore, we will call `arity2()`:
 

--- a/imagej/imagej-ops2-tutorial/docs/MigratingFromImageJOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/MigratingFromImageJOps.md
@@ -1,0 +1,198 @@
+# Migrating from ImageJ Ops
+
+The [ImageJ Ops](https://imagej.net/libs/imagej-ops/index) framework is the predecessor of the SciJava Ops framework, and many steps were taken to make expressing Ops much easier. This document shows ImageJ Ops developers how to convert their Ops to SciJava Ops - we'll convert [`DefaultGaussRAI`](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/filter/gauss/DefaultGaussRAI.java) from the ImageJ Ops repository as an example.
+
+# Upgrading pom-scijava
+
+Before doing anything else, you should ensure that your version of pom-scijava is new enough to make use of SciJava 3 goodness.
+
+TODO: Replace with the pom-scijava version needed to grab this annotation processor.
+
+Until the SciJava 3 annotation processor is added to pom-scijava, developers must add the following block of code to the `build` section of your POM:
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.scijava</groupId>
+                        <artifactId>scijava-javadoc-parser</artifactId>
+                        <version>${project.version}</version>
+                    </path>
+                </annotationProcessorPaths>
+                <fork>true</fork>
+                <showWarnings>true</showWarnings>
+                <compilerArgs>
+                    <arg>-Ajavadoc.packages="${therapi.packages}"</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+The other step recommended in your POM is to remove the dependency on ImageJ Ops!
+
+# Removing all the boilerplate
+
+In ImageJ Ops, all Ops were written as `Class`es, with SciJava `@Plugin` and `@Parameter` annotations everywhere - most of these annotations can be removed in SciJava Ops!
+
+## Replace the `@Plugin` annotation with an `@implNote` in the javadoc
+
+SciJava Ops uses a separate annotation processor to record plugins at compile time. This allows SciJava Ops to discover Ops *without any runtime dependencies*! Thus, instead of using an annotation, plugin declaration is performed *within the javadoc* of all plugins, using the `@implNote` tag new to Java 9. The general schema for op declaration is as follows:
+
+```java
+/**
+ * My sweet Op
+ * 
+ * @implNote op names='name1'
+ */
+```
+
+Additional options include:
+* Providing multiple names by replacing `names='name1'` with `names='name1,name2,...'` to allow your Op to be discoverable under multiple names
+* Providing the Op's priority by appending `priority=<the priority>`. SciJava Ops uses the same priority values as ImageJ Ops2, and relative priorities can be retained by using the new SciJava Priority library.
+
+The following diff shows the changes needed to replace the `@Plugin` annotation:
+
+```diff
+  * @author Christian Dietz (University of Konstanz)
+  * @author Stephan Saalfeld
+  * @param <T> type of input and output
++ * @implNote op names='filter.gauss', priority='1.0'
+  */
+ @SuppressWarnings({ "unchecked", "rawtypes" })
+-@Plugin(type = Ops.Filter.Gauss.class, priority = 1.0)
+ public class DefaultGaussRAI<T extends NumericType<T> & NativeType<T>> extends
+        AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+        implements Ops.Filter.Gauss
+```
+
+## Moving parameters to the functional method
+
+SciJava Ops no longer uses the `@Parameter` annotation to declare parameters - *all* Op parameters are instead passed through the functional method.
+
+To conform `DefaultGaussRAI` to this schema, the following diff should be applied:
+
+```diff
+ public class DefaultGaussRAI<T extends NumericType<T> & NativeType<T>> extends
+        AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+        implements Ops.Filter.Gauss
+ {
+ 
+-       @Parameter
+-       private ThreadService threads;
+-
+-       @Parameter
+-       private double[] sigmas;
+-
+-       @Parameter(required = false)
+-       private OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds;
+-
+        @Override
+        public void compute(final RandomAccessibleInterval<T> input,
++               final ThreadService threads,
++               final double[] sigmas,
++               @Optional OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
+                final RandomAccessibleInterval<T> output)
+        {
+```
+
+**Note**: optional parameters are denoted using the `org.scijava.ops.spi.Optional` annotation. Just like in ImageJ Ops, if the user does *not* decide to pass that parameter, it will be assigned to `null`, so leave in any null-checks for optional parameters.
+
+## Implementing the right functional interface
+
+Ops in the SciJava Ops framework implement a new set of Op types, designed for functional simplicity. These functional interfaces are built off of the `java.util.function.Function` interface, and are housed in the SciJava Functions library. 
+
+The first step to finding the right functional interface for the Op being converted. While the `Computer`, `Function`, and `Inplace` Op interfaces persist in SciJava Ops, there are many more interfaces *because* all parameters are defined in the functional method.
+
+If your Op was originally a `Function`, then the Op should implement one of the following interfaces:
+* `java.util.function.Function`, if your Op has only one parameter
+* `java.util.function.BiFunction`, if your Op has only two parameters
+* `org.scijava.function.Functions.ArityX`, if your Op has `X>2` parameters
+
+If your Op was originally a `Computer` and now has `X` parameters in its functional method, then the Op should implement `org.scijava.function.Computers.ArityX`.
+
+Finally, if your Op was originally an `Inplace` and now has `X` parameters in its functional method, with parameter `Y` being the one to mutate, then the Op should implement `org.scijava.function.Inplace.ArityX_Y`.
+
+After the last step, we see that our example Op (a `Computer`) has 4 inputs - thus it should implement `org.scijava.function.Computers.Arity4` - below is the diff of the change necessary:
+
+```diff
+  * @author Christian Dietz (University of Konstanz)
+  * @author Stephan Saalfeld
+  * @param <T> type of input and output
+  * @implNote op names='filter.gauss', priority='1.0'
+  */
+ @SuppressWarnings({ "unchecked", "rawtypes" })
+-public class DefaultGaussRAI<T extends NumericType<T> & NativeType<T>> extends
+-       AbstractUnaryHybridCF<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>>
+-       implements Ops.Filter.Gauss
++public class DefaultGaussRAI<T extends NumericType<T> & NativeType<T>> implements
++       Computers.Arity4<RandomAccessibleInterval<T>, ThreadSerice, double[], OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>>
+ {
+```
+
+Note two things when you change the interface:
+* The interface `Ops.Filter.Gauss` is no longer necessary - if you are implementing some such interface, you no longer need it!
+* Additional interface methods, including hybrid Op method like `createOutput` are no longer necessary, and can also be deleted. Below is the diff of removing `createOutput` from our example Op:
+  ```diff
+                    }
+            }
+
+    -       @Override
+    -       public RandomAccessibleInterval<T> createOutput(
+    -               final RandomAccessibleInterval<T> input)
+    -       {
+    -               return ops().create().img(input);
+    -       }
+    -
+    }
+  ```
+
+## The Example Op, configured for SciJava Ops
+
+And that's it! Your Op is now ready to be used in SciJava Ops!
+
+```java
+/**
+ * Gaussian filter, wrapping {@link Gauss3} of imglib2-algorithms.
+ *
+ * @author Christian Dietz (University of Konstanz)
+ * @author Stephan Saalfeld
+ * @param <T> type of input and output
+ * @implNote op names='filter.gauss', priority='1.0'
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class DefaultGaussRAI<T extends NumericType<T> & NativeType<T>> implements
+		Computers.Arity4<RandomAccessibleInterval<T>, ThreadSerice, double[], OutOfBoundsFactory<T, RandomAccessibleInterval<T>>, RandomAccessibleInterval<T>>
+{
+
+	@Override
+	public void compute(final RandomAccessibleInterval<T> input,
+			final ThreadService threads,
+			final double[] sigmas,
+			@Optional OutOfBoundsFactory<T, RandomAccessibleInterval<T>> outOfBounds,
+			final RandomAccessibleInterval<T> output)
+	{
+
+		if (outOfBounds == null) {
+			outOfBounds = new OutOfBoundsMirrorFactory<>(Boundary.SINGLE);
+		}
+
+		final RandomAccessible<FloatType> eIn = //
+				(RandomAccessible) Views.extend(input, outOfBounds);
+
+		try {
+			SeparableSymmetricConvolution.convolve(Gauss3.halfkernels(sigmas), eIn,
+					output, threads.getExecutorService());
+		}
+		catch (final IncompatibleTypeException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}
+```

--- a/imagej/imagej-ops2-tutorial/docs/MigratingFromImageJOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/MigratingFromImageJOps.md
@@ -2,7 +2,7 @@
 
 The [ImageJ Ops](https://imagej.net/libs/imagej-ops/index) framework is the predecessor of the SciJava Ops framework, and many steps were taken to make expressing Ops much easier. This document shows ImageJ Ops developers how to convert their Ops to SciJava Ops - we'll convert [`DefaultGaussRAI`](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/filter/gauss/DefaultGaussRAI.java) from the ImageJ Ops repository as an example.
 
-# Upgrading pom-scijava
+## 1. Upgrading pom-scijava
 
 Before doing anything else, you should ensure that your version of pom-scijava is new enough to make use of SciJava 3 goodness.
 
@@ -36,11 +36,11 @@ Until the SciJava 3 annotation processor is added to pom-scijava, developers mus
 
 The other step recommended in your POM is to remove the dependency on ImageJ Ops!
 
-# Removing all the boilerplate
+## 2. Removing all the boilerplate
 
 In ImageJ Ops, all Ops were written as `Class`es, with SciJava `@Plugin` and `@Parameter` annotations everywhere - most of these annotations can be removed in SciJava Ops!
 
-## Replace the `@Plugin` annotation with an `@implNote` in the javadoc
+### 2.1 Replace the `@Plugin` annotation with an `@implNote` in the javadoc
 
 SciJava Ops uses a separate annotation processor to record plugins at compile time. This allows SciJava Ops to discover Ops *without any runtime dependencies*! Thus, instead of using an annotation, plugin declaration is performed *within the javadoc* of all plugins, using the `@implNote` tag new to Java 9. The general schema for op declaration is as follows:
 
@@ -71,7 +71,7 @@ The following diff shows the changes needed to replace the `@Plugin` annotation:
         implements Ops.Filter.Gauss
 ```
 
-## Moving parameters to the functional method
+### 2.2 Moving parameters to the functional method
 
 SciJava Ops no longer uses the `@Parameter` annotation to declare parameters - *all* Op parameters are instead passed through the functional method.
 
@@ -103,7 +103,7 @@ To conform `DefaultGaussRAI` to this schema, the following diff should be applie
 
 **Note**: optional parameters are denoted using the `org.scijava.ops.spi.Optional` annotation. Just like in ImageJ Ops, if the user does *not* decide to pass that parameter, it will be assigned to `null`, so leave in any null-checks for optional parameters.
 
-## Implementing the right functional interface
+## 3 Implementing the right functional interface
 
 Ops in the SciJava Ops framework implement a new set of Op types, designed for functional simplicity. These functional interfaces are built off of the `java.util.function.Function` interface, and are housed in the SciJava Functions library. 
 

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -10,7 +10,7 @@ Simple pixel-wise operations like addition, inversion, and more can be written o
 /**
  * A simple pixelwise Op
  * 
- * @implNote op names="my.op"
+ * @implNote op names="pixel.op"
  */
 class <T extends RealType<T>> MyPixelwiseOp implements Computers.Arity2<T, T, T> {
 	@Override
@@ -27,18 +27,18 @@ ArrayImg<UnsignedByteType> in1 = ...
 ArrayImg<UnsignedByteType> in2 = ...
 ArrayImg<UnsignedByteType> out = ...
 
-ops.op("my.op").arity2().input(in1, in2).output(out).compute();
+ops.op("pixel.op").arity2().input(in1, in2).output(out).compute();
 ```
 
 A similar vein of thought works for simple `List`s and `Array`s - if you have an Op that produces a `Double` from another `Double`, there's no need to write a wrapper to work on `Double[]`s - Ops will do that for you!
 
 ```java
 /**
- * A simple pixelwise Op
+ * An element-wise Op
  *
- * @implNote op names="my.op"
+ * @implNote op names="element.op"
  */
-class MyPixelwiseOp implements Function<Double, Double> {
+class MyElementOp implements Function<Double, Double> {
     @Override
     public Double apply(final Double input) {
         ... pixelwise computation here ...
@@ -50,7 +50,7 @@ If you then have SciJava Ops, the following Op call will match on your arrays, `
 
 ```java
 List<Double> inList = ...
-List<Double> outList = ops.op("my.op2").arity1().input(in1).apply();
+List<Double> outList = ops.op("element.op").arity1().input(in1).apply();
 ```
 
 ## Neighborhood-wise Ops
@@ -62,7 +62,7 @@ A slightly more complicated class of algorithms operate on local regions around 
 /**
  * A simple neighborhood-based Op
  *
- * @implNote op names="my.op"
+ * @implNote op names="neighborhood.op"
  */
 class <T extends RealType<T>> MyNeighborhoodOp implements Computers.Arity1<Neighborhood<T>, T> {
 	@Override
@@ -79,7 +79,7 @@ ArrayImg<DoubleType> input = ...
 Shape neighborhoodShape = ...
 ArrayImg<DoubleType> output = ...
 
-ops.op("my.op").arity2().input(input, shape).output(output).compute()
+ops.op("neighborhood.op").arity2().input(input, shape).output(output).compute()
 ```
 
 ## Using dependencies
@@ -95,10 +95,11 @@ import org.scijava.ops.spi.OpDependency;
 /**
  * An Op that needs to run on the whole image
  *
- * @implNote op names="my.op"
+ * @implNote op names="iterating.op"
  */
-class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
-    @OpDependency(name = "my.internalOp")
+class<I, O> MultiPassOp implements Computers.Arity1<Img<I>,Img<O>>{
+	
+    @OpDependency(name = "internal.Op")
     private final Computers.Arity1<Img<I>, Img<O>> iteration;
 
     @Override
@@ -107,16 +108,19 @@ class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
             iteration.compute(input, container);
 		}
     }
+    
 }
 
 /**
  * An Op that executes a single iteration of some iterative process
- * @implNote op names="my.internalOp"
+ * @implNote op names="internal.Op"
  */
-class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
+class<I, O> IterationOp implements Computers.Arity1<Img<I>,Img<O>>{
+	
     @Override
     public void compute(final Img<I> input, final Img<O> container){
         ...perform an iteration...
     }
+    
 }
 ```

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -120,11 +120,3 @@ class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
     }
 }
 ```
-
-
-
-
-
-
-
-

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -53,7 +53,7 @@ List<Double> inList = ...
 List<Double> outList = ops.op("my.op2").arity1().input(in1).apply();
 ```
 
-## Lifting to Neighborhoods
+## Neighborhood-wise Ops
 
 A slightly more complicated class of algorithms operate on local regions around each input pixel. For this class of algorithms, we recommend writing Ops on an imglib2-algorithm `net.imglib2.algorithm.neighborhood.Neighborhood` object. 
 

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -4,7 +4,7 @@ SciJava Ops is designed for modularity, extensibility, and granularity - by writ
 
 ## Element-wise Ops
 
-Simple pixel-wise operations like addition, inversion, and more can be written on a single pixel (i.e. `RealType`) - therefore, ImageJ Ops2 takes care to automagically adapt pixel-wise Ops across a wide variety of image types. Therefore, if you would like to write a pixel-wise Op, we recommend the following structure.
+Simple pixel-wise operations like addition, inversion, and more can be written on a single pixel (i.e. `RealType`) - therefore, ImageJ Ops2 takes care to automagically adapt pixel-wise Ops across a wide variety of image types. If you would like to write a pixel-wise Op, we recommend the following structure.
 
 ```java
 

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -1,0 +1,132 @@
+# Writing Small, Easy, Modular Ops
+
+SciJava Ops is designed for modularity, extensibility, and granularity - by writing your Ops on the smallest functional elements possible, you'll allow SciJava Ops to lift your Op to new image types, enable parallelism, and more without any additional effort!
+
+## Element-wise Ops
+
+Simple pixel-wise operations like addition, inversion, and more can be written on a single pixel (i.e. `RealType`) - therefore, ImageJ Ops2 takes care to automagically adapt pixel-wise Ops across a wide variety of image types. Therefore, if you would like to write a pixel-wise Op, we recommend the following structure.
+
+```java
+
+/**
+ * A simple pixelwise Op
+ * 
+ * @implNote op names="my.op"
+ */
+class <T extends RealType<T>> MyPixelwiseOp implements Computers.Arity2<T, T, T> {
+	@Override
+        public void compute(final T in1, final T in2, final T out) {
+            ... pixelwise computation here ...
+        }
+}
+```
+
+If you then have ImageJ Ops2, the following Op call will match your pixel-wise Op using ImageJ Ops2's lifting mechanisms:
+
+```java
+ArrayImg<UnsignedByteType> in1 = ...
+ArrayImg<UnsignedByteType> in2 = ...
+ArrayImg<UnsignedByteType> out = ...
+
+ops.op("my.op").arity2().input(in1, in2).output(out).compute();
+```
+
+A similar vein of thought works for simple `List`s and `Array`s - if you have an Op that produces a `Double` from another `Double`, there's no need to write a wrapper to work on `Double[]`s - Ops will do that for you!
+
+```java
+
+/**
+ * A simple pixelwise Op
+ *
+ * @implNote op names="my.op"
+ */
+class MyPixelwiseOp implements Function<Double, Double> {
+    @Override
+    public Double apply(final Double input) {
+        ... pixelwise computation here ...
+    }
+}
+```
+
+If you then have SciJava Ops, the following Op call will match on your arrays, `List`s, `Set`s, and more - an example is shown below:
+
+```java
+List<Double> inList = ...
+List<Double> outList = ops.op("my.op2").arity1().input(in1).apply();
+```
+
+## Lifting to Neighborhoods
+
+A slightly more complicated class of algorithms operate on local regions around each input pixel. For this class of algorithms, we recommend writing Ops on an imglib2-algorithm `net.imglib2.algorithm.neighborhood.Neighborhood` object. 
+
+```java
+
+/**
+ * A simple neighborhood-based Op
+ *
+ * @implNote op names="my.op"
+ */
+class <T extends RealType<T>> MyNeighborhoodOp implements Computers.Arity1<Neighborhood<T>, T> {
+	@Override
+	public void compute(final Neighborhood<T> input, final T output) {
+        ... pixelwise computation here ...
+	}
+}
+```
+
+ImageJ Ops2 will then lift this algorithm to operate on images in parallel, requiring users to only define the shape of the neighborhoods to be used:
+
+```java
+ArrayImg<DoubleType> input = ...
+Shape neighborhoodShape = ...
+ArrayImg<DoubleType> output = ...
+
+ops.op("my.op").arity2().input(input, shape).output(output).compute()
+```
+
+## Using dependencies
+
+Even when your Op must be run on entire Images, you can use Op Dependencies to promote extensibility, reusability and flexibility.
+
+For example, if your Op must iterate over some algorithm n times, consider internalizing the algorithm within a separate Op, and make it a depedency, like shown below:
+
+```java
+import org.scijava.ops.spi.OpDependency;
+
+
+/**
+ * An Op that needs to run on the whole image
+ *
+ * @implNote op names="my.op"
+ */
+class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
+    @OpDependency(name = "my.internalOp")
+    private final Computers.Arity1<Img<I>, Img<O>> iteration;
+
+    @Override
+    public void compute(final Img<I> input, final Img<O> container){
+        for(int i=0; i < numItrs; i++){
+            iteration.compute(input, container);
+		}
+    }
+}
+
+/**
+ * An Op that executes a single iteration of some iterative process
+ * @implNote op names="my.internalOp"
+ */
+class<I, O> ComplicatedOp implements Computers.Arity1<Img<I>,Img<O>>{
+    @Override
+    public void compute(final Img<I> input, final Img<O> container){
+        ...perform an iteration...
+    }
+}
+```
+
+
+
+
+
+
+
+

--- a/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
+++ b/imagej/imagej-ops2-tutorial/docs/OpCurrency.md
@@ -7,7 +7,6 @@ SciJava Ops is designed for modularity, extensibility, and granularity - by writ
 Simple pixel-wise operations like addition, inversion, and more can be written on a single pixel (i.e. `RealType`) - therefore, ImageJ Ops2 takes care to automagically adapt pixel-wise Ops across a wide variety of image types. If you would like to write a pixel-wise Op, we recommend the following structure.
 
 ```java
-
 /**
  * A simple pixelwise Op
  * 
@@ -34,7 +33,6 @@ ops.op("my.op").arity2().input(in1, in2).output(out).compute();
 A similar vein of thought works for simple `List`s and `Array`s - if you have an Op that produces a `Double` from another `Double`, there's no need to write a wrapper to work on `Double[]`s - Ops will do that for you!
 
 ```java
-
 /**
  * A simple pixelwise Op
  *

--- a/imagej/imagej-ops2-tutorial/docs/ScriptingInImageJ2.md
+++ b/imagej/imagej-ops2-tutorial/docs/ScriptingInImageJ2.md
@@ -1,0 +1,49 @@
+# Scripting in ImageJ2
+
+Using SciJava Ops and ImageJ Ops2 within scripts provide the most powerful aspects of Ops. The following page will explain how you can write a script in ImageJ2's Script Editor that utilizes Ops for image processing.
+
+## Obtaining an OpEnvironment
+
+To run Ops, scripts must first create an `OpEnvironment`. The following line will create a new `OpEnvironment` containing all Ops available in the environment:
+
+```groovy
+import org.scijava.ops.engine.DefaultOpEnvironment
+
+ops = new DefaultOpEnvironment()
+```
+
+## Obtaining inputs
+
+Scripts using SciJava Ops obtain inputs like any other SciJava script, and the lines below will provide us with an `Img` input parameter and an `Img` output parameter, as well as a `ThreadService` which we will use later.
+
+```groovy
+#@ ThreadService ts
+#@ Img imgInput
+#@output Img out
+```
+
+For more information on SciJava scripting parameters, please visit [this page](https://imagej.net/scripting/parameters).
+
+## Calling Ops
+
+The OpBuilder syntax should be used to retrieve and execute Ops from the `OpEnvironment`. The following line executes a Gaussian Blur on an input image using a `filter.gauss` Op:
+```groovy
+out = ops.op("filter.gauss").arity3().input(imgInput, ts.getExecutorService(), new Double(3.0)).apply()
+```
+
+## Putting it all together
+
+The below script can be pasted into the Script Editor. **Ensure that the Script Editor is configured to run a Groovy script**.
+
+```groovy
+#@ ThreadService ts
+#@ Img imgInput
+#@output Img out
+
+// Obtain an OpEnvironment
+import org.scijava.ops.engine.DefaultOpEnvironment
+ops = new DefaultOpEnvironment()
+
+// Call some Ops!
+out = ops.op("filter.gauss").arity3().input(imgInput, ts.getExecutorService(), new Double(3.0)).apply()
+```

--- a/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
@@ -8,5 +8,43 @@ Users can query the `OpEnvironment` for Ops matching a given name using the meth
 import org.scijava.ops.engine.DefaultOpEnvironment
 ops = new DefaultOpEnvironment()
 
-ops.descriptions("filter.gauss")
+print(ops.descriptions("filter.gauss"))
+```
+This script yields the following printout:
+```groovy
+[filter.gauss(
+	 Inputs:
+		net.imglib2.RandomAccessibleInterval<T> input1
+		java.util.concurrent.ExecutorService input2
+		double[] input3
+		net.imglib2.outofbounds.OutOfBoundsFactory<T, net.imglib2.RandomAccessibleInterval<T>> input4?
+	 Containers (I/O):
+		net.imglib2.RandomAccessibleInterval<T> container1
+)
+, filter.gauss(
+	 Inputs:
+		net.imglib2.RandomAccessibleInterval<T> input1
+		java.util.concurrent.ExecutorService input2
+		double[] input3
+	 Containers (I/O):
+		net.imglib2.RandomAccessibleInterval<T> container1
+)
+, filter.gauss(
+	 Inputs:
+		net.imglib2.RandomAccessibleInterval<T> input1
+		java.util.concurrent.ExecutorService input2
+		java.lang.Double input3
+		net.imglib2.outofbounds.OutOfBoundsFactory<T, net.imglib2.RandomAccessibleInterval<T>> input4?
+	 Containers (I/O):
+		net.imglib2.RandomAccessibleInterval<T> container1
+)
+, filter.gauss(
+	 Inputs:
+		net.imglib2.RandomAccessibleInterval<T> input1
+		java.util.concurrent.ExecutorService input2
+		java.lang.Double input3
+	 Containers (I/O):
+		net.imglib2.RandomAccessibleInterval<T> container1
+)
+]
 ```

--- a/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
@@ -1,0 +1,12 @@
+# Searching for Ops in the Environment
+
+As the `OpEnvironment` is fully extensible, different `OpEnvironment`s might contain different Ops, and it is important to be able to query an `OpEnvironment` about the available Ops.
+
+Users can query the `OpEnvironment` for Ops matching a given name using the method `OpEnvironment.descriptions(String)`. The following SciJava script queries an `OpEnvironment` for all Ops matching the name `filter.gauss`:
+
+```groovy
+import org.scijava.ops.engine.DefaultOpEnvironment
+ops = new DefaultOpEnvironment()
+
+ops.descriptions("filter.gauss")
+```

--- a/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
+++ b/imagej/imagej-ops2-tutorial/docs/SearchingForOps.md
@@ -48,3 +48,5 @@ This script yields the following printout:
 )
 ]
 ```
+
+**Note**: The no-argument call to `OpEnvironment.descriptions()` will print out *all Ops in the `OpEnvironment`*.

--- a/imagej/imagej-ops2-tutorial/docs/TempInstallingSciJava3ComponentsInFiji.md
+++ b/imagej/imagej-ops2-tutorial/docs/TempInstallingSciJava3ComponentsInFiji.md
@@ -1,0 +1,23 @@
+Until we start using the update site, here's how I have set up SciJava Ops in Fiji:
+
+# Ensure Java 11 is being used
+
+`sudo update-java-alternatives` is likely the best 
+
+# Building the necesssary jars into a Fiji installation
+
+From the top-level incubator folder, you can run the following to install the incubator into a local Fiji. 
+
+```bash
+mvn clean install -Dscijava.app.directory=<path to your Fiji.app folder>
+```
+
+# Launching Fiji
+
+Ideally, until Fiji starts shipping Java 11, we'd follow [these instructions](https://forum.image.sc/t/run-fiji-or-imagej-headless-mode-with-java-11/73989/4). Unfortunately, we don't have access to the full classpath with this method, breaking the Therapi Op discovery mechanism. The following line of code DOES work, however:
+
+```bash
+export FIJI_HOME=~/Applications/Fiji.app; /usr/bin/java -cp "$FIJI_HOME/jars/*:$FIJI_HOME/jars/bio-formats/*:$FIJI_HOME/plugins/*" sc.fiji.Main
+```
+
+

--- a/imagej/imagej-ops2-tutorial/docs/WritingYourOwnOpPackage.md
+++ b/imagej/imagej-ops2-tutorial/docs/WritingYourOwnOpPackage.md
@@ -1,0 +1,211 @@
+# Writing Your Own Op Package
+
+Right now, there are two ways to write and expose your own Ops.
+
+## Ops Through Javadoc
+
+Ops can be declared directly through Javadoc - this yields a couple of benefits, namely:
+* No additional runtime dependencies needed for simple Ops
+
+This mechanism of Op declaration is used by the ImageJ Ops2 project
+
+### Adding the SciJava Javadoc Parser to your POM
+
+Ops written through Javadoc are discovered by the SciJava Javadoc Parser, which creates a file `op.yaml` containing all of the data needed to import each Op you declare.
+
+Until the SciJava 3 annotation processor is added to pom-scijava, developers must add the following block of code to the `build` section of your POM:
+
+TODO: Replace with the pom-scijava version needed to grab this annotation processor.
+TODO: Replace the SciJava Javadoc Parser version with the correct initial version
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.scijava</groupId>
+                        <artifactId>scijava-javadoc-parser</artifactId>
+                        <version>${project.version}</version>
+                    </path>
+                </annotationProcessorPaths>
+                <fork>true</fork>
+                <showWarnings>true</showWarnings>
+                <compilerArgs>
+                    <arg>-Ajavadoc.packages="-"</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+### Declaring Ops with the `@implNote` syntax
+
+To declare a block of code as an Op, simply add the `@implNote` tag to that block's Javadoc. The `@implNote` schema for declaring Ops is as follows:
+
+```java
+/**
+ * @implNote op names='<names>' [priority='<priority>'] [type='<type>']
+ */
+```
+
+The arguments to the `@implNote op` syntax are described below:
+* `names='<names>'` provides the names that the Op will match. If you'd like this Op to be searchable under one name `foo.bar`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`.
+* `priority='<priority>'` provides a decimal-valued priority used to break ties when multiple Ops match a given Op request. *We advise against adding priorities unless you experience matching conflicts*. Op priorities should follow the SciJava Priority standards [insert link].
+* `type='<type>'` identifies the functional type of the Op **and is only required for Ops written as methods** - more information on that below [insert link].
+
+### Declaring Ops as Methods
+
+Any `static` method can be easily declared as an Op by simply appending the `@implNote` tag to the method's Javadoc:
+
+```java
+/**
+ * My static method, which is also an Op
+ * @implNote op names='my.op' type='java.util.function.BiFunction'
+ * @param arg1 the first argument to the method
+ * @param arg2 the first argument to the method
+ * @return the result of the method
+ */
+public static Double myStaticMethodOp(Double arg1, Double arg2) {
+    ...computation here...
+}
+```
+Note that the `type` argument in the `@implNote` syntax is **required** for Ops written as methods (and only for Ops written as methods), as the Op must be registered to a functional type. The recommended functional types are housed in the SciJava Functions library [insert link].
+
+### Declaring Ops as Classes
+
+Any `Class` implementing a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can be declared as an Op using the `@implNote` syntax within the Javadoc *of that class*, as shown in the example below:
+
+```java
+/**
+ * My class, which is also an Op
+ *
+ * @implNote op names='my.op'
+ */
+public class MyClassOp
+		implements java.util.function.BiFunction<Double, Double, Double>
+{
+
+	/**
+     * The functional method of my Op
+     * @param arg1 the first argument to the Op
+     * @param arg2 the first argument to the Op
+     * @return the result of the Op
+	 */
+	@Override
+    public Double apply(Double arg1, Double arg2) {
+		return null;
+	}
+}
+```
+
+Note that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.scijava</groupId>
+        <artifactId>scijava-function</artifactId>
+    </dependency>
+</dependencies>
+```
+
+### Declaring Ops as Fields
+
+Any `Field` whose type is a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can also be declared as an Op. Function Ops are useful for very simple Ops, such as [Lambda Expressions](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html) or [Method references](https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html). For `Field`s, the `@implNote` syntax should be placed on Javadoc on the Field, as shown below:
+
+```java
+public class MyOpCollection {
+
+	/**
+     * @implNote op names='my.op'
+	 */
+    public final BiFunction<Double, Double, Double> myFieldOp =
+        (arg1, arg2) -> {...computation...};
+	
+}
+```
+
+Note again that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.scijava</groupId>
+        <artifactId>scijava-function</artifactId>
+    </dependency>
+</dependencies>
+```
+
+## Ops using JPMS
+
+The other way to expose Ops is by using the [Java Platform Module System](https://www.oracle.com/corporate/features/understanding-java-9-modules.html). This mechanism is used to expose the Ops declared within SciJava Ops Engine, and may be preferred for its usage of plain Java mechanisms:
+
+In opposition to the Javadoc mechanism, all projects wishing to declare Ops using JPMS must add a dependency on the SciJava Ops SPI library:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.scijava</groupId>
+        <artifactId>scijava-ops-spi</artifactId>
+    </dependency>
+</dependencies>
+```
+
+### Declaring Ops as Classes
+
+Using JPMS, Ops can be declared as Classes using the `OpClass` annotation and the `Op` interface, as shown below:
+
+```java
+@OpClass(names = "my.op")
+public class MyClassOp implements BiFunction<Double, Double, Double>, Op {
+	@Override
+    public Double apply(Double arg1, Double arg2) {
+      ...computation...
+    }
+}
+```
+Note the following:
+* The `@OpClass` annotation provides the names of the Op
+* The `BiFunction` interface determines the functional type of the Op
+* The `Op` interface allows us to declare the Class as a service using JPMS
+
+Below, we'll see how to expose the Op within the `module-info.java`.
+
+### Declaring Ops as Fields and Methods
+
+Using JPMS, Ops can be declared as Fields using the `OpField` annotation, or as Methods using the `OpMethod` annotation, within any class that implements the `OpCollection` interface. An example is shown below:
+
+```java
+public class MyOpCollection implements OpCollection {
+	@OpField(names="my.fieldOp")
+    public final BiFunction<Double, Double, Double> myFieldOp =
+        (arg1, arg2) -> {...computation...};
+	
+	@OpMethod(names="my.methodOp", type=BiFunction.class)
+    public Double myMethodOp(final Double arg1, final Double arg2) {
+      ...computation...
+    }
+}
+```
+Note the following:
+* The `OpCollection` interface allows us to declare the Class as a service using JPMS
+* The `@OpField` annotation declares the `Field` as an Op and also specifies the name(s) of the Op
+* The `@OpMethod` annotation declares the `Method` as an Op and also specifies the name(s) of the Op. **In addition**, it specifies the functional interface of the resulting Op.
+
+### Exposing the Ops to SciJava Ops using the `module-info.java`
+
+The last step of declaring Ops using JPMS is to declare them in a `module-info.java`, located in the root package directory of your project (`src/main/java` for Maven projects).
+
+For an example module `com.example.ops` declaring the above Ops, we use the [`provides...with`] syntax to declare our `Op`s and our `OpCollection`s:
+
+```java
+module com.example.ops {
+	provides org.scijava.ops.spi.Op with com.example.ops.MyClassOp;
+	
+	provides org.scijava.ops.spi.OpCollection with com.example.ops.MyOpCollection;
+}
+```
+


### PR DESCRIPTION
This PR introduces a set of drafts for wiki-like documentation for using the SciJava Ops/ImageJ Ops2 framework, addressing the points of need described in scijava/scijava#124.

@hinerm let me know if there's anything you think I left out. We also have to figure out where they should live.