### PR TITLE
Add type shortcut parsing to `type` value in `@implNote` annotations

### DIFF
--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.java
@@ -69,7 +69,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Function<RAII1, RAIO> lift11(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -87,7 +86,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> BiFunction<RAII1, I2, RAIO> lift21(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -105,7 +103,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> BiFunction<RAII1, RAII2, RAIO> lift22(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -124,7 +121,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, I2, I3, RAIO> lift31(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -142,7 +138,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, RAII2, I3, RAIO> lift32(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -161,7 +156,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, RAII2, RAII3, RAIO> lift33(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -181,7 +175,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, I2, I3, I4, RAIO> lift41(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -199,7 +192,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, I3, I4, RAIO> lift42(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -218,7 +210,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO> lift43(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -238,7 +229,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO> lift44(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -259,7 +249,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO> lift51(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -277,7 +266,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO> lift52(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -296,7 +284,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO> lift53(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -316,7 +303,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO> lift54(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -337,7 +323,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO> lift55(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/Copiers.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/copy/Copiers.java
@@ -60,7 +60,7 @@ public final class Copiers {
      * @param <T> the {@link Type} of the objects involved
      * @param input the input {@link Type}
      * @param output the {@link Type} that will be filled with the value of {@code input}
-     * @implNote op names='copy, copy.type'
+     * @implNote op names='copy, copy.type', type=Computer
      */
     public static <T extends Type<T>> void copyType(final T input, final T output) {
         output.set(input);
@@ -75,7 +75,7 @@ public final class Copiers {
      * @param input the {@link RandomAccessibleInterval} whose data will be copied
      * @param copy  the {@link RandomAccessibleInterval} that will be filled with the contents of {@code input}
      * @author Christian Dietz (University of Konstanz)
-     * @implNote op names='copy, copy.rai, copy.img', priority='10.0'
+     * @implNote op names='copy, copy.rai, copy.img', priority='10.0', type=Computer
      */
     public static <T> void copyRAI( //
                                     final @OpDependency(name = "copy") Computers.Arity1<T, T> copier, //
@@ -95,7 +95,7 @@ public final class Copiers {
      * @param input         the {@link ImgLabeling} to copy
      * @param output        the destination container of the copy operation
      * @author Christian Dietz (University of Konstanz)
-     * @implNote op names='copy, copy.imgLabeling'
+     * @implNote op names='copy, copy.imgLabeling', type=Computer
      */
     public static <T extends IntegerType<T> & NativeType<T>, L> void copyImgLabeling( //
       final @OpDependency(name = "copy") Computers.Arity1<RandomAccessibleInterval<T>, RandomAccessibleInterval<T>> raiCopier,  //
@@ -118,7 +118,7 @@ public final class Copiers {
      * @param <L> the type of the {@link LabelingMapping} elements
      * @param input the {@link LabelingMapping} to copy
      * @param output the destination container of the copy operation
-     * @implNote op names='copy, copy.labelingMapping', priority='10000.'
+     * @implNote op names='copy, copy.labelingMapping', priority='10000.', type=Computer
      */
     public static <L> void copyLabelingMapping(final LabelingMapping<L> input, final LabelingMapping<L> output) {
         output.setLabelSets(input.getLabelSets());
@@ -132,7 +132,7 @@ public final class Copiers {
      * @param <A> the type of the backing data storage for each image
      * @param input the {@link ArrayImg} to copy
      * @param output the destination container of the copy operation
-     * @implNote op names='copy, copy.img', priority='10000.'
+     * @implNote op names='copy, copy.img', priority='10000.', type=Computer
      */
     public static <T extends NativeType<T>, A extends ArrayDataAccess<A>> void copyArrayImage( //
            final ArrayImg<T, A> input,
@@ -154,7 +154,7 @@ public final class Copiers {
      * @param copier an Op responsible for copying element types
      * @param input the {@link IterableInterval} to copy
      * @param output the destination container of the copy operation
-     * @implNote op names='copy, copy.iterableInterval, copy.img', priority='1.0'
+     * @implNote op names='copy, copy.iterableInterval, copy.img', priority='1.0', type=Computer
      */
     public static <T> void copyIterableInterval( //
         @OpDependency(name = "copy.type") final Computers.Arity1<Iterable<T>, Iterable<T>> copier, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/NeighborhoodFilters.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/NeighborhoodFilters.java
@@ -30,8 +30,6 @@
 package net.imagej.ops2.filter;
 
 import net.imglib2.algorithm.neighborhood.Neighborhood;
-import net.imglib2.type.numeric.RealType;
-import net.imglib2.type.numeric.real.DoubleType;
 import org.scijava.function.Computers;
 import org.scijava.ops.spi.OpDependency;
 
@@ -51,7 +49,7 @@ public final class NeighborhoodFilters {
 	 * @param <T> the {@link java.lang.reflect.Type} of the elements of
 	 *          {@code neighborhood}
 	 * @param <V> the {@link java.lang.reflect.Type} of the output container
-	 * @implNote op name='filter.max',type='org.scijava.function.Computers$Arity1'
+	 * @implNote op name='filter.max', type='Computer'
 	 */
 	public static <T, V> void defaultMax(@OpDependency(
 		name = "stats.max") Computers.Arity1<Iterable<T>, V> op,
@@ -70,8 +68,7 @@ public final class NeighborhoodFilters {
 	 * @param <T> the {@link java.lang.reflect.Type} of the elements of
 	 *          {@code neighborhood}
 	 * @param <V> the {@link java.lang.reflect.Type} of the output container
-	 * @implNote op
-	 *           name='filter.mean',type='org.scijava.function.Computers$Arity1'
+	 * @implNote op name='filter.mean',type='Computer'
 	 */
 	public static <T, V> void defaultMean(@OpDependency(
 		name = "stats.mean") Computers.Arity1<Iterable<T>, V> op,
@@ -90,8 +87,7 @@ public final class NeighborhoodFilters {
 	 * @param <T> the {@link java.lang.reflect.Type} of the elements of
 	 *          {@code neighborhood}
 	 * @param <V> the {@link java.lang.reflect.Type} of the output container
-	 * @implNote op
-	 *           name='filter.median',type='org.scijava.function.Computers$Arity1'
+	 * @implNote op name='filter.median', type='Computer'
 	 */
 	public static <T, V> void defaultMedian(@OpDependency(
 		name = "stats.median") Computers.Arity1<Iterable<T>, V> op,
@@ -110,7 +106,7 @@ public final class NeighborhoodFilters {
 	 * @param <T> the {@link java.lang.reflect.Type} of the elements of
 	 *          {@code neighborhood}
 	 * @param <V> the {@link java.lang.reflect.Type} of the output container
-	 * @implNote op name='filter.min',type='org.scijava.function.Computers$Arity1'
+	 * @implNote op name='filter.min', type='Computer'
 	 */
 	public static <T, V> void defaultMinimum(@OpDependency(
 		name = "stats.min") Computers.Arity1<Iterable<T>, V> op,
@@ -129,8 +125,7 @@ public final class NeighborhoodFilters {
 	 * @param <T> the {@link java.lang.reflect.Type} of the elements of
 	 *          {@code neighborhood}
 	 * @param <V> the {@link java.lang.reflect.Type} of the output container
-	 * @implNote op
-	 *           name='filter.variance',type='org.scijava.function.Computers$Arity1'
+	 * @implNote op name='filter.variance', type='Computer'
 	 */
 	public static <T, V> void defaultVariance(@OpDependency(
 		name = "stats.variance") Computers.Arity1<Iterable<T>, V> op,

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/filter/gauss/Gaussians.java
@@ -70,7 +70,7 @@ public final class Gaussians {
 	 * @param outOfBounds the {@link OutOfBoundsFactory} that defines how the
 	 *          calculation is affected outside the input bounds.
 	 * @param output the output image
-	 * @implNote op names='filter.gauss'
+	 * @implNote op names='filter.gauss', type=Computer
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <I extends NumericType<I>, O extends NumericType<O>> void
@@ -108,7 +108,7 @@ public final class Gaussians {
 	 * @param outOfBounds the {@link OutOfBoundsFactory} that defines how the
 	 *          calculation is affected outside the input bounds.
 	 * @param output the preallocated output image
-	 * @implNote op names='filter.gauss'
+	 * @implNote op names='filter.gauss', type=Computer
 	 */
 	public static <I extends NumericType<I>, O extends NumericType<O>> void
 		gaussRAISingleSigma( //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/BinaryNumericTypeMath.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/BinaryNumericTypeMath.java
@@ -67,7 +67,7 @@ public class BinaryNumericTypeMath <T extends NumericType<T>> {
 	 * @param input2
 	 * @param dbzVal
 	 * @param output
-	 * @implNote op names='math.div, math.divide', priority='100.'
+	 * @implNote op names='math.div, math.divide', priority='100.', type=Computer
 	 */
 	public static <N extends NumericType<N>> void divider(N input1, N input2,
 			@Nullable N dbzVal, N output)

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/BinaryRealTypeMath.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/math/BinaryRealTypeMath.java
@@ -82,7 +82,7 @@ public class BinaryRealTypeMath <I1 extends RealType<I1>, I2 extends RealType<I2
 	 * @param input2
 	 * @param dbzVal
 	 * @param output
-	 * @implNote op names='math.div, math.divide'
+	 * @implNote op names='math.div, math.divide', type=Computer
 	 */
 	public static <T1 extends RealType<T1>, T2 extends RealType<T2>, O extends RealType<O>> void divider(
 			T1 input1, T2 input2, @Nullable Double dbzVal, O output)

--- a/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.vm
+++ b/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.vm
@@ -71,7 +71,6 @@ public final class LiftFunctionsToRAI {
 
 	/**
 	 * @implNote op names='adapt', priority='100.'
-	 *           type='java.util.function.Function'
 	 */
 	 public static <#foreach($a in [1..$arity])I$a, #{end}O extends Type<O>, #foreach($a in [1..$rais])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>> $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rais)RAI#{end}I$a, #{end}RAIO> lift$arity$rais(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //

--- a/scijava/scijava-function/src/main/java/org/scijava/function/Inplaces.java
+++ b/scijava/scijava-function/src/main/java/org/scijava/function/Inplaces.java
@@ -33,12 +33,11 @@
 
 package org.scijava.function;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -1843,6 +1842,18 @@ public final class Inplaces {
 
 		public int mutablePosition() {
 			return mutablePosition;
+		}
+
+		@Override
+		public boolean equals(Object that) {
+			if (!(that instanceof InplaceInfo)) return false;
+			InplaceInfo other = (InplaceInfo) that;
+			return other.arity == arity && other.mutablePosition == mutablePosition;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(arity, mutablePosition);
 		}
 	}
 }

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
@@ -29,6 +29,10 @@
 
 package org.scijava.ops.engine.yaml.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -65,10 +69,27 @@ public class YAMLOpTest extends AbstractTestEnvironment {
 	}
 
 	@Test
-	public void testYAMLMethod() {
+	public void testYAMLMethodFunction() {
 		Double sum = ops.op("example.sub").arity2().input(2., 3.).outType(Double.class)
 			.apply();
 		Assertions.assertEquals(-1., sum, 1e-6);
+	}
+
+	@Test
+	public void testYAMLMethodInplaceShortType() {
+		List<Integer> l1 = Arrays.asList(1);
+		List<Integer> l2 = Arrays.asList(3);
+		ops.op("example.xor").arity2().input(l1, l2).mutate1();
+		Assertions.assertEquals(2, l1.get(0), 1e-6);
+	}
+
+	@Test
+	public void testYAMLMethodComputerShortType() {
+		List<Integer> l1 = Arrays.asList(1);
+		List<Integer> l2 = Arrays.asList(3);
+		List<Integer> out = new ArrayList<>();
+		ops.op("example.and").arity2().input(l1, l2).output(out).compute();
+		Assertions.assertEquals(1, l1.get(0), 1e-6);
 	}
 
 	@Test

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/ops/YAMLMethodOp.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/ops/YAMLMethodOp.java
@@ -30,6 +30,7 @@
 package org.scijava.ops.engine.yaml.impl.ops;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 /**
  * A static {@link Method}, exposed to Ops via YAML
@@ -48,6 +49,35 @@ public class YAMLMethodOp {
 	 */
 	public static Double subtract(Double aDouble, Double aDouble2) {
 		return aDouble - aDouble2;
+	}
+
+	/**
+	 * Another example Op, implemented by a {@link Method}
+	 *
+	 * @implNote op name=example.xor, type=Inplace1
+	 * @param aList the first integer {@link List}
+	 * @param aList2 the second integer {@link List}
+	 * @return the xor
+	 */
+	public static void xor(List<Integer> aList, List<Integer> aList2) {
+		for(int i = 0; i < aList.size(); i++) {
+			aList.set(i, aList.get(i) ^ aList2.get(i));
+		}
+	}
+
+	/**
+	 * A third example Op, implemented by a {@link Method}
+	 *
+	 * @implNote op name=example.and, type=Computer
+	 * @param aList the first integer {@link List}
+	 * @param aList2 the second integer {@link List}
+	 * @param out the logical and of the two integer {@link List}s
+	 */
+	public static void and(List<Integer> aList, List<Integer> aList2, List<Integer> out) {
+		out.clear();
+		for(int i = 0; i < aList.size(); i++) {
+			out.add(aList.get(i) & aList2.get(i));
+		}
 	}
 
 }


### PR DESCRIPTION
This PR allows you to write the below class and call the internal Ops. Note that the absence of a `type` parameter in `Function` Ops worked before - now, you can write `type=Computer` or `type=InplaceX` (and `type=Function`, if you really want) instead of typing out the whole op class name. The arity of those types will be pulled off of the method.

For example, if you annotate a 5-parameter inplace Op with `type=Inplace3`, the Op will become a `Inplaces.Arity5_3`

```java
/**
 * A static {@link Method}, exposed to Ops via YAML
 * 
 * @author Gabriel Selzer
 */
public class YAMLMethodOp {

	/**
	 * An example Op, implemented by a {@link Method}
	 *
	 * @implNote op name=example.sub
	 * @param aDouble the first double
	 * @param aDouble2 the second double
	 * @return the difference
	 */
	public static Double subtract(Double aDouble, Double aDouble2) {
		return aDouble - aDouble2;
	}

	/**
	 * Another example Op, implemented by a {@link Method}
	 *
	 * @implNote op name=example.xor, type=Inplace1
	 * @param aList the first integer {@link List}
	 * @param aList2 the second integer {@link List}
	 * @return the xor
	 */
	public static void xor(List<Integer> aList, List<Integer> aList2) {
		for(int i = 0; i < aList.size(); i++) {
			aList.set(i, aList.get(i) ^ aList2.get(i));
		}
	}

	/**
	 * A third example Op, implemented by a {@link Method}
	 *
	 * @implNote op name=example.and, type=Computer
	 * @param aList the first integer {@link List}
	 * @param aList2 the second integer {@link List}
	 * @param out the logical and of the two integer {@link List}s
	 */
	public static void and(List<Integer> aList, List<Integer> aList2, List<Integer> out) {
		out.clear();
		for(int i = 0; i < aList.size(); i++) {
			out.add(aList.get(i) & aList2.get(i));
		}
	}

}
```

Closes scijava/scijava#163