### PR TITLE
Add more noticable nullable parameter notation

### DIFF
--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
@@ -37,6 +37,7 @@ import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpRequest;
 import org.scijava.ops.engine.OpDescriptionGenerator;
+import org.scijava.ops.engine.matcher.reduce.ReducedOpInfo;
 import org.scijava.ops.engine.util.Infos;
 import org.scijava.priority.Priority;
 
@@ -119,6 +120,10 @@ public class SimplifiedOpDescriptionGenerator implements
 	private List<OpInfo> filterInfos(Iterable<? extends OpInfo> infos, OpRequest req) {
 		List<OpInfo> filtered = new ArrayList<>();
 		for (var info: infos) {
+			if (info instanceof ReducedOpInfo) {
+				continue;
+			}
+
 			var numPureInputs = info.inputs().stream() //
 					.filter(m -> !m.isOutput()) //
 					.count();
@@ -126,6 +131,7 @@ public class SimplifiedOpDescriptionGenerator implements
 			if (req.getArgs() == null || req.getArgs().length == numPureInputs) {
 				filtered.add(info);
 			}
+
 		}
 		return filtered;
 	}

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
@@ -227,7 +227,7 @@ public final class Infos {
 			sb.append(typeString(arg.getType(), verbose));
 			sb.append(" ");
 			sb.append(arg.getKey());
-			if (!arg.isRequired()) sb.append("?");
+			if (!arg.isRequired()) sb.append(" = null");
 			if (!arg.getDescription().isEmpty()) {
 					sb.append(" -> ");
 					sb.append(arg.getDescription());

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/InfosTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/InfosTest.java
@@ -1,0 +1,38 @@
+package org.scijava.ops.engine.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.spi.Nullable;
+import org.scijava.ops.spi.OpCollection;
+import org.scijava.ops.spi.OpMethod;
+
+import java.util.function.BiFunction;
+
+/**
+ * Test class for {@link Infos} static methods.
+ *
+ * @author Gabriel Selzer
+ */
+public class InfosTest extends AbstractTestEnvironment implements OpCollection {
+
+    @BeforeAll
+    public static void addNeededOps() {
+        ops.register(new InfosTest());
+    }
+
+    @OpMethod(names="test.nullableMethod", type=BiFunction.class)
+    public static Integer nullableMethod(Integer i1, @Nullable Integer i2) {
+        if (i2 == null) i2 = 0;
+        return i1 + i2;
+    }
+
+    @Test
+    public void testDescriptionOfNullableParameter() {
+        var actual = ops.help("test.nullableMethod");
+        var expected = "Ops:\n\t> test.nullableMethod(\n\t\t Inputs:\n\t\t\tInteger input1\n\t\t\tInteger input2 = null\n\t\t Outputs:\n\t\t\tInteger output1\n\t)\n\t";
+        Assertions.assertEquals(expected, actual);
+    }
+}
+


### PR DESCRIPTION
This PR adds more visible notation for Ops with nullable parameters. For example, given the Op
```java
    @OpMethod(names="test.nullableMethod", type=BiFunction.class)
    public static Integer nullableMethod(Integer i1, @Nullable Integer i2) {
        if (i2 == null) i2 = 0;
        return i1 + i2;
    }
```
And for the following `help` call:
```
var actual = ops.help("test.nullableMethod");
```
The following text is returned 
```
Ops:
	> test.nullableMethod(
		 Inputs:
			Integer input1
			Integer input2 = null
		 Outputs:
			Integer output1
	)
```