### PR TITLE
Remove null names in Op descriptions

### DIFF
--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/AbstractYAMLOpInfoCreator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/AbstractYAMLOpInfoCreator.java
@@ -147,7 +147,10 @@ public abstract class AbstractYAMLOpInfoCreator implements YAMLOpInfoCreator {
     private Member<?> wrapMember(final Member<?> member, final Map<String, Object> map) {
         String name = member.getKey();
         if (member.isInput() && !member.isOutput()) {
-            name = (String) map.get("INPUT");
+            var newName = (String) map.get("name");
+            if (newName != null) {
+                name = newName;
+            }
         }
         else {
             for (String key: outputKeys) {

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
@@ -99,4 +99,17 @@ public class YAMLOpTest extends AbstractTestEnvironment {
 		Assertions.assertEquals(6., sum, 1e-6);
 	}
 
+	@Test
+	public void testYAMLDescription() {
+		var actual = ops.help("example.mul");
+		var expected = "Ops:\n\t> example.mul(" + //
+				"\n\t\t Inputs:" +  //
+				"\n\t\t\tDouble a -> the first double" + //
+				"\n\t\t\tDouble b -> the first double" + //
+				"\n\t\t Outputs:" + //
+				"\n\t\t\tDouble output1 -> the product" + //
+				"\n\t)\n\t";
+		Assertions.assertEquals(expected, actual);
+	}
+
 }


### PR DESCRIPTION
This PR fixes a bug wherein Ops declared using YAML would look up the wrong key in YAML map when overwriting the default parameter names, and adds a small test to ensure that the parameter names are a part of the description. This test fails without the corresponding change in `AbstractYAMLOpInfoCreator.java`

Closes scijava/scijava#169