### PR TITLE
Sipmlify getWrapperClass

### DIFF
--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodInParentTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpMethodInParentTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
+import org.scijava.types.Nil;
 
 public class OpMethodInParentTest extends AbstractTestEnvironment {
 
@@ -61,6 +62,22 @@ public class OpMethodInParentTest extends AbstractTestEnvironment {
 		String expected = "This string came from " +
 			SuperOpMethodHousingInterface.class;
 		Assertions.assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testRequestingFunctionalTypeSubclass() {
+		// Assert that things work just fine when asking for a Function
+		Function<String, String> function = ops//
+			.op("test.superMethod", new Nil<>()
+			{}, new Nil[] { new Nil<String>() {} }, new Nil<String>() {});
+
+		// Assert that things don't work when asking for a SuperOpMethodHousingClass
+		Assertions.assertThrows(ClassCastException.class, () -> {
+			SuperOpMethodHousingClass op = ops.op("test.superMethod", new Nil<>() {
+
+			}, new Nil[] { new Nil<String>() {} }, new Nil<String>() {});
+		});
+
 	}
 
 }


### PR DESCRIPTION
I made these changes while investigating scijava/scijava#51. It seems like there is no longer any errors thrown with the `DoubleFunction` type, unless we make following Op call **without making a `DoubleFunctionOpWrapper**:
```java
DoubleFunction func = ops.op("some.name", new Nil<DoubleFunction>() {}, new Nil[] {new Nil<Double>() {}}, new Nil<Double>() {})
```
In the case someone makes this Op call, they'll get a `ClassCastException` because the return is wrapped by the `Function1OpWrapper` - i.e. it is a `Function`, but not a `DoubleFunction`. You'll need a `DoubleFunctionOpWrapper` to get that type back, and this PR adds a warning that is logged when it is attempted.

I also made a change to the way that we find the wrapper; now, we no longer call `instanceof` on every wrapper class. We instead call contains on the inheritance hierarchy, which should be both more robust and faster.

Closes scijava/scijava#51