### PR TITLE
Make InfoTreeGenerator Prioritized

### DIFF
--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/InfoTreeGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/InfoTreeGenerator.java
@@ -36,8 +36,10 @@ import java.util.stream.Collectors;
 
 import org.scijava.ops.api.InfoTree;
 import org.scijava.ops.api.OpInfo;
+import org.scijava.priority.Prioritized;
+import org.scijava.priority.Priority;
 
-public interface InfoTreeGenerator {
+public interface InfoTreeGenerator extends Prioritized<InfoTreeGenerator> {
 
 
 	/**
@@ -68,13 +70,11 @@ public interface InfoTreeGenerator {
 	{
 		List<InfoTreeGenerator> suitableGenerators = generators.stream() //
 			.filter(g -> g.canGenerate(signature)) //
+			.sorted() //
 			.collect(Collectors.toList());
-		if (suitableGenerators.size() == 0) throw new IllegalArgumentException(
+		if (suitableGenerators.isEmpty()) throw new IllegalArgumentException(
 			"No InfoTreeGenerator in given collection " + generators +
 				" is able to reify signature " + signature);
-		if (suitableGenerators.size() > 1) throw new IllegalArgumentException(
-			"Signature " + signature +
-				" is able to be reified by multiple generators: " + suitableGenerators);
 		return suitableGenerators.get(0);
 	}
 
@@ -90,8 +90,8 @@ public interface InfoTreeGenerator {
 	 * Finds the subsignature in {@link String} {@code signature}. The
 	 * subsignature is assumed to start at index {@code start}.
 	 * 
-	 * @param signature
-	 * @param start
+	 * @param signature the signature containing a subsignature
+	 * @param start the index where the subsignature starts
 	 * @return a signature contained withing {@code signature}
 	 */
 	static String subSignatureFrom(String signature, int start) {
@@ -103,8 +103,7 @@ public interface InfoTreeGenerator {
 			else if (ch == InfoTree.DEP_END_DELIM) {
 				depth--;
 				if (depth == 0) {
-					int depsEnd = i;
-					return signature.substring(start, depsEnd + 1);
+					return signature.substring(start, i + 1);
 				}
 			}
 		}
@@ -124,4 +123,8 @@ public interface InfoTreeGenerator {
 	 */
 	boolean canGenerate(String signature);
 
+	@Override
+	default double getPriority() {
+		return Priority.NORMAL;
+	}
 }

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/InfoTreeGeneratorTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/InfoTreeGeneratorTest.java
@@ -1,0 +1,60 @@
+package org.scijava.ops.engine;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.api.InfoTree;
+import org.scijava.ops.api.OpInfo;
+import org.scijava.ops.engine.matcher.impl.OpFieldInfo;
+import org.scijava.ops.spi.OpCollection;
+import org.scijava.ops.spi.OpField;
+import org.scijava.priority.Priority;
+
+public class InfoTreeGeneratorTest extends AbstractTestEnvironment implements
+		OpCollection
+{
+
+	@OpField(names="test.infoTreeGeneration")
+	public final Function<Double, Double> foo = in -> in + 1;
+
+	@BeforeAll
+	public static void addNeededOps() {
+		ops.register(new DummyInfoTreeGenerator(), new InfoTreeGeneratorTest());
+	}
+
+
+	@Test
+	public void testMultipleValidInfoTreeGenerators() {
+		// Obtain a signature that can be reified by the DefaultInfoTreeGenerator and by our dummy generator
+		var op = ops.unary("test.infoTreeGeneration").inType(Double.class).outType(Double.class).function();
+		String signature = ops.history().signatureOf(op);
+		// Run treeFromID to make sure our generator doesn't run
+		var infoTree = ops.treeFromID(signature);
+		// Assert non-null output
+		Assertions.assertNotNull(infoTree);
+	}
+
+
+	static class DummyInfoTreeGenerator implements InfoTreeGenerator {
+
+		@Override
+		public InfoTree generate(String signature, Map<String, OpInfo> idMap,
+				Collection<InfoTreeGenerator> generators)
+		{
+			return null;
+		}
+
+		@Override public boolean canGenerate(String signature) {
+			return true;
+		}
+
+		@Override public double getPriority() {
+			return Priority.LOW;
+		}
+
+	}
+}


### PR DESCRIPTION
@ctrueden noted [here](https://github.com/scijava/incubator/pull/46#discussion_r763345469) that current logic could throw errors if there are multiple InfoTreeGenerators that match a particular Op signature, and outlined two choices:
1. Hide `InfoTreeGenerator`, so people can't implement it, and hardcode the priority.
2. Implement a priority system, and when multiple `InfoTreeGenerator`s could reify the signature, choose the highest priority.

This PR chooses option 2 as it is the less-API-breaking change, and because a priority-based system makes more sense than encoding an ordering by e.g. position in a `List`. This PR *doesn't* hide `InfoTreeGenerator`, but it also does not prevent us doing so in the future, and I'm not particularly against hiding it until we decide we need it.

Hiding `InfoTreeGenerator` would be as simple as moving it to a non-exported package. I still believe we'd want to service-load the implementations, as otherwise we'd probably introduce sub-package dependencies, failing the build, but that should still work if we move the package of the `InfoTreeGenerator`.

Closes scijava/scijava#87