### PR TITLE
Hide internal Op namespaces

### DIFF
--- a/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/OpAdaptation.java
+++ b/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/OpAdaptation.java
@@ -43,7 +43,7 @@ import org.scijava.ops.spi.OpField;
  * <p>
  * The simplest type of transformation is termed "adaptation". Adaptation
  * involves transforming an Op into a different functional type. A set of
- * "adapt" Ops exist to perform this transformation, taking in any Op of
+ * "engine.adapt" Ops exist to perform this transformation, taking in any Op of
  * functional type X and returning an Op of functional type Y.
  * <p>
  * Adaptation can be used to call a Function like a Computer, or to call an Op

--- a/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/OpSimplification.java
+++ b/imagej/imagej-ops2-tutorial/src/main/java/net/imagej/ops2/tutorial/OpSimplification.java
@@ -46,8 +46,8 @@ import org.scijava.ops.spi.OpField;
  * involves transforming some subset of Op inputs into a different, but similar
  * type. This process makes use of two different Op types:
  * <ul>
- * <li>"simplify" Ops transform user inputs into a broader data type</li>
- * <li>"focus" Ops transform that broader type into the type used by the Op</li>
+ * <li>"engine.simplify" Ops transform user inputs into a broader data type</li>
+ * <li>"engine.focus" Ops transform that broader type into the type used by the Op</li>
  * </ul>
  * functional type X and returning an Op of functional type Y.
  * <p>
@@ -89,15 +89,15 @@ public class OpSimplification implements OpCollection {
 		1. SciJava Ops determines that there are no existing "tutorial.simplify" Ops
 		that work on Integers
 		
-		2. SciJava Ops finds a "focus" Op that can make Doubles from Numbers. Thus,
-		if the inputs are Numbers, SciJava Ops could use this "focus" Op to make
+		2. SciJava Ops finds a "engine.focus" Op that can make Doubles from Numbers. Thus,
+		if the inputs are Numbers, SciJava Ops could use this "engine.focus" Op to make
 		those Numbers into Doubles
 		
-		3. SciJava Ops finds a "simplify" Op that can make Numbers from Integers.
-		Thus, if the inputs are Integers, SciJava Ops can use this "simplify" Op
+		3. SciJava Ops finds a "engine.simplify" Op that can make Numbers from Integers.
+		Thus, if the inputs are Integers, SciJava Ops can use this "engine.simplify" Op
 		to make those Integers into Numbers
 		
-		4. By using the "simplify" and then the "focus" Op, SciJava Ops can convert
+		4. By using the "engine.simplify" and then the "engine.focus" Op, SciJava Ops can convert
 		the Integer inputs into Double inputs, and by creating a similar chain
 		in reverse, can convert the Double output into an Integer output.
 		Thus, we get an Op that can run on Integers!

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftComputersToRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftComputersToRAI.java
@@ -65,7 +65,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity1<RAII1, RAIO> lift11(Computers.Arity1<I1, O> computer) {
 		 return (raiInput1, raiOutput) -> {
@@ -75,7 +75,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity2<RAII1, I2, RAIO> lift21(Computers.Arity2<I1, I2, O> computer) {
 		 return (raiInput1, in2, raiOutput) -> {
@@ -85,7 +85,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity2<RAII1, RAII2, RAIO> lift22(Computers.Arity2<I1, I2, O> computer) {
 		 return (raiInput1, raiInput2, raiOutput) -> {
@@ -95,7 +95,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity3<RAII1, I2, I3, RAIO> lift31(Computers.Arity3<I1, I2, I3, O> computer) {
 		 return (raiInput1, in2, in3, raiOutput) -> {
@@ -105,7 +105,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity3<RAII1, RAII2, I3, RAIO> lift32(Computers.Arity3<I1, I2, I3, O> computer) {
 		 return (raiInput1, raiInput2, in3, raiOutput) -> {
@@ -115,7 +115,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity3<RAII1, RAII2, RAII3, RAIO> lift33(Computers.Arity3<I1, I2, I3, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, raiOutput) -> {
@@ -125,7 +125,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity4<RAII1, I2, I3, I4, RAIO> lift41(Computers.Arity4<I1, I2, I3, I4, O> computer) {
 		 return (raiInput1, in2, in3, in4, raiOutput) -> {
@@ -135,7 +135,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity4<RAII1, RAII2, I3, I4, RAIO> lift42(Computers.Arity4<I1, I2, I3, I4, O> computer) {
 		 return (raiInput1, raiInput2, in3, in4, raiOutput) -> {
@@ -145,7 +145,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO> lift43(Computers.Arity4<I1, I2, I3, I4, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, in4, raiOutput) -> {
@@ -155,7 +155,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO> lift44(Computers.Arity4<I1, I2, I3, I4, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, raiInput4, raiOutput) -> {
@@ -165,7 +165,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO> lift51(Computers.Arity5<I1, I2, I3, I4, I5, O> computer) {
 		 return (raiInput1, in2, in3, in4, in5, raiOutput) -> {
@@ -175,7 +175,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO> lift52(Computers.Arity5<I1, I2, I3, I4, I5, O> computer) {
 		 return (raiInput1, raiInput2, in3, in4, in5, raiOutput) -> {
@@ -185,7 +185,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO> lift53(Computers.Arity5<I1, I2, I3, I4, I5, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, in4, in5, raiOutput) -> {
@@ -195,7 +195,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO> lift54(Computers.Arity5<I1, I2, I3, I4, I5, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, raiInput4, in5, raiOutput) -> {
@@ -205,7 +205,7 @@ public final class LiftComputersToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>> Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO> lift55(Computers.Arity5<I1, I2, I3, I4, I5, O> computer) {
 		 return (raiInput1, raiInput2, raiInput3, raiInput4, raiInput5, raiOutput) -> {

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.java
@@ -68,7 +68,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Function<RAII1, RAIO> lift11(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -85,7 +85,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> BiFunction<RAII1, I2, RAIO> lift21(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -102,7 +102,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> BiFunction<RAII1, RAII2, RAIO> lift22(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -120,7 +120,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, I2, I3, RAIO> lift31(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -137,7 +137,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, RAII2, I3, RAIO> lift32(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -155,7 +155,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity3<RAII1, RAII2, RAII3, RAIO> lift33(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -174,7 +174,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, I2, I3, I4, RAIO> lift41(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -191,7 +191,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, I3, I4, RAIO> lift42(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -209,7 +209,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO> lift43(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -228,7 +228,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO> lift44(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -248,7 +248,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO> lift51(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -265,7 +265,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO> lift52(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -283,7 +283,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO> lift53(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -302,7 +302,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO> lift54(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //
@@ -322,7 +322,7 @@ public final class LiftFunctionsToRAI {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <I1, I2, I3, I4, I5, O extends Type<O>, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>> Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO> lift55(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftNeighborhoodComputersToImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftNeighborhoodComputersToImg.java
@@ -29,11 +29,6 @@
 
 package net.imagej.ops2.adapt;
 
-import java.util.function.Function;
-
-import org.scijava.function.Computers;
-import org.scijava.ops.spi.OpMethod;
-
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
 import net.imglib2.algorithm.neighborhood.Shape;
@@ -41,6 +36,7 @@ import net.imglib2.loops.LoopBuilder;
 import net.imglib2.outofbounds.OutOfBoundsFactory;
 import net.imglib2.outofbounds.OutOfBoundsMirrorFactory;
 import net.imglib2.view.Views;
+import org.scijava.function.Computers;
 
 public final class LiftNeighborhoodComputersToImg {
 
@@ -50,7 +46,7 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
 	public static <T, U>
 		Computers.Arity2<RandomAccessibleInterval<T>, Shape, RandomAccessibleInterval<U>>
@@ -69,9 +65,8 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
-	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, F extends RandomAccessibleInterval<T>>
 		Computers.Arity3<F, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt1UsingShapeAndOOBF(Computers.Arity1<Neighborhood<T>, U> op)
@@ -86,7 +81,7 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
 	public static <T, U, V>
 		Computers.Arity3<RandomAccessibleInterval<T>, V, Shape, RandomAccessibleInterval<U>>
@@ -106,9 +101,8 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
-	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, V, F extends RandomAccessibleInterval<T>>
 		Computers.Arity4<F, V, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt2UsingShapeAndOOBF(Computers.Arity2<Neighborhood<T>, V, U> op)
@@ -124,7 +118,7 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
 	public static <T, U, V, W>
 		Computers.Arity4<RandomAccessibleInterval<T>, V, W, Shape, RandomAccessibleInterval<U>>
@@ -144,9 +138,8 @@ public final class LiftNeighborhoodComputersToImg {
 
 	/**
 	 * @implNote op names='engine.adapt', priority='100.',
-	 *           type='java.util.function.Function'
+	 *           type=Function
 	 */
-	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, V, W, F extends RandomAccessibleInterval<T>>
 		Computers.Arity5<F, V, W, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt3UsingShapeAndOOBF(Computers.Arity3<Neighborhood<T>, V, W, U> op)

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftNeighborhoodComputersToImg.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/LiftNeighborhoodComputersToImg.java
@@ -49,7 +49,7 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
 	public static <T, U>
@@ -68,10 +68,10 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
-	@OpMethod(names = "adapt", type = Function.class)
+	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, F extends RandomAccessibleInterval<T>>
 		Computers.Arity3<F, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt1UsingShapeAndOOBF(Computers.Arity1<Neighborhood<T>, U> op)
@@ -85,7 +85,7 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
 	public static <T, U, V>
@@ -105,10 +105,10 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
-	@OpMethod(names = "adapt", type = Function.class)
+	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, V, F extends RandomAccessibleInterval<T>>
 		Computers.Arity4<F, V, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt2UsingShapeAndOOBF(Computers.Arity2<Neighborhood<T>, V, U> op)
@@ -123,7 +123,7 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
 	public static <T, U, V, W>
@@ -143,10 +143,10 @@ public final class LiftNeighborhoodComputersToImg {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.',
+	 * @implNote op names='engine.adapt', priority='100.',
 	 *           type='java.util.function.Function'
 	 */
-	@OpMethod(names = "adapt", type = Function.class)
+	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, U, V, W, F extends RandomAccessibleInterval<T>>
 		Computers.Arity5<F, V, W, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt3UsingShapeAndOOBF(Computers.Arity3<Neighborhood<T>, V, W, U> op)

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/RAIToIIOps.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/RAIToIIOps.java
@@ -37,14 +37,14 @@ import net.imglib2.view.Views;
 public class RAIToIIOps<T, U, V> {
 
 	/**
-	 * @implNote op names='adapt'
+	 * @implNote op names='engine.adapt'
 	 */
 	public final Function<Function<Iterable<T>, U>, Function<RandomAccessibleInterval<T>, U>> func = (in) -> {
 		return (in1) -> in.apply(Views.flatIterable(in1));
 	};
 
 	/**
-	 * @implNote op names='adapt'
+	 * @implNote op names='engine.adapt'
 	 */
 	public final Function<BiFunction<Iterable<T>, Iterable<U>, V>, BiFunction<RandomAccessibleInterval<T>, RandomAccessibleInterval<U>, V>> biFunc = (in) -> {
 		return (in1, in2) -> in.apply(Views.flatIterable(in1), Views.flatIterable(in2));

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/ComputersToFunctionsAndLift.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/ComputersToFunctionsAndLift.java
@@ -57,15 +57,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the first RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI11ComputerToFunctionAndLiftViaSource<I1, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity1<I1, O>, Function<RAII1, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity1<I1, O>, Computers.Arity1<RAII1, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity1<RAII1, RAIO>, Function<RAII1, RAIO>> adapter;
 
 		/**
@@ -87,15 +87,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The second parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI21ComputerToFunctionAndLiftViaSource<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity2<I1, I2, O>, BiFunction<RAII1, I2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<RAII1, I2, RAIO>, BiFunction<RAII1, I2, RAIO>> adapter;
 
 		/**
@@ -117,15 +117,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the second RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI22ComputerToFunctionAndLiftViaSource<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity2<I1, I2, O>, BiFunction<RAII1, RAII2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<RAII1, RAII2, RAIO>, BiFunction<RAII1, RAII2, RAIO>> adapter;
 
 		/**
@@ -149,15 +149,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI31ComputerToFunctionAndLiftViaSource<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, I2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<RAII1, I2, I3, RAIO>, Functions.Arity3<RAII1, I2, I3, RAIO>> adapter;
 
 		/**
@@ -181,15 +181,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI32ComputerToFunctionAndLiftViaSource<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<RAII1, RAII2, I3, RAIO>, Functions.Arity3<RAII1, RAII2, I3, RAIO>> adapter;
 
 		/**
@@ -213,15 +213,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the third RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI33ComputerToFunctionAndLiftViaSource<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, RAII3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<RAII1, RAII2, RAII3, RAIO>, Functions.Arity3<RAII1, RAII2, RAII3, RAIO>> adapter;
 
 		/**
@@ -247,15 +247,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI41ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, I2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<RAII1, I2, I3, I4, RAIO>, Functions.Arity4<RAII1, I2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -281,15 +281,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI42ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>, Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -315,15 +315,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI43ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>, Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> adapter;
 
 		/**
@@ -349,15 +349,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the fourth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI44ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>, Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> adapter;
 
 		/**
@@ -385,15 +385,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI51ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>, Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -421,15 +421,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI52ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -457,15 +457,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI53ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -493,15 +493,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI54ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> adapter;
 
 		/**
@@ -529,15 +529,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the fifth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI55ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> adapter;
 
 		/**
@@ -567,15 +567,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI61ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -605,15 +605,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI62ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -643,15 +643,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI63ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -681,15 +681,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI64ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -719,15 +719,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI65ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> adapter;
 
 		/**
@@ -757,15 +757,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the sixth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI66ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> adapter;
 
 		/**
@@ -797,15 +797,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI71ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -837,15 +837,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI72ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -877,15 +877,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI73ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -917,15 +917,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI74ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -957,15 +957,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI75ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -997,15 +997,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI76ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> adapter;
 
 		/**
@@ -1037,15 +1037,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the seventh RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI77ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> adapter;
 
 		/**
@@ -1079,15 +1079,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI81ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1121,15 +1121,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI82ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1163,15 +1163,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI83ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1205,15 +1205,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI84ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1247,15 +1247,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI85ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1289,15 +1289,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI86ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1331,15 +1331,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI87ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> adapter;
 
 		/**
@@ -1373,15 +1373,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the eighth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI88ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> adapter;
 
 		/**
@@ -1417,15 +1417,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI91ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1461,15 +1461,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI92ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1505,15 +1505,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI93ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1549,15 +1549,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI94ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1593,15 +1593,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI95ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1637,15 +1637,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI96ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1681,15 +1681,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI97ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1725,15 +1725,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI98ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> adapter;
 
 		/**
@@ -1769,15 +1769,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the ninth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI99ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> adapter;
 
 		/**
@@ -1815,15 +1815,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI101ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1861,15 +1861,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI102ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1907,15 +1907,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI103ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1953,15 +1953,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI104ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1999,15 +1999,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI105ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2045,15 +2045,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI106ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2091,15 +2091,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI107ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2137,15 +2137,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI108ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2183,15 +2183,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI109ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> adapter;
 
 		/**
@@ -2229,15 +2229,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the tenth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1010ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> adapter;
 
 		/**
@@ -2277,15 +2277,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI111ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2325,15 +2325,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI112ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2373,15 +2373,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI113ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2421,15 +2421,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI114ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2469,15 +2469,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI115ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2517,15 +2517,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI116ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2565,15 +2565,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI117ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2613,15 +2613,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI118ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2661,15 +2661,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI119ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2709,15 +2709,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1110ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> adapter;
 
 		/**
@@ -2757,15 +2757,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the eleventh RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1111ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> adapter;
 
 		/**
@@ -2807,15 +2807,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI121ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2857,15 +2857,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI122ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2907,15 +2907,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI123ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2957,15 +2957,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI124ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3007,15 +3007,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI125ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3057,15 +3057,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI126ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3107,15 +3107,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI127ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3157,15 +3157,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI128ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3207,15 +3207,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI129ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3257,15 +3257,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1210ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3307,15 +3307,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1211ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> adapter;
 
 		/**
@@ -3357,15 +3357,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the twelfth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1212ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> adapter;
 
 		/**
@@ -3409,15 +3409,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI131ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3461,15 +3461,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI132ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3513,15 +3513,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI133ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3565,15 +3565,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI134ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3617,15 +3617,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI135ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3669,15 +3669,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI136ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3721,15 +3721,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI137ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3773,15 +3773,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI138ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3825,15 +3825,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI139ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3877,15 +3877,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1310ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3929,15 +3929,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1311ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3981,15 +3981,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1312ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> adapter;
 
 		/**
@@ -4033,15 +4033,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the thirteenth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1313ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> adapter;
 
 		/**
@@ -4087,15 +4087,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI141ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4141,15 +4141,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI142ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4195,15 +4195,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI143ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4249,15 +4249,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI144ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4303,15 +4303,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI145ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4357,15 +4357,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI146ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4411,15 +4411,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI147ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4465,15 +4465,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI148ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4519,15 +4519,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI149ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4573,15 +4573,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1410ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4627,15 +4627,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1411ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4681,15 +4681,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1412ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4735,15 +4735,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1413ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> adapter;
 
 		/**
@@ -4789,15 +4789,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the fourteenth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1414ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> adapter;
 
 		/**
@@ -4845,15 +4845,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI151ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4901,15 +4901,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI152ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4957,15 +4957,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI153ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5013,15 +5013,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI154ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5069,15 +5069,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI155ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5125,15 +5125,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI156ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5181,15 +5181,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI157ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5237,15 +5237,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI158ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5293,15 +5293,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI159ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5349,15 +5349,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1510ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5405,15 +5405,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1511ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5461,15 +5461,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1512ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5517,15 +5517,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1513ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -5573,15 +5573,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1514ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> adapter;
 
 		/**
@@ -5629,15 +5629,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the fifteenth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1515ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> adapter;
 
 		/**
@@ -5687,15 +5687,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI161ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5745,15 +5745,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI162ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5803,15 +5803,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI163ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5861,15 +5861,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI164ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5919,15 +5919,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI165ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5977,15 +5977,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI166ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6035,15 +6035,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI167ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6093,15 +6093,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI168ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6151,15 +6151,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI169ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6209,15 +6209,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1610ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6267,15 +6267,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1611ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6325,15 +6325,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1612ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6383,15 +6383,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1613ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6441,15 +6441,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1614ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -6499,15 +6499,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1615ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> adapter;
 
 		/**
@@ -6557,15 +6557,15 @@ public final class ComputersToFunctionsAndLift {
 	 *            Type of the sixteenth RAI
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1616ComputerToFunctionAndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAII16 extends RandomAccessibleInterval<I16>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> adapter;
 
 		/**

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/FunctionsToComputersAndLift.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/FunctionsToComputersAndLift.java
@@ -57,15 +57,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the first RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI11FunctionToComputerAndLiftAfter<I1, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Function<I1, O>, Computers.Arity1<RAII1, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<I1, O>, Computers.Arity1<I1, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity1<I1, O>, Computers.Arity1<RAII1, RAIO>> lifter;
 
 		/**
@@ -86,15 +86,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the first RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI11FunctionToComputerAndLiftBefore<I1, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Function<I1, O>, Computers.Arity1<RAII1, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<I1, O>, Function<RAII1, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<RAII1, RAIO>, Computers.Arity1<RAII1, RAIO>> adapter;
 
 		/**
@@ -117,15 +117,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The second parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI21FunctionToComputerAndLiftAfter<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>> lifter;
 
 		/**
@@ -148,15 +148,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The second parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI21FunctionToComputerAndLiftBefore<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, BiFunction<RAII1, I2, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<RAII1, I2, RAIO>, Computers.Arity2<RAII1, I2, RAIO>> adapter;
 
 		/**
@@ -179,15 +179,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the second RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI22FunctionToComputerAndLiftAfter<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>> lifter;
 
 		/**
@@ -210,15 +210,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the second RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI22FunctionToComputerAndLiftBefore<I1, I2, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, BiFunction<RAII1, RAII2, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<RAII1, RAII2, RAIO>, Computers.Arity2<RAII1, RAII2, RAIO>> adapter;
 
 		/**
@@ -243,15 +243,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI31FunctionToComputerAndLiftAfter<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>> lifter;
 
 		/**
@@ -276,15 +276,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI31FunctionToComputerAndLiftBefore<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, I2, I3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<RAII1, I2, I3, RAIO>, Computers.Arity3<RAII1, I2, I3, RAIO>> adapter;
 
 		/**
@@ -309,15 +309,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI32FunctionToComputerAndLiftAfter<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
 
 		/**
@@ -342,15 +342,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The third parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI32FunctionToComputerAndLiftBefore<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<RAII1, RAII2, I3, RAIO>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> adapter;
 
 		/**
@@ -375,15 +375,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the third RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI33FunctionToComputerAndLiftAfter<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
 
 		/**
@@ -408,15 +408,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the third RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI33FunctionToComputerAndLiftBefore<I1, I2, I3, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<RAII1, RAII2, RAII3, RAIO>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> adapter;
 
 		/**
@@ -443,15 +443,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI41FunctionToComputerAndLiftAfter<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
 
 		/**
@@ -478,15 +478,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI41FunctionToComputerAndLiftBefore<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<RAII1, I2, I3, I4, RAIO>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -513,15 +513,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI42FunctionToComputerAndLiftAfter<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
 
 		/**
@@ -548,15 +548,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI42FunctionToComputerAndLiftBefore<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -583,15 +583,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI43FunctionToComputerAndLiftAfter<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
 
 		/**
@@ -618,15 +618,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI43FunctionToComputerAndLiftBefore<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> adapter;
 
 		/**
@@ -653,15 +653,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fourth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI44FunctionToComputerAndLiftAfter<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
 
 		/**
@@ -688,15 +688,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fourth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI44FunctionToComputerAndLiftBefore<I1, I2, I3, I4, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> adapter;
 
 		/**
@@ -725,15 +725,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI51FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -762,15 +762,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI51FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -799,15 +799,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI52FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -836,15 +836,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI52FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -873,15 +873,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI53FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -910,15 +910,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI53FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -947,15 +947,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI54FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
 
 		/**
@@ -984,15 +984,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI54FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> adapter;
 
 		/**
@@ -1021,15 +1021,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fifth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI55FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
 
 		/**
@@ -1058,15 +1058,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fifth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI55FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> adapter;
 
 		/**
@@ -1097,15 +1097,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI61FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1136,15 +1136,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI61FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1175,15 +1175,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI62FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1214,15 +1214,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI62FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1253,15 +1253,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI63FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1292,15 +1292,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI63FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1331,15 +1331,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI64FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1370,15 +1370,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI64FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1409,15 +1409,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI65FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
 
 		/**
@@ -1448,15 +1448,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI65FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> adapter;
 
 		/**
@@ -1487,15 +1487,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the sixth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI66FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
 
 		/**
@@ -1526,15 +1526,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the sixth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI66FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> adapter;
 
 		/**
@@ -1567,15 +1567,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI71FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1608,15 +1608,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI71FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1649,15 +1649,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI72FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1690,15 +1690,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI72FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1731,15 +1731,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI73FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1772,15 +1772,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI73FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1813,15 +1813,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI74FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1854,15 +1854,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI74FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1895,15 +1895,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI75FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1936,15 +1936,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI75FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1977,15 +1977,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI76FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
 
 		/**
@@ -2018,15 +2018,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The seventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI76FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> adapter;
 
 		/**
@@ -2059,15 +2059,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the seventh RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI77FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
 
 		/**
@@ -2100,15 +2100,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the seventh RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI77FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> adapter;
 
 		/**
@@ -2143,15 +2143,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI81FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2186,15 +2186,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI81FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2229,15 +2229,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI82FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2272,15 +2272,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI82FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2315,15 +2315,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI83FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2358,15 +2358,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI83FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2401,15 +2401,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI84FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2444,15 +2444,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI84FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2487,15 +2487,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI85FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2530,15 +2530,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI85FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2573,15 +2573,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI86FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2616,15 +2616,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI86FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2659,15 +2659,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI87FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
 
 		/**
@@ -2702,15 +2702,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eighth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI87FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> adapter;
 
 		/**
@@ -2745,15 +2745,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the eighth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI88FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
 
 		/**
@@ -2788,15 +2788,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the eighth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI88FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> adapter;
 
 		/**
@@ -2833,15 +2833,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI91FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2878,15 +2878,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI91FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -2923,15 +2923,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI92FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2968,15 +2968,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI92FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3013,15 +3013,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI93FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3058,15 +3058,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI93FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3103,15 +3103,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI94FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3148,15 +3148,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI94FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3193,15 +3193,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI95FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3238,15 +3238,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI95FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3283,15 +3283,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI96FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3328,15 +3328,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI96FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3373,15 +3373,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI97FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3418,15 +3418,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI97FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3463,15 +3463,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI98FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
 
 		/**
@@ -3508,15 +3508,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The ninth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI98FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> adapter;
 
 		/**
@@ -3553,15 +3553,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the ninth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI99FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
 
 		/**
@@ -3598,15 +3598,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the ninth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI99FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> adapter;
 
 		/**
@@ -3645,15 +3645,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI101FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3692,15 +3692,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI101FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3739,15 +3739,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI102FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3786,15 +3786,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI102FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3833,15 +3833,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI103FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3880,15 +3880,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI103FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3927,15 +3927,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI104FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3974,15 +3974,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI104FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4021,15 +4021,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI105FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -4068,15 +4068,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI105FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4115,15 +4115,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI106FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -4162,15 +4162,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI106FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4209,15 +4209,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI107FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -4256,15 +4256,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI107FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4303,15 +4303,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI108FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -4350,15 +4350,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI108FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4397,15 +4397,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI109FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
 
 		/**
@@ -4444,15 +4444,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The tenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI109FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> adapter;
 
 		/**
@@ -4491,15 +4491,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the tenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1010FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
 
 		/**
@@ -4538,15 +4538,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the tenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1010FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> adapter;
 
 		/**
@@ -4587,15 +4587,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI111FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4636,15 +4636,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI111FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4685,15 +4685,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI112FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4734,15 +4734,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI112FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4783,15 +4783,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI113FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4832,15 +4832,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI113FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4881,15 +4881,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI114FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4930,15 +4930,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI114FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4979,15 +4979,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI115FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -5028,15 +5028,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI115FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -5077,15 +5077,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI116FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -5126,15 +5126,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI116FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -5175,15 +5175,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI117FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -5224,15 +5224,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI117FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -5273,15 +5273,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI118FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -5322,15 +5322,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI118FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -5371,15 +5371,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI119FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -5420,15 +5420,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI119FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -5469,15 +5469,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1110FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
 
 		/**
@@ -5518,15 +5518,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The eleventh parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1110FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> adapter;
 
 		/**
@@ -5567,15 +5567,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the eleventh RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1111FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
 
 		/**
@@ -5616,15 +5616,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the eleventh RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1111FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> adapter;
 
 		/**
@@ -5667,15 +5667,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI121FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5718,15 +5718,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI121FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5769,15 +5769,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI122FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5820,15 +5820,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI122FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5871,15 +5871,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI123FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5922,15 +5922,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI123FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5973,15 +5973,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI124FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6024,15 +6024,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI124FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6075,15 +6075,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI125FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6126,15 +6126,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI125FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6177,15 +6177,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI126FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6228,15 +6228,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI126FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6279,15 +6279,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI127FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6330,15 +6330,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI127FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6381,15 +6381,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI128FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6432,15 +6432,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI128FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6483,15 +6483,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI129FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6534,15 +6534,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI129FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6585,15 +6585,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1210FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -6636,15 +6636,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1210FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6687,15 +6687,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1211FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
 
 		/**
@@ -6738,15 +6738,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The twelfth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1211FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> adapter;
 
 		/**
@@ -6789,15 +6789,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the twelfth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1212FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
 
 		/**
@@ -6840,15 +6840,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the twelfth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1212FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> adapter;
 
 		/**
@@ -6893,15 +6893,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI131FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6946,15 +6946,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI131FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6999,15 +6999,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI132FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7052,15 +7052,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI132FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7105,15 +7105,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI133FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7158,15 +7158,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI133FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7211,15 +7211,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI134FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7264,15 +7264,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI134FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7317,15 +7317,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI135FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7370,15 +7370,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI135FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7423,15 +7423,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI136FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7476,15 +7476,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI136FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7529,15 +7529,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI137FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7582,15 +7582,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI137FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7635,15 +7635,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI138FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7688,15 +7688,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI138FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7741,15 +7741,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI139FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7794,15 +7794,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI139FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7847,15 +7847,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1310FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7900,15 +7900,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1310FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7953,15 +7953,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1311FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -8006,15 +8006,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1311FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -8059,15 +8059,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1312FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
 
 		/**
@@ -8112,15 +8112,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The thirteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1312FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> adapter;
 
 		/**
@@ -8165,15 +8165,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the thirteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1313FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
 
 		/**
@@ -8218,15 +8218,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the thirteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1313FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> adapter;
 
 		/**
@@ -8273,15 +8273,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI141FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8328,15 +8328,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI141FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8383,15 +8383,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI142FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8438,15 +8438,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI142FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8493,15 +8493,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI143FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8548,15 +8548,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI143FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8603,15 +8603,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI144FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8658,15 +8658,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI144FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8713,15 +8713,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI145FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8768,15 +8768,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI145FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8823,15 +8823,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI146FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8878,15 +8878,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI146FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8933,15 +8933,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI147FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8988,15 +8988,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI147FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9043,15 +9043,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI148FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -9098,15 +9098,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI148FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9153,15 +9153,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI149FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -9208,15 +9208,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI149FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9263,15 +9263,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1410FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -9318,15 +9318,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1410FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9373,15 +9373,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1411FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -9428,15 +9428,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1411FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9483,15 +9483,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1412FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -9538,15 +9538,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1412FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -9593,15 +9593,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1413FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
 
 		/**
@@ -9648,15 +9648,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fourteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1413FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> adapter;
 
 		/**
@@ -9703,15 +9703,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fourteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1414FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
 
 		/**
@@ -9758,15 +9758,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fourteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1414FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> adapter;
 
 		/**
@@ -9815,15 +9815,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI151FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9872,15 +9872,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI151FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9929,15 +9929,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI152FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9986,15 +9986,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI152FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10043,15 +10043,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI153FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10100,15 +10100,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI153FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10157,15 +10157,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI154FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10214,15 +10214,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI154FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10271,15 +10271,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI155FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10328,15 +10328,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI155FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10385,15 +10385,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI156FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10442,15 +10442,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI156FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10499,15 +10499,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI157FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10556,15 +10556,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI157FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10613,15 +10613,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI158FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10670,15 +10670,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI158FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10727,15 +10727,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI159FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10784,15 +10784,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI159FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10841,15 +10841,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1510FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -10898,15 +10898,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1510FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -10955,15 +10955,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1511FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -11012,15 +11012,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1511FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -11069,15 +11069,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1512FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -11126,15 +11126,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1512FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -11183,15 +11183,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1513FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -11240,15 +11240,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1513FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -11297,15 +11297,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1514FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
 
 		/**
@@ -11354,15 +11354,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The fifteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1514FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> adapter;
 
 		/**
@@ -11411,15 +11411,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fifteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1515FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
 
 		/**
@@ -11468,15 +11468,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the fifteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1515FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> adapter;
 
 		/**
@@ -11527,15 +11527,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI161FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11586,15 +11586,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI161FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11645,15 +11645,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI162FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11704,15 +11704,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI162FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11763,15 +11763,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI163FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11822,15 +11822,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI163FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11881,15 +11881,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI164FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11940,15 +11940,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI164FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11999,15 +11999,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI165FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12058,15 +12058,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI165FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12117,15 +12117,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI166FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12176,15 +12176,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI166FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12235,15 +12235,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI167FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12294,15 +12294,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI167FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12353,15 +12353,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI168FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12412,15 +12412,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI168FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12471,15 +12471,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI169FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12530,15 +12530,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI169FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12589,15 +12589,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1610FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12648,15 +12648,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1610FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12707,15 +12707,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1611FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12766,15 +12766,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1611FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12825,15 +12825,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1612FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -12884,15 +12884,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1612FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -12943,15 +12943,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1613FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -13002,15 +13002,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1613FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -13061,15 +13061,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1614FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -13120,15 +13120,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1614FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -13179,15 +13179,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1615FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
 
 		/**
@@ -13238,15 +13238,15 @@ public final class FunctionsToComputersAndLift {
 	 *            The sixteenth parameter type
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1615FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> adapter;
 
 		/**
@@ -13297,15 +13297,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the sixteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI1616FunctionToComputerAndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAII16 extends RandomAccessibleInterval<I16>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
 
 		/**
@@ -13356,15 +13356,15 @@ public final class FunctionsToComputersAndLift {
 	 *            Type of the sixteenth RAI
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI1616FunctionToComputerAndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O, RAII1 extends RandomAccessibleInterval<I1>, RAII2 extends RandomAccessibleInterval<I2>, RAII3 extends RandomAccessibleInterval<I3>, RAII4 extends RandomAccessibleInterval<I4>, RAII5 extends RandomAccessibleInterval<I5>, RAII6 extends RandomAccessibleInterval<I6>, RAII7 extends RandomAccessibleInterval<I7>, RAII8 extends RandomAccessibleInterval<I8>, RAII9 extends RandomAccessibleInterval<I9>, RAII10 extends RandomAccessibleInterval<I10>, RAII11 extends RandomAccessibleInterval<I11>, RAII12 extends RandomAccessibleInterval<I12>, RAII13 extends RandomAccessibleInterval<I13>, RAII14 extends RandomAccessibleInterval<I14>, RAII15 extends RandomAccessibleInterval<I15>, RAII16 extends RandomAccessibleInterval<I16>, RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> adapter;
 
 		/**

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/LiftNeighborhoodComputersToFunctionsOnImgs.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/adapt/complexLift/LiftNeighborhoodComputersToFunctionsOnImgs.java
@@ -57,7 +57,7 @@ public final class LiftNeighborhoodComputersToFunctionsOnImgs {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.', type='java.util.function.Function'
+	 * @implNote op names='engine.adapt', priority='100.', type='java.util.function.Function'
 	 */
 	public static <T, U> BiFunction<RandomAccessibleInterval<T>, Shape, Img<T>>
 	adaptUsingShape(
@@ -78,9 +78,9 @@ public final class LiftNeighborhoodComputersToFunctionsOnImgs {
 	}
 
 	/**
-	 * @implNote op names='adapt', priority='100.', type='java.util.function.Function'
+	 * @implNote op names='engine.adapt', priority='100.', type='java.util.function.Function'
 	 */
-	@OpMethod(names = "adapt", type = Function.class)
+	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, F extends RandomAccessibleInterval<T>>
 	Functions.Arity3<F, Shape, OutOfBoundsFactory<T, ? super F>, Img<T>>
 	adaptUsingShapeAndOOBF(

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/MergeLabeling.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/labeling/MergeLabeling.java
@@ -62,7 +62,7 @@ public class MergeLabeling<L, I extends IntegerType<I>, B extends BooleanType<B>
 	@OpDependency(name = "create.imgLabeling")
 	private BiFunction<Dimensions, I, ImgLabeling<L, I>> imgLabelingCreator;
 	
-	@OpDependency(name = "adapt")
+	@OpDependency(name = "engine.adapt")
 	private Function<Computers.Arity2<LabelingType<L>, LabelingType<L>, LabelingType<L>>, Computers.Arity2<Iterable<LabelingType<L>>, Iterable<LabelingType<L>>, Iterable<LabelingType<L>>>> adaptor;
 
 	@SuppressWarnings({ "unchecked", "rawtypes", "hiding" })

--- a/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyConstantThreshold.java
+++ b/imagej/imagej-ops2/src/main/java/net/imagej/ops2/threshold/apply/ApplyConstantThreshold.java
@@ -52,7 +52,7 @@ public class ApplyConstantThreshold<T extends RealType<T>>
 	@OpDependency(name = "threshold.apply")
 	Computers.Arity3<T, T, Comparator<? super T>, BitType> applyThreshold;
 
-	@OpDependency(name = "adapt")
+	@OpDependency(name = "engine.adapt")
 	Function<Computers.Arity1<T, BitType>, Computers.Arity1<Iterable<T>, Iterable<BitType>>> lifter;
 
 	// TODO can/should the Comparator be of <? super T> instead of just <T>?

--- a/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftComputersToRAI.vm
+++ b/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftComputersToRAI.vm
@@ -67,7 +67,7 @@ public final class LiftComputersToRAI {
 #foreach($rais in [1..$arity])
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <#foreach($a in [1..$arity])I$a, #{end}O, #foreach($a in [1..$rais])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>> Computers.Arity$arity<#foreach($a in [1..$arity])#if($a <= $rais)RAI#{end}I$a, #{end}RAIO> lift$arity$rais(Computers.Arity$arity<#foreach($a in [1..$arity])I$a, #{end}O> computer) {
 		 return (#foreach($a in [1..$arity])#if($a <= $rais)raiInput#{else}in#{end}$a, #{end}raiOutput) -> {

--- a/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.vm
+++ b/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/LiftFunctionsToRAI.vm
@@ -70,7 +70,7 @@ public final class LiftFunctionsToRAI {
 #foreach($rais in [1..$arity])
 
 	/**
-	 * @implNote op names='adapt', priority='100.'
+	 * @implNote op names='engine.adapt', priority='100.'
 	 */
 	 public static <#foreach($a in [1..$arity])I$a, #{end}O extends Type<O>, #foreach($a in [1..$rais])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>> $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rais)RAI#{end}I$a, #{end}RAIO> lift$arity$rais(
 			@OpDependency(name = "create") BiFunction<Dimensions, O, RAIO> imgCreator, //

--- a/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/complexLift/ComputersToFunctionsAndLift.vm
+++ b/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/complexLift/ComputersToFunctionsAndLift.vm
@@ -65,15 +65,15 @@ public final class ComputersToFunctionsAndLift {
 #end
 	 * @param <O>
 	 *            Type of the output RAI
-	 * @implNote op names='adapt', priority='-100.'
+	 * @implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI$arity${rai}ComputerToFunctionAndLiftViaSource<#foreach($a in [1..$arity])I$a, #{end}O, #foreach($a in [1..$rai])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<Computers.Arity$arity<#foreach($a in [1..$arity])I$a, #{end}O>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> adapter;
 
 		/**

--- a/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/complexLift/FunctionsToComputersAndLift.vm
+++ b/imagej/imagej-ops2/templates/main/java/net/imagej/ops2/adapt/complexLift/FunctionsToComputersAndLift.vm
@@ -65,15 +65,15 @@ public final class FunctionsToComputersAndLift {
 #end
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-100.'
+	 *@implNote op names='engine.adapt', priority='-100.'
 	 */
 	 public static class RAI$arity${rai}FunctionToComputerAndLiftAfter<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O, #foreach($a in [1..$rai])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O>, Computers.Arity$arity<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>> adapter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
 
 		/**
@@ -100,15 +100,15 @@ public final class FunctionsToComputersAndLift {
 #end
 	 * @param <O>
 	 *            The RAI return type
-	 *@implNote op names='adapt', priority='-99.'
+	 *@implNote op names='engine.adapt', priority='-99.'
 	 */
 	 public static class RAI$arity${rai}FunctionToComputerAndLiftBefore<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O, #foreach($a in [1..$rai])RAII$a extends RandomAccessibleInterval<I$a>, #{end}RAIO extends RandomAccessibleInterval<O>>
 		 implements Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O>, Computers.Arity$arity<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a, #{end}O>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> adapter;
 
 		/**

--- a/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
+++ b/scijava/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
@@ -757,7 +757,7 @@ public interface OpEnvironment extends Prioritized<OpEnvironment> {
 	 * <p>
 	 *
 	 * <pre>{@code
-	 * op("adapt")
+	 * op("engine.adapt")
 	 *  input(computer)
 	 *   .outType(new Nil<Computers.Arity1<Iterable<Double>, Iterable<Double>>>() {})
 	 *   .apply()

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.java
@@ -52,13 +52,13 @@ import org.scijava.priority.Priority;
  */
 public class ComputersToFunctionsAndLift {
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer1ToFunction1AndLiftViaSource<I, O>
 			implements Function<Computers.Arity1<I, O>, Function<Iterable<I>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity1<I, O>, Function<I, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<I, O>, Function<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -72,13 +72,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer2ToFunction2AndLiftViaSource<I1, I2, O>
 			implements Function<Computers.Arity2<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -92,13 +92,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer3ToFunction3AndLiftViaSource<I1, I2, I3, O>
 			implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<I1, I2, I3, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -112,13 +112,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer4ToFunction4AndLiftViaSource<I1, I2, I3, I4, O>
 			implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<I1, I2, I3, I4, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -132,13 +132,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer5ToFunction5AndLiftViaSource<I1, I2, I3, I4, I5, O>
 			implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<I1, I2, I3, I4, I5, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -152,13 +152,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer6ToFunction6AndLiftViaSource<I1, I2, I3, I4, I5, I6, O>
 			implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<I1, I2, I3, I4, I5, I6, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -172,13 +172,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer7ToFunction7AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, O>
 			implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -192,13 +192,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer8ToFunction8AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O>
 			implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -212,13 +212,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer9ToFunction9AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>
 			implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -232,13 +232,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer10ToFunction10AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>
 			implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -252,13 +252,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer11ToFunction11AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>
 			implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -272,13 +272,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer12ToFunction12AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>
 			implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -292,13 +292,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer13ToFunction13AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>
 			implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -312,13 +312,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer14ToFunction14AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>
 			implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -332,13 +332,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer15ToFunction15AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>
 			implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -352,13 +352,13 @@ public class ComputersToFunctionsAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer16ToFunction16AndLiftViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>
 			implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.java
@@ -53,15 +53,15 @@ import org.scijava.priority.Priority;
  */
 public class FunctionsToComputersAndLift {
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function1ToComputer1AndLiftAfter<I, O> implements
 		Function<Function<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<I, O>, Computers.Arity1<I, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity1<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -77,15 +77,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function1ToComputer1AndLiftBefore<I, O> implements
 		Function<Function<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<Iterable<I>, Iterable<O>>, Computers.Arity1<Iterable<I>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Function<I, O>, Function<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -101,15 +101,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function2ToComputer2AndLiftAfter<I1, I2, O> implements
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -125,15 +125,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function2ToComputer2AndLiftBefore<I1, I2, O> implements
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<BiFunction<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -149,15 +149,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function3ToComputer3AndLiftAfter<I1, I2, I3, O> implements
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -173,15 +173,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function3ToComputer3AndLiftBefore<I1, I2, I3, O> implements
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -197,15 +197,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function4ToComputer4AndLiftAfter<I1, I2, I3, I4, O> implements
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -221,15 +221,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function4ToComputer4AndLiftBefore<I1, I2, I3, I4, O> implements
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -245,15 +245,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function5ToComputer5AndLiftAfter<I1, I2, I3, I4, I5, O> implements
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -269,15 +269,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function5ToComputer5AndLiftBefore<I1, I2, I3, I4, I5, O> implements
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -293,15 +293,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function6ToComputer6AndLiftAfter<I1, I2, I3, I4, I5, I6, O> implements
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -317,15 +317,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function6ToComputer6AndLiftBefore<I1, I2, I3, I4, I5, I6, O> implements
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -341,15 +341,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function7ToComputer7AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, O> implements
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -365,15 +365,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function7ToComputer7AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, O> implements
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -389,15 +389,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function8ToComputer8AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, O> implements
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -413,15 +413,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function8ToComputer8AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, O> implements
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -437,15 +437,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function9ToComputer9AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> implements
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -461,15 +461,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function9ToComputer9AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> implements
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -485,15 +485,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function10ToComputer10AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> implements
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -509,15 +509,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function10ToComputer10AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> implements
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -533,15 +533,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function11ToComputer11AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> implements
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -557,15 +557,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function11ToComputer11AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> implements
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -581,15 +581,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function12ToComputer12AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> implements
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -605,15 +605,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function12ToComputer12AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> implements
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -629,15 +629,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function13ToComputer13AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> implements
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -653,15 +653,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function13ToComputer13AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> implements
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -677,15 +677,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function14ToComputer14AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> implements
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -701,15 +701,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function14ToComputer14AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> implements
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -725,15 +725,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function15ToComputer15AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> implements
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -749,15 +749,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function15ToComputer15AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> implements
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -773,15 +773,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function16ToComputer16AndLiftAfter<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> implements
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**
@@ -797,15 +797,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function16ToComputer16AndLiftBefore<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> implements
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.java
@@ -52,7 +52,7 @@ import org.scijava.ops.spi.OpClass;
  */
 public class ComputersToFunctionsViaFunction {
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer1ToFunction1ViaFunction<I, O>
 			implements Function<Computers.Arity1<I, O>, Function<I, O>>,
 			Op
@@ -76,7 +76,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer2ToFunction2ViaFunction<I1, I2, O>
 			implements Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>>,
 			Op
@@ -100,7 +100,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer3ToFunction3ViaFunction<I1, I2, I3, O>
 			implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<I1, I2, I3, O>>,
 			Op
@@ -124,7 +124,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer4ToFunction4ViaFunction<I1, I2, I3, I4, O>
 			implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<I1, I2, I3, I4, O>>,
 			Op
@@ -148,7 +148,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer5ToFunction5ViaFunction<I1, I2, I3, I4, I5, O>
 			implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<I1, I2, I3, I4, I5, O>>,
 			Op
@@ -172,7 +172,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer6ToFunction6ViaFunction<I1, I2, I3, I4, I5, I6, O>
 			implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<I1, I2, I3, I4, I5, I6, O>>,
 			Op
@@ -196,7 +196,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer7ToFunction7ViaFunction<I1, I2, I3, I4, I5, I6, I7, O>
 			implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>>,
 			Op
@@ -220,7 +220,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer8ToFunction8ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, O>
 			implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>>,
 			Op
@@ -244,7 +244,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer9ToFunction9ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>
 			implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>>,
 			Op
@@ -268,7 +268,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer10ToFunction10ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>
 			implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>>,
 			Op
@@ -292,7 +292,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer11ToFunction11ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>
 			implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>>,
 			Op
@@ -316,7 +316,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer12ToFunction12ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>
 			implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>>,
 			Op
@@ -340,7 +340,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer13ToFunction13ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>
 			implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>>,
 			Op
@@ -364,7 +364,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer14ToFunction14ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>
 			implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>>,
 			Op
@@ -388,7 +388,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer15ToFunction15ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>
 			implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>>,
 			Op
@@ -412,7 +412,7 @@ public class ComputersToFunctionsViaFunction {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer16ToFunction16ViaFunction<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>
 			implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>>,
 			Op

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.java
@@ -54,7 +54,7 @@ import org.scijava.priority.Priority;
  */
 public class ComputersToFunctionsViaSource {
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer0ToFunction0ViaSource<O>
 			implements Function<Computers.Arity0<O>, Producer<O>>, 
 			Op
@@ -78,7 +78,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer1ToFunction1ViaSource<I, O>
 			implements Function<Computers.Arity1<I, O>, Function<I, O>>, 
 			Op
@@ -102,7 +102,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer2ToFunction2ViaSource<I1, I2, O>
 			implements Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>>, 
 			Op
@@ -126,7 +126,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer3ToFunction3ViaSource<I1, I2, I3, O>
 			implements Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<I1, I2, I3, O>>, 
 			Op
@@ -150,7 +150,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer4ToFunction4ViaSource<I1, I2, I3, I4, O>
 			implements Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<I1, I2, I3, I4, O>>, 
 			Op
@@ -174,7 +174,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer5ToFunction5ViaSource<I1, I2, I3, I4, I5, O>
 			implements Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<I1, I2, I3, I4, I5, O>>, 
 			Op
@@ -198,7 +198,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer6ToFunction6ViaSource<I1, I2, I3, I4, I5, I6, O>
 			implements Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<I1, I2, I3, I4, I5, I6, O>>, 
 			Op
@@ -222,7 +222,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer7ToFunction7ViaSource<I1, I2, I3, I4, I5, I6, I7, O>
 			implements Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>>, 
 			Op
@@ -246,7 +246,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer8ToFunction8ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, O>
 			implements Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>>, 
 			Op
@@ -270,7 +270,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer9ToFunction9ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>
 			implements Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>>, 
 			Op
@@ -294,7 +294,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer10ToFunction10ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>
 			implements Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>>, 
 			Op
@@ -318,7 +318,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer11ToFunction11ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>
 			implements Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>>, 
 			Op
@@ -342,7 +342,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer12ToFunction12ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>
 			implements Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>>, 
 			Op
@@ -366,7 +366,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer13ToFunction13ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>
 			implements Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>>, 
 			Op
@@ -390,7 +390,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer14ToFunction14ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>
 			implements Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>>, 
 			Op
@@ -414,7 +414,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer15ToFunction15ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>
 			implements Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>>, 
 			Op
@@ -438,7 +438,7 @@ public class ComputersToFunctionsViaSource {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer16ToFunction16ViaSource<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>
 			implements Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>>, 
 			Op

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.java
@@ -53,7 +53,7 @@ import org.scijava.ops.spi.OpClass;
  */
 public class FunctionsToComputers {
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function0ToComputer0<O> implements Function<Producer<O>, Computers.Arity0<O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -73,7 +73,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function1ToComputer1<I, O> implements Function<Function<I, O>, Computers.Arity1<I, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -93,7 +93,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function2ToComputer2<I1, I2, O> implements Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -113,7 +113,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function3ToComputer3<I1, I2, I3, O> implements Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -133,7 +133,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function4ToComputer4<I1, I2, I3, I4, O> implements Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -153,7 +153,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function5ToComputer5<I1, I2, I3, I4, I5, O> implements Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -173,7 +173,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function6ToComputer6<I1, I2, I3, I4, I5, I6, O> implements Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -193,7 +193,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function7ToComputer7<I1, I2, I3, I4, I5, I6, I7, O> implements Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -213,7 +213,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function8ToComputer8<I1, I2, I3, I4, I5, I6, I7, I8, O> implements Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -233,7 +233,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function9ToComputer9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O> implements Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -253,7 +253,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function10ToComputer10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O> implements Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -273,7 +273,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function11ToComputer11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O> implements Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -293,7 +293,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function12ToComputer12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O> implements Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -313,7 +313,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function13ToComputer13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O> implements Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -333,7 +333,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function14ToComputer14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O> implements Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -353,7 +353,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function15ToComputer15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O> implements Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)
@@ -373,7 +373,7 @@ public class FunctionsToComputers {
 
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function16ToComputer16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> implements Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.java
@@ -53,7 +53,7 @@ import org.scijava.ops.spi.OpDependency;
  */
 public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO> implements OpCollection {
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace1ToFunction1<IO> implements Function<Inplaces.Arity1<IO>, Function<IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -76,7 +76,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace2_1ToFunction2<IO, I2> implements Function<Inplaces.Arity2_1<IO, I2>, BiFunction<IO, I2, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -99,7 +99,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace2_2ToFunction2<I1, IO> implements Function<Inplaces.Arity2_2<I1, IO>, BiFunction<I1, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -122,7 +122,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace3_1ToFunction3<IO, I2, I3> implements Function<Inplaces.Arity3_1<IO, I2, I3>, Functions.Arity3<IO, I2, I3, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -145,7 +145,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace3_2ToFunction3<I1, IO, I3> implements Function<Inplaces.Arity3_2<I1, IO, I3>, Functions.Arity3<I1, IO, I3, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -168,7 +168,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace3_3ToFunction3<I1, I2, IO> implements Function<Inplaces.Arity3_3<I1, I2, IO>, Functions.Arity3<I1, I2, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -191,7 +191,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace4_1ToFunction4<IO, I2, I3, I4> implements Function<Inplaces.Arity4_1<IO, I2, I3, I4>, Functions.Arity4<IO, I2, I3, I4, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -214,7 +214,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace4_2ToFunction4<I1, IO, I3, I4> implements Function<Inplaces.Arity4_2<I1, IO, I3, I4>, Functions.Arity4<I1, IO, I3, I4, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -237,7 +237,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace4_3ToFunction4<I1, I2, IO, I4> implements Function<Inplaces.Arity4_3<I1, I2, IO, I4>, Functions.Arity4<I1, I2, IO, I4, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -260,7 +260,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace4_4ToFunction4<I1, I2, I3, IO> implements Function<Inplaces.Arity4_4<I1, I2, I3, IO>, Functions.Arity4<I1, I2, I3, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -283,7 +283,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace5_1ToFunction5<IO, I2, I3, I4, I5> implements Function<Inplaces.Arity5_1<IO, I2, I3, I4, I5>, Functions.Arity5<IO, I2, I3, I4, I5, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -306,7 +306,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace5_2ToFunction5<I1, IO, I3, I4, I5> implements Function<Inplaces.Arity5_2<I1, IO, I3, I4, I5>, Functions.Arity5<I1, IO, I3, I4, I5, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -329,7 +329,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace5_3ToFunction5<I1, I2, IO, I4, I5> implements Function<Inplaces.Arity5_3<I1, I2, IO, I4, I5>, Functions.Arity5<I1, I2, IO, I4, I5, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -352,7 +352,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace5_4ToFunction5<I1, I2, I3, IO, I5> implements Function<Inplaces.Arity5_4<I1, I2, I3, IO, I5>, Functions.Arity5<I1, I2, I3, IO, I5, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -375,7 +375,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace5_5ToFunction5<I1, I2, I3, I4, IO> implements Function<Inplaces.Arity5_5<I1, I2, I3, I4, IO>, Functions.Arity5<I1, I2, I3, I4, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -398,7 +398,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_1ToFunction6<IO, I2, I3, I4, I5, I6> implements Function<Inplaces.Arity6_1<IO, I2, I3, I4, I5, I6>, Functions.Arity6<IO, I2, I3, I4, I5, I6, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -421,7 +421,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_2ToFunction6<I1, IO, I3, I4, I5, I6> implements Function<Inplaces.Arity6_2<I1, IO, I3, I4, I5, I6>, Functions.Arity6<I1, IO, I3, I4, I5, I6, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -444,7 +444,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_3ToFunction6<I1, I2, IO, I4, I5, I6> implements Function<Inplaces.Arity6_3<I1, I2, IO, I4, I5, I6>, Functions.Arity6<I1, I2, IO, I4, I5, I6, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -467,7 +467,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_4ToFunction6<I1, I2, I3, IO, I5, I6> implements Function<Inplaces.Arity6_4<I1, I2, I3, IO, I5, I6>, Functions.Arity6<I1, I2, I3, IO, I5, I6, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -490,7 +490,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_5ToFunction6<I1, I2, I3, I4, IO, I6> implements Function<Inplaces.Arity6_5<I1, I2, I3, I4, IO, I6>, Functions.Arity6<I1, I2, I3, I4, IO, I6, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -513,7 +513,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace6_6ToFunction6<I1, I2, I3, I4, I5, IO> implements Function<Inplaces.Arity6_6<I1, I2, I3, I4, I5, IO>, Functions.Arity6<I1, I2, I3, I4, I5, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -536,7 +536,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_1ToFunction7<IO, I2, I3, I4, I5, I6, I7> implements Function<Inplaces.Arity7_1<IO, I2, I3, I4, I5, I6, I7>, Functions.Arity7<IO, I2, I3, I4, I5, I6, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -559,7 +559,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_2ToFunction7<I1, IO, I3, I4, I5, I6, I7> implements Function<Inplaces.Arity7_2<I1, IO, I3, I4, I5, I6, I7>, Functions.Arity7<I1, IO, I3, I4, I5, I6, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -582,7 +582,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_3ToFunction7<I1, I2, IO, I4, I5, I6, I7> implements Function<Inplaces.Arity7_3<I1, I2, IO, I4, I5, I6, I7>, Functions.Arity7<I1, I2, IO, I4, I5, I6, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -605,7 +605,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_4ToFunction7<I1, I2, I3, IO, I5, I6, I7> implements Function<Inplaces.Arity7_4<I1, I2, I3, IO, I5, I6, I7>, Functions.Arity7<I1, I2, I3, IO, I5, I6, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -628,7 +628,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_5ToFunction7<I1, I2, I3, I4, IO, I6, I7> implements Function<Inplaces.Arity7_5<I1, I2, I3, I4, IO, I6, I7>, Functions.Arity7<I1, I2, I3, I4, IO, I6, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -651,7 +651,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_6ToFunction7<I1, I2, I3, I4, I5, IO, I7> implements Function<Inplaces.Arity7_6<I1, I2, I3, I4, I5, IO, I7>, Functions.Arity7<I1, I2, I3, I4, I5, IO, I7, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -674,7 +674,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace7_7ToFunction7<I1, I2, I3, I4, I5, I6, IO> implements Function<Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, IO>, Functions.Arity7<I1, I2, I3, I4, I5, I6, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -697,7 +697,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_1ToFunction8<IO, I2, I3, I4, I5, I6, I7, I8> implements Function<Inplaces.Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8>, Functions.Arity8<IO, I2, I3, I4, I5, I6, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -720,7 +720,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_2ToFunction8<I1, IO, I3, I4, I5, I6, I7, I8> implements Function<Inplaces.Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8>, Functions.Arity8<I1, IO, I3, I4, I5, I6, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -743,7 +743,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_3ToFunction8<I1, I2, IO, I4, I5, I6, I7, I8> implements Function<Inplaces.Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8>, Functions.Arity8<I1, I2, IO, I4, I5, I6, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -766,7 +766,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_4ToFunction8<I1, I2, I3, IO, I5, I6, I7, I8> implements Function<Inplaces.Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8>, Functions.Arity8<I1, I2, I3, IO, I5, I6, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -789,7 +789,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_5ToFunction8<I1, I2, I3, I4, IO, I6, I7, I8> implements Function<Inplaces.Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8>, Functions.Arity8<I1, I2, I3, I4, IO, I6, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -812,7 +812,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_6ToFunction8<I1, I2, I3, I4, I5, IO, I7, I8> implements Function<Inplaces.Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8>, Functions.Arity8<I1, I2, I3, I4, I5, IO, I7, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -835,7 +835,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_7ToFunction8<I1, I2, I3, I4, I5, I6, IO, I8> implements Function<Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8>, Functions.Arity8<I1, I2, I3, I4, I5, I6, IO, I8, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -858,7 +858,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace8_8ToFunction8<I1, I2, I3, I4, I5, I6, I7, IO> implements Function<Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO>, Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -881,7 +881,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_1ToFunction9<IO, I2, I3, I4, I5, I6, I7, I8, I9> implements Function<Inplaces.Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9>, Functions.Arity9<IO, I2, I3, I4, I5, I6, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -904,7 +904,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_2ToFunction9<I1, IO, I3, I4, I5, I6, I7, I8, I9> implements Function<Inplaces.Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9>, Functions.Arity9<I1, IO, I3, I4, I5, I6, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -927,7 +927,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_3ToFunction9<I1, I2, IO, I4, I5, I6, I7, I8, I9> implements Function<Inplaces.Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9>, Functions.Arity9<I1, I2, IO, I4, I5, I6, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -950,7 +950,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_4ToFunction9<I1, I2, I3, IO, I5, I6, I7, I8, I9> implements Function<Inplaces.Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9>, Functions.Arity9<I1, I2, I3, IO, I5, I6, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -973,7 +973,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_5ToFunction9<I1, I2, I3, I4, IO, I6, I7, I8, I9> implements Function<Inplaces.Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9>, Functions.Arity9<I1, I2, I3, I4, IO, I6, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -996,7 +996,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_6ToFunction9<I1, I2, I3, I4, I5, IO, I7, I8, I9> implements Function<Inplaces.Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9>, Functions.Arity9<I1, I2, I3, I4, I5, IO, I7, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1019,7 +1019,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_7ToFunction9<I1, I2, I3, I4, I5, I6, IO, I8, I9> implements Function<Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9>, Functions.Arity9<I1, I2, I3, I4, I5, I6, IO, I8, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1042,7 +1042,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_8ToFunction9<I1, I2, I3, I4, I5, I6, I7, IO, I9> implements Function<Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, IO, I9, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1065,7 +1065,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace9_9ToFunction9<I1, I2, I3, I4, I5, I6, I7, I8, IO> implements Function<Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1088,7 +1088,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_1ToFunction10<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10> implements Function<Inplaces.Arity10_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10>, Functions.Arity10<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1111,7 +1111,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_2ToFunction10<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10> implements Function<Inplaces.Arity10_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10>, Functions.Arity10<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1134,7 +1134,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_3ToFunction10<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10> implements Function<Inplaces.Arity10_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10>, Functions.Arity10<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1157,7 +1157,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_4ToFunction10<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10> implements Function<Inplaces.Arity10_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10>, Functions.Arity10<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1180,7 +1180,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_5ToFunction10<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10> implements Function<Inplaces.Arity10_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10>, Functions.Arity10<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1203,7 +1203,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_6ToFunction10<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10> implements Function<Inplaces.Arity10_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10>, Functions.Arity10<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1226,7 +1226,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_7ToFunction10<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10> implements Function<Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10>, Functions.Arity10<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1249,7 +1249,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_8ToFunction10<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10> implements Function<Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1272,7 +1272,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_9ToFunction10<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10> implements Function<Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1295,7 +1295,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace10_10ToFunction10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO> implements Function<Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1318,7 +1318,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_1ToFunction11<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11>, Functions.Arity11<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1341,7 +1341,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_2ToFunction11<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11>, Functions.Arity11<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1364,7 +1364,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_3ToFunction11<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11>, Functions.Arity11<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1387,7 +1387,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_4ToFunction11<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11>, Functions.Arity11<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1410,7 +1410,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_5ToFunction11<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11>, Functions.Arity11<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1433,7 +1433,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_6ToFunction11<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11> implements Function<Inplaces.Arity11_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11>, Functions.Arity11<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1456,7 +1456,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_7ToFunction11<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11> implements Function<Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11>, Functions.Arity11<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1479,7 +1479,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_8ToFunction11<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11> implements Function<Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1502,7 +1502,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_9ToFunction11<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11> implements Function<Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1525,7 +1525,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_10ToFunction11<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11> implements Function<Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1548,7 +1548,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace11_11ToFunction11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO> implements Function<Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1571,7 +1571,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_1ToFunction12<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Functions.Arity12<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1594,7 +1594,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_2ToFunction12<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Functions.Arity12<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1617,7 +1617,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_3ToFunction12<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Functions.Arity12<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1640,7 +1640,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_4ToFunction12<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12>, Functions.Arity12<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1663,7 +1663,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_5ToFunction12<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12>, Functions.Arity12<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1686,7 +1686,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_6ToFunction12<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12>, Functions.Arity12<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1709,7 +1709,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_7ToFunction12<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12> implements Function<Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12>, Functions.Arity12<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1732,7 +1732,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_8ToFunction12<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12> implements Function<Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1755,7 +1755,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_9ToFunction12<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12> implements Function<Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1778,7 +1778,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_10ToFunction12<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12> implements Function<Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1801,7 +1801,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_11ToFunction12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12> implements Function<Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1824,7 +1824,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace12_12ToFunction12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO> implements Function<Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1847,7 +1847,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_1ToFunction13<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1870,7 +1870,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_2ToFunction13<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1893,7 +1893,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_3ToFunction13<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1916,7 +1916,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_4ToFunction13<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1939,7 +1939,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_5ToFunction13<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1962,7 +1962,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_6ToFunction13<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -1985,7 +1985,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_7ToFunction13<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2008,7 +2008,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_8ToFunction13<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13> implements Function<Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2031,7 +2031,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_9ToFunction13<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13> implements Function<Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2054,7 +2054,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_10ToFunction13<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13> implements Function<Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2077,7 +2077,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_11ToFunction13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13> implements Function<Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2100,7 +2100,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_12ToFunction13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13> implements Function<Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2123,7 +2123,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace13_13ToFunction13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO> implements Function<Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2146,7 +2146,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_1ToFunction14<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2169,7 +2169,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_2ToFunction14<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2192,7 +2192,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_3ToFunction14<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2215,7 +2215,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_4ToFunction14<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2238,7 +2238,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_5ToFunction14<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2261,7 +2261,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_6ToFunction14<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2284,7 +2284,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_7ToFunction14<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2307,7 +2307,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_8ToFunction14<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2330,7 +2330,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_9ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14> implements Function<Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2353,7 +2353,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_10ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14> implements Function<Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2376,7 +2376,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_11ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14> implements Function<Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2399,7 +2399,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_12ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14> implements Function<Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2422,7 +2422,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_13ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14> implements Function<Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2445,7 +2445,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace14_14ToFunction14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO> implements Function<Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2468,7 +2468,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_1ToFunction15<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2491,7 +2491,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_2ToFunction15<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2514,7 +2514,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_3ToFunction15<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2537,7 +2537,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_4ToFunction15<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2560,7 +2560,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_5ToFunction15<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2583,7 +2583,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_6ToFunction15<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2606,7 +2606,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_7ToFunction15<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2629,7 +2629,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_8ToFunction15<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2652,7 +2652,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_9ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2675,7 +2675,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_10ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15> implements Function<Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2698,7 +2698,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_11ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15> implements Function<Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2721,7 +2721,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_12ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15> implements Function<Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2744,7 +2744,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_13ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15> implements Function<Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2767,7 +2767,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_14ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15> implements Function<Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2790,7 +2790,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace15_15ToFunction15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO> implements Function<Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2813,7 +2813,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_1ToFunction16<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2836,7 +2836,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_2ToFunction16<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2859,7 +2859,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_3ToFunction16<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2882,7 +2882,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_4ToFunction16<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2905,7 +2905,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_5ToFunction16<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2928,7 +2928,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_6ToFunction16<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2951,7 +2951,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_7ToFunction16<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2974,7 +2974,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_8ToFunction16<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -2997,7 +2997,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_9ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3020,7 +3020,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_10ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3043,7 +3043,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_11ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16> implements Function<Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3066,7 +3066,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_12ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16> implements Function<Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3089,7 +3089,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_13ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16> implements Function<Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3112,7 +3112,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_14ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16> implements Function<Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3135,7 +3135,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_15ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16> implements Function<Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)
@@ -3158,7 +3158,7 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		}
 	}
 
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace16_16ToFunction16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO> implements Function<Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO, IO>>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/ComputerToArrays.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/ComputerToArrays.java
@@ -55,7 +55,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		return minLength;
 	}
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity0<O>, Computers.Arity0<O[]>> liftComputer0 =
 		(computer) -> {
 			return (out) -> {
@@ -66,7 +66,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity1<I, O>, Computers.Arity1<I[], O[]>> liftComputer1 =
 		(computer) -> {
 			return (in, out) -> {
@@ -77,7 +77,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<I1[], I2[], O[]>> liftComputer2 =
 		(computer) -> {
 			return (in1, in2, out) -> {
@@ -88,7 +88,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<I1[], I2[], I3[], O[]>> liftComputer3 =
 		(computer) -> {
 			return (in1, in2, in3, out) -> {
@@ -99,7 +99,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1[], I2[], I3[], I4[], O[]>> liftComputer4 =
 		(computer) -> {
 			return (in1, in2, in3, in4, out) -> {
@@ -110,7 +110,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1[], I2[], I3[], I4[], I5[], O[]>> liftComputer5 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, out) -> {
@@ -121,7 +121,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1[], I2[], I3[], I4[], I5[], I6[], O[]>> liftComputer6 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, out) -> {
@@ -132,7 +132,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1[], I2[], I3[], I4[], I5[], I6[], I7[], O[]>> liftComputer7 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, out) -> {
@@ -143,7 +143,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], O[]>> liftComputer8 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, out) -> {
@@ -154,7 +154,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], O[]>> liftComputer9 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, out) -> {
@@ -165,7 +165,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], O[]>> liftComputer10 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, out) -> {
@@ -176,7 +176,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], O[]>> liftComputer11 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, out) -> {
@@ -187,7 +187,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], O[]>> liftComputer12 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, out) -> {
@@ -198,7 +198,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], O[]>> liftComputer13 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, out) -> {
@@ -209,7 +209,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], O[]>> liftComputer14 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, out) -> {
@@ -220,7 +220,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], O[]>> liftComputer15 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, out) -> {
@@ -231,7 +231,7 @@ public class ComputerToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[], O[]>> liftComputer16 =
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, out) -> {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/ComputerToIterables.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/ComputerToIterables.java
@@ -51,7 +51,7 @@ import org.scijava.ops.spi.OpCollection;
  */
 public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O> implements OpCollection {
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity0<O>, Computers.Arity0<Iterable<O>>> liftComputer0 = 
 		(computer) -> {
 			return (out) -> {
@@ -62,7 +62,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity1<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>> liftComputer1 = 
 		(computer) -> {
 			return (in, out) -> {
@@ -74,7 +74,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>> liftComputer2 = 
 		(computer) -> {
 			return (in1, in2, out) -> {
@@ -87,7 +87,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> liftComputer3 = 
 		(computer) -> {
 			return (in1, in2, in3, out) -> {
@@ -101,7 +101,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> liftComputer4 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, out) -> {
@@ -116,7 +116,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> liftComputer5 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, out) -> {
@@ -132,7 +132,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> liftComputer6 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, out) -> {
@@ -149,7 +149,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> liftComputer7 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, out) -> {
@@ -167,7 +167,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> liftComputer8 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, out) -> {
@@ -186,7 +186,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> liftComputer9 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, out) -> {
@@ -206,7 +206,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> liftComputer10 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, out) -> {
@@ -227,7 +227,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> liftComputer11 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, out) -> {
@@ -249,7 +249,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> liftComputer12 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, out) -> {
@@ -272,7 +272,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> liftComputer13 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, out) -> {
@@ -296,7 +296,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> liftComputer14 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, out) -> {
@@ -321,7 +321,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> liftComputer15 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, out) -> {
@@ -347,7 +347,7 @@ public class ComputerToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 			};
 		};
 
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> liftComputer16 = 
 		(computer) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, out) -> {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/FunctionToArrays.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/FunctionToArrays.java
@@ -65,7 +65,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 	// NOTE: we cannot convert Producers since there is no way to determine the
 	// length of the output array
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Function<I, O>, Function<I[], O[]>> liftFunction1 =
 		(function) -> {
 			return (in) -> {
@@ -82,7 +82,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<BiFunction<I1, I2, O>, BiFunction<I1[], I2[], O[]>> liftFunction2 =
 		(function) -> {
 			return (in1, in2) -> {
@@ -99,7 +99,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<I1[], I2[], I3[], O[]>> liftFunction3 =
 		(function) -> {
 			return (in1, in2, in3) -> {
@@ -116,7 +116,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<I1[], I2[], I3[], I4[], O[]>> liftFunction4 =
 		(function) -> {
 			return (in1, in2, in3, in4) -> {
@@ -133,7 +133,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<I1[], I2[], I3[], I4[], I5[], O[]>> liftFunction5 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5) -> {
@@ -150,7 +150,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<I1[], I2[], I3[], I4[], I5[], I6[], O[]>> liftFunction6 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6) -> {
@@ -167,7 +167,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<I1[], I2[], I3[], I4[], I5[], I6[], I7[], O[]>> liftFunction7 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7) -> {
@@ -184,7 +184,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], O[]>> liftFunction8 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8) -> {
@@ -201,7 +201,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], O[]>> liftFunction9 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9) -> {
@@ -218,7 +218,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], O[]>> liftFunction10 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10) -> {
@@ -235,7 +235,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], O[]>> liftFunction11 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11) -> {
@@ -252,7 +252,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], O[]>> liftFunction12 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -269,7 +269,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], O[]>> liftFunction13 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -286,7 +286,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], O[]>> liftFunction14 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -303,7 +303,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], O[]>> liftFunction15 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -320,7 +320,7 @@ public class FunctionToArrays<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[], O[]>> liftFunction16 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/FunctionToIterables.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/FunctionToIterables.java
@@ -58,112 +58,112 @@ public class FunctionToIterables<I, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11
 	// length of the output Iterable
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Function<I, O>, Function<Iterable<I>, Iterable<O>>> liftFunction1 =
 		(function) -> {
 			return (in1) -> lazyIterable(itrs -> function.apply((I) itrs[0].next()), in1);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<BiFunction<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>> liftFunction2 =
 		(function) -> {
 			return (in1, in2) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next()), in1, in2);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> liftFunction3 =
 		(function) -> {
 			return (in1, in2, in3) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next()), in1, in2, in3);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> liftFunction4 =
 		(function) -> {
 			return (in1, in2, in3, in4) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next()), in1, in2, in3, in4);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> liftFunction5 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next()), in1, in2, in3, in4, in5);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> liftFunction6 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next()), in1, in2, in3, in4, in5, in6);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> liftFunction7 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next()), in1, in2, in3, in4, in5, in6, in7);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> liftFunction8 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next()), in1, in2, in3, in4, in5, in6, in7, in8);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> liftFunction9 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> liftFunction10 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> liftFunction11 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> liftFunction12 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next(), (I12) itrs[11].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> liftFunction13 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next(), (I12) itrs[11].next(), (I13) itrs[12].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> liftFunction14 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next(), (I12) itrs[11].next(), (I13) itrs[12].next(), (I14) itrs[13].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> liftFunction15 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next(), (I12) itrs[11].next(), (I13) itrs[12].next(), (I14) itrs[13].next(), (I15) itrs[14].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15);
 		};
 
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> liftFunction16 =
 		(function) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> lazyIterable(itrs -> function.apply((I1) itrs[0].next(), (I2) itrs[1].next(), (I3) itrs[2].next(), (I4) itrs[3].next(), (I5) itrs[4].next(), (I6) itrs[5].next(), (I7) itrs[6].next(), (I8) itrs[7].next(), (I9) itrs[8].next(), (I10) itrs[9].next(), (I11) itrs[10].next(), (I12) itrs[11].next(), (I13) itrs[12].next(), (I14) itrs[13].next(), (I15) itrs[14].next(), (I16) itrs[15].next()), in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16);

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/InplaceToArrays.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/lift/InplaceToArrays.java
@@ -57,7 +57,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		return minLength;
 	}
 	
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity1<IO>, Inplaces.Arity1<IO[]>> liftInplace1 =
 		(inplace) -> {
 			return (io) -> {
@@ -68,7 +68,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity2_1<IO, I2>, Inplaces.Arity2_1<IO[], I2[]>> liftInplace2_1 =
 		(inplace) -> {
 			return (io, in2) -> {
@@ -79,7 +79,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity2_2<I1, IO>, Inplaces.Arity2_2<I1[], IO[]>> liftInplace2_2 =
 		(inplace) -> {
 			return (in1, io) -> {
@@ -90,7 +90,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity3_1<IO, I2, I3>, Inplaces.Arity3_1<IO[], I2[], I3[]>> liftInplace3_1 =
 		(inplace) -> {
 			return (io, in2, in3) -> {
@@ -101,7 +101,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity3_2<I1, IO, I3>, Inplaces.Arity3_2<I1[], IO[], I3[]>> liftInplace3_2 =
 		(inplace) -> {
 			return (in1, io, in3) -> {
@@ -112,7 +112,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity3_3<I1, I2, IO>, Inplaces.Arity3_3<I1[], I2[], IO[]>> liftInplace3_3 =
 		(inplace) -> {
 			return (in1, in2, io) -> {
@@ -123,7 +123,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity4_1<IO, I2, I3, I4>, Inplaces.Arity4_1<IO[], I2[], I3[], I4[]>> liftInplace4_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4) -> {
@@ -134,7 +134,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity4_2<I1, IO, I3, I4>, Inplaces.Arity4_2<I1[], IO[], I3[], I4[]>> liftInplace4_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4) -> {
@@ -145,7 +145,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity4_3<I1, I2, IO, I4>, Inplaces.Arity4_3<I1[], I2[], IO[], I4[]>> liftInplace4_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4) -> {
@@ -156,7 +156,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity4_4<I1, I2, I3, IO>, Inplaces.Arity4_4<I1[], I2[], I3[], IO[]>> liftInplace4_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io) -> {
@@ -167,7 +167,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity5_1<IO, I2, I3, I4, I5>, Inplaces.Arity5_1<IO[], I2[], I3[], I4[], I5[]>> liftInplace5_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5) -> {
@@ -178,7 +178,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity5_2<I1, IO, I3, I4, I5>, Inplaces.Arity5_2<I1[], IO[], I3[], I4[], I5[]>> liftInplace5_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5) -> {
@@ -189,7 +189,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity5_3<I1, I2, IO, I4, I5>, Inplaces.Arity5_3<I1[], I2[], IO[], I4[], I5[]>> liftInplace5_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5) -> {
@@ -200,7 +200,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity5_4<I1, I2, I3, IO, I5>, Inplaces.Arity5_4<I1[], I2[], I3[], IO[], I5[]>> liftInplace5_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5) -> {
@@ -211,7 +211,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity5_5<I1, I2, I3, I4, IO>, Inplaces.Arity5_5<I1[], I2[], I3[], I4[], IO[]>> liftInplace5_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io) -> {
@@ -222,7 +222,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_1<IO, I2, I3, I4, I5, I6>, Inplaces.Arity6_1<IO[], I2[], I3[], I4[], I5[], I6[]>> liftInplace6_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6) -> {
@@ -233,7 +233,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_2<I1, IO, I3, I4, I5, I6>, Inplaces.Arity6_2<I1[], IO[], I3[], I4[], I5[], I6[]>> liftInplace6_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6) -> {
@@ -244,7 +244,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_3<I1, I2, IO, I4, I5, I6>, Inplaces.Arity6_3<I1[], I2[], IO[], I4[], I5[], I6[]>> liftInplace6_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6) -> {
@@ -255,7 +255,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_4<I1, I2, I3, IO, I5, I6>, Inplaces.Arity6_4<I1[], I2[], I3[], IO[], I5[], I6[]>> liftInplace6_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6) -> {
@@ -266,7 +266,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_5<I1, I2, I3, I4, IO, I6>, Inplaces.Arity6_5<I1[], I2[], I3[], I4[], IO[], I6[]>> liftInplace6_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6) -> {
@@ -277,7 +277,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity6_6<I1, I2, I3, I4, I5, IO>, Inplaces.Arity6_6<I1[], I2[], I3[], I4[], I5[], IO[]>> liftInplace6_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io) -> {
@@ -288,7 +288,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_1<IO, I2, I3, I4, I5, I6, I7>, Inplaces.Arity7_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[]>> liftInplace7_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7) -> {
@@ -299,7 +299,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_2<I1, IO, I3, I4, I5, I6, I7>, Inplaces.Arity7_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[]>> liftInplace7_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7) -> {
@@ -310,7 +310,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_3<I1, I2, IO, I4, I5, I6, I7>, Inplaces.Arity7_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[]>> liftInplace7_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7) -> {
@@ -321,7 +321,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_4<I1, I2, I3, IO, I5, I6, I7>, Inplaces.Arity7_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[]>> liftInplace7_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7) -> {
@@ -332,7 +332,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_5<I1, I2, I3, I4, IO, I6, I7>, Inplaces.Arity7_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[]>> liftInplace7_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7) -> {
@@ -343,7 +343,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_6<I1, I2, I3, I4, I5, IO, I7>, Inplaces.Arity7_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[]>> liftInplace7_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7) -> {
@@ -354,7 +354,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, IO>, Inplaces.Arity7_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[]>> liftInplace7_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io) -> {
@@ -365,7 +365,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8>, Inplaces.Arity8_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[]>> liftInplace8_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8) -> {
@@ -376,7 +376,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8>, Inplaces.Arity8_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[]>> liftInplace8_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8) -> {
@@ -387,7 +387,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8>, Inplaces.Arity8_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[]>> liftInplace8_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8) -> {
@@ -398,7 +398,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8>, Inplaces.Arity8_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[]>> liftInplace8_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8) -> {
@@ -409,7 +409,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8>, Inplaces.Arity8_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[]>> liftInplace8_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8) -> {
@@ -420,7 +420,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8>, Inplaces.Arity8_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[]>> liftInplace8_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8) -> {
@@ -431,7 +431,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8>, Inplaces.Arity8_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[]>> liftInplace8_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8) -> {
@@ -442,7 +442,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO>, Inplaces.Arity8_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[]>> liftInplace8_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io) -> {
@@ -453,7 +453,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9>, Inplaces.Arity9_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[]>> liftInplace9_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9) -> {
@@ -464,7 +464,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9>, Inplaces.Arity9_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[]>> liftInplace9_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9) -> {
@@ -475,7 +475,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9>, Inplaces.Arity9_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[]>> liftInplace9_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9) -> {
@@ -486,7 +486,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9>, Inplaces.Arity9_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[]>> liftInplace9_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9) -> {
@@ -497,7 +497,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9>, Inplaces.Arity9_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[]>> liftInplace9_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9) -> {
@@ -508,7 +508,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9>, Inplaces.Arity9_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[]>> liftInplace9_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9) -> {
@@ -519,7 +519,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9>, Inplaces.Arity9_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[]>> liftInplace9_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9) -> {
@@ -530,7 +530,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9>, Inplaces.Arity9_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[]>> liftInplace9_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9) -> {
@@ -541,7 +541,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO>, Inplaces.Arity9_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[]>> liftInplace9_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io) -> {
@@ -552,7 +552,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10>, Inplaces.Arity10_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[]>> liftInplace10_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10) -> {
@@ -563,7 +563,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10>, Inplaces.Arity10_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[]>> liftInplace10_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10) -> {
@@ -574,7 +574,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10>, Inplaces.Arity10_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[]>> liftInplace10_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10) -> {
@@ -585,7 +585,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10>, Inplaces.Arity10_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[]>> liftInplace10_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10) -> {
@@ -596,7 +596,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10>, Inplaces.Arity10_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[]>> liftInplace10_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10) -> {
@@ -607,7 +607,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10>, Inplaces.Arity10_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[]>> liftInplace10_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10) -> {
@@ -618,7 +618,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10>, Inplaces.Arity10_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[]>> liftInplace10_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10) -> {
@@ -629,7 +629,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10>, Inplaces.Arity10_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[]>> liftInplace10_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10) -> {
@@ -640,7 +640,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10>, Inplaces.Arity10_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[]>> liftInplace10_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10) -> {
@@ -651,7 +651,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO>, Inplaces.Arity10_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[]>> liftInplace10_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io) -> {
@@ -662,7 +662,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11>, Inplaces.Arity11_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11) -> {
@@ -673,7 +673,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11>, Inplaces.Arity11_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11) -> {
@@ -684,7 +684,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11>, Inplaces.Arity11_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11) -> {
@@ -695,7 +695,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11>, Inplaces.Arity11_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11) -> {
@@ -706,7 +706,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11>, Inplaces.Arity11_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11) -> {
@@ -717,7 +717,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11>, Inplaces.Arity11_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[]>> liftInplace11_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11) -> {
@@ -728,7 +728,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11>, Inplaces.Arity11_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[]>> liftInplace11_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11) -> {
@@ -739,7 +739,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11>, Inplaces.Arity11_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[]>> liftInplace11_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11) -> {
@@ -750,7 +750,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11>, Inplaces.Arity11_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[]>> liftInplace11_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11) -> {
@@ -761,7 +761,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11>, Inplaces.Arity11_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[]>> liftInplace11_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11) -> {
@@ -772,7 +772,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO>, Inplaces.Arity11_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[]>> liftInplace11_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io) -> {
@@ -783,7 +783,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -794,7 +794,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -805,7 +805,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -816,7 +816,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -827,7 +827,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12) -> {
@@ -838,7 +838,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12>, Inplaces.Arity12_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12) -> {
@@ -849,7 +849,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12>, Inplaces.Arity12_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[], I12[]>> liftInplace12_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12) -> {
@@ -860,7 +860,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12>, Inplaces.Arity12_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[], I12[]>> liftInplace12_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12) -> {
@@ -871,7 +871,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12>, Inplaces.Arity12_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[], I12[]>> liftInplace12_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12) -> {
@@ -882,7 +882,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12>, Inplaces.Arity12_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[], I12[]>> liftInplace12_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12) -> {
@@ -893,7 +893,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12>, Inplaces.Arity12_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[], I12[]>> liftInplace12_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12) -> {
@@ -904,7 +904,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO>, Inplaces.Arity12_12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], IO[]>> liftInplace12_12 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io) -> {
@@ -915,7 +915,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -926,7 +926,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -937,7 +937,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -948,7 +948,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -959,7 +959,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -970,7 +970,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13) -> {
@@ -981,7 +981,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13>, Inplaces.Arity13_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13) -> {
@@ -992,7 +992,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13>, Inplaces.Arity13_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[], I12[], I13[]>> liftInplace13_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13) -> {
@@ -1003,7 +1003,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13>, Inplaces.Arity13_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[], I12[], I13[]>> liftInplace13_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13) -> {
@@ -1014,7 +1014,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13>, Inplaces.Arity13_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[], I12[], I13[]>> liftInplace13_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13) -> {
@@ -1025,7 +1025,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13>, Inplaces.Arity13_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[], I12[], I13[]>> liftInplace13_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13) -> {
@@ -1036,7 +1036,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13>, Inplaces.Arity13_12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], IO[], I13[]>> liftInplace13_12 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13) -> {
@@ -1047,7 +1047,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>, Inplaces.Arity13_13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], IO[]>> liftInplace13_13 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io) -> {
@@ -1058,7 +1058,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1069,7 +1069,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1080,7 +1080,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1091,7 +1091,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1102,7 +1102,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1113,7 +1113,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1124,7 +1124,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14) -> {
@@ -1135,7 +1135,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14>, Inplaces.Arity14_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14) -> {
@@ -1146,7 +1146,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14>, Inplaces.Arity14_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[], I12[], I13[], I14[]>> liftInplace14_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14) -> {
@@ -1157,7 +1157,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14>, Inplaces.Arity14_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[], I12[], I13[], I14[]>> liftInplace14_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14) -> {
@@ -1168,7 +1168,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14>, Inplaces.Arity14_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[], I12[], I13[], I14[]>> liftInplace14_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14) -> {
@@ -1179,7 +1179,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14>, Inplaces.Arity14_12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], IO[], I13[], I14[]>> liftInplace14_12 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14) -> {
@@ -1190,7 +1190,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14>, Inplaces.Arity14_13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], IO[], I14[]>> liftInplace14_13 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14) -> {
@@ -1201,7 +1201,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>, Inplaces.Arity14_14<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], IO[]>> liftInplace14_14 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io) -> {
@@ -1212,7 +1212,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1223,7 +1223,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1234,7 +1234,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1245,7 +1245,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1256,7 +1256,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1267,7 +1267,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1278,7 +1278,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1289,7 +1289,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14, in15) -> {
@@ -1300,7 +1300,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15>, Inplaces.Arity15_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14, in15) -> {
@@ -1311,7 +1311,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15>, Inplaces.Arity15_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[], I12[], I13[], I14[], I15[]>> liftInplace15_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14, in15) -> {
@@ -1322,7 +1322,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15>, Inplaces.Arity15_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[], I12[], I13[], I14[], I15[]>> liftInplace15_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14, in15) -> {
@@ -1333,7 +1333,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15>, Inplaces.Arity15_12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], IO[], I13[], I14[], I15[]>> liftInplace15_12 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14, in15) -> {
@@ -1344,7 +1344,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15>, Inplaces.Arity15_13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], IO[], I14[], I15[]>> liftInplace15_13 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14, in15) -> {
@@ -1355,7 +1355,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15>, Inplaces.Arity15_14<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], IO[], I15[]>> liftInplace15_14 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io, in15) -> {
@@ -1366,7 +1366,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>, Inplaces.Arity15_15<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], IO[]>> liftInplace15_15 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, io) -> {
@@ -1377,7 +1377,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_1<IO[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_1 =
 		(inplace) -> {
 			return (io, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1388,7 +1388,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_2<I1[], IO[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_2 =
 		(inplace) -> {
 			return (in1, io, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1399,7 +1399,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_3<I1[], I2[], IO[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_3 =
 		(inplace) -> {
 			return (in1, in2, io, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1410,7 +1410,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_4<I1[], I2[], I3[], IO[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_4 =
 		(inplace) -> {
 			return (in1, in2, in3, io, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1421,7 +1421,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_5<I1[], I2[], I3[], I4[], IO[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_5 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, io, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1432,7 +1432,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_6<I1[], I2[], I3[], I4[], I5[], IO[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_6 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, io, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1443,7 +1443,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_7<I1[], I2[], I3[], I4[], I5[], I6[], IO[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_7 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, io, in8, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1454,7 +1454,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_8<I1[], I2[], I3[], I4[], I5[], I6[], I7[], IO[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_8 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, io, in9, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1465,7 +1465,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_9<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], IO[], I10[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_9 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, io, in10, in11, in12, in13, in14, in15, in16) -> {
@@ -1476,7 +1476,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16>, Inplaces.Arity16_10<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], IO[], I11[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_10 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, io, in11, in12, in13, in14, in15, in16) -> {
@@ -1487,7 +1487,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16>, Inplaces.Arity16_11<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], IO[], I12[], I13[], I14[], I15[], I16[]>> liftInplace16_11 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, io, in12, in13, in14, in15, in16) -> {
@@ -1498,7 +1498,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16>, Inplaces.Arity16_12<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], IO[], I13[], I14[], I15[], I16[]>> liftInplace16_12 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, io, in13, in14, in15, in16) -> {
@@ -1509,7 +1509,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16>, Inplaces.Arity16_13<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], IO[], I14[], I15[], I16[]>> liftInplace16_13 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, io, in14, in15, in16) -> {
@@ -1520,7 +1520,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16>, Inplaces.Arity16_14<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], IO[], I15[], I16[]>> liftInplace16_14 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, io, in15, in16) -> {
@@ -1531,7 +1531,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16>, Inplaces.Arity16_15<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], IO[], I16[]>> liftInplace16_15 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, io, in16) -> {
@@ -1542,7 +1542,7 @@ public class InplaceToArrays<IO, I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 			};
 		};
 
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>, Inplaces.Arity16_16<I1[], I2[], I3[], I4[], I5[], I6[], I7[], I8[], I9[], I10[], I11[], I12[], I13[], I14[], I15[], IO[]>> liftInplace16_16 =
 		(inplace) -> {
 			return (in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, io) -> {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/LambdaTypeBaker.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/LambdaTypeBaker.java
@@ -68,7 +68,7 @@ public final class LambdaTypeBaker {
 	 * <p>
 	 *
 	 * <pre>{@code
-	 * op("adapt")
+	 * op("engine.adapt")
 	 *   .input(computer)
 	 *   .outType(new Nil&lt;Computers.Arity1&lt;Iterable&lt;Double&gt;, Iterable&lt;Double&gt;&gt;&gt;() {})
 	 *   .apply()

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
@@ -104,7 +104,7 @@ public class AdaptationMatchingRoutine implements MatchingRoutine {
 		Hints adaptationHints = conditions.hints().plus(Adaptation.IN_PROGRESS);
 		List<Exception> matchingExceptions = new ArrayList<>();
 		List<DependencyMatchingException> depExceptions = new ArrayList<>();
-		for (final OpInfo adaptor : env.infos("adapt")) {
+		for (final OpInfo adaptor : env.infos("engine.adapt")) {
 			Type adaptTo = adaptor.output().getType();
 			Map<TypeVariable<?>, Type> map = new HashMap<>();
 			// make sure that the adaptor outputs the correct type

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedOpInfo.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedOpInfo.java
@@ -369,8 +369,8 @@ public class FocusedOpInfo implements OpInfo {
 	}
 
 	/**
-	 * Calls a {@code lossReporter} Op to determine the <b>worst-case</b> loss
-	 * from a {@code T} to a {@code R}. If no {@code lossReporter} exists for such
+	 * Calls a {@code engine.lossReporter} Op to determine the <b>worst-case</b> loss
+	 * from a {@code T} to a {@code R}. If no {@code engine.lossReporter} exists for such
 	 * a conversion, we assume infinite loss.
 	 *
 	 * @param <T> -the generic type we are converting from.
@@ -396,7 +396,7 @@ public class FocusedOpInfo implements OpInfo {
 				.getType() });
 			Hints h = new Hints(BaseOpHints.Adaptation.FORBIDDEN,
 				BaseOpHints.Simplification.FORBIDDEN);
-			LossReporter<T, R> op = env.op("lossReporter", specialTypeNil, new Nil[] {
+			LossReporter<T, R> op = env.op("engine.lossReporter", specialTypeNil, new Nil[] {
 				Nil.of(nilFromType), Nil.of(nilToType) }, Nil.of(Double.class), h);
 			return op.apply(from, to);
 		}

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityCollection.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityCollection.java
@@ -50,7 +50,7 @@ public class IdentityCollection<T> implements OpCollection {
 	 *         simplification, this is just a reference to the input object).
 	 */
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names="simplify, focus, identify", priority=Priority.LAST)
+	@OpField(names="simplify, focus, identity", priority=Priority.LAST)
 	public final Function<T, T> identity = (t) -> t;
 
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityCollection.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityCollection.java
@@ -50,7 +50,7 @@ public class IdentityCollection<T> implements OpCollection {
 	 *         simplification, this is just a reference to the input object).
 	 */
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names="simplify, focus, identity", priority=Priority.LAST)
+	@OpField(names="engine.simplify, engine.focus, identity", priority=Priority.LAST)
 	public final Function<T, T> identity = (t) -> t;
 
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityLossReporter.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/IdentityLossReporter.java
@@ -44,7 +44,7 @@ import org.scijava.types.Nil;
  * @param <T> - the type that is not being simplified.
  */
 @OpHints(hints = {Simplification.FORBIDDEN})
-@OpClass(names = "lossReporter", priority= Priority.VERY_HIGH)
+@OpClass(names = "engine.lossReporter", priority= Priority.VERY_HIGH)
 public class IdentityLossReporter<U, T extends U> implements LossReporter<T, U>, Op {
 
 	/**

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveArrayLossReporters.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveArrayLossReporters.java
@@ -37,11 +37,11 @@ import org.scijava.ops.spi.OpField;
 public class PrimitiveArrayLossReporters implements OpCollection {
 	
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Byte[], Integer[]> bArrIArr = (from, to) -> 0.;
 	
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Double[], Integer[]> dArrIArr = (from, to) -> 0.;
 
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveArraySimplifiers.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveArraySimplifiers.java
@@ -48,7 +48,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 
 	// -- Object simplifiers -- //
 		@OpHints(hints = { Simplification.FORBIDDEN })
-		@OpField(names = "simplify")
+		@OpField(names = "engine.simplify")
 		public final Function<N[], ObjectArray<Number>> byteArrSimplifier = arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
 			// TODO: Why doesn't System.arraycopy work?
@@ -61,7 +61,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 	// -- Primitive simplifiers -- //
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<byte[], ObjectArray<Number>> bytePrimitiveArraySimplifier =
 		arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
@@ -73,7 +73,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<short[], ObjectArray<Number>> shortPrimitiveArraySimplifier =
 		arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
@@ -85,7 +85,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<int[], ObjectArray<Number>> intPrimitiveArraySimplifier = arr -> {
 		var oa = new ObjectArray<>(Number.class, arr.length);
 		// TODO: Why doesn't System.arraycopy work?
@@ -96,7 +96,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 	};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<long[], ObjectArray<Number>> longPrimitiveArraySimplifier =
 		arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
@@ -108,7 +108,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<float[], ObjectArray<Number>> floatPrimitiveArraySimplifier =
 		arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
@@ -120,7 +120,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<double[], ObjectArray<Number>> doublePrimitiveArraySimplifier =
 		arr -> {
 			var oa = new ObjectArray<>(Number.class, arr.length);
@@ -134,32 +134,32 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 	// -- Object Focusers -- //
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Byte[]> byteArrFocuser = o -> o
 		.stream().map(b -> b == null ? null : b.byteValue()).toArray(Byte[]::new);
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Integer[]> intArrFocuser = o -> o
 		.stream().map(i -> i == null ? null : i.intValue()).toArray(Integer[]::new);
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Short[]> shortArrFocuser = o -> o
 		.stream().map(s -> s == null ? null : s.shortValue()).toArray(Short[]::new);
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Long[]> longArrFocuser = o -> o
 		.stream().map(l -> l == null ? null : l.longValue()).toArray(Long[]::new);
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Float[]> floatArrFocuser = o -> o
 		.stream().map(f -> f == null ? null : f.floatValue()).toArray(Float[]::new);
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, Double[]> doubleArrFocuser = o -> o
 		.stream().map(d -> d == null ? null : d.doubleValue()).toArray(
 			Double[]::new);
@@ -167,7 +167,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 	// -- Primitive Focusers -- //
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, byte[]> bytePrimitiveArrFocuser =
 		o -> {
 			byte[] arr = new byte[o.size()];
@@ -178,7 +178,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, short[]> shortPrimitiveArrFocuser =
 		o -> {
 			short[] arr = new short[o.size()];
@@ -189,7 +189,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, int[]> intPrimitiveArrFocuser =
 		o -> {
 			int[] arr = new int[o.size()];
@@ -200,7 +200,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, long[]> longPrimitiveArrFocuser =
 		o -> {
 			long[] arr = new long[o.size()];
@@ -211,7 +211,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, float[]> floatPrimitiveArrFocuser =
 		o -> {
 			float[] arr = new float[o.size()];
@@ -222,7 +222,7 @@ public class PrimitiveArraySimplifiers<N extends Number> implements
 		};
 
 	@OpHints(hints = { Simplification.FORBIDDEN })
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<ObjectArray<Number>, double[]> doublePrimitiveArrFocuser =
 		o -> {
 			double[] arr = new double[o.size()];

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveListSimplifier.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveListSimplifier.java
@@ -39,7 +39,7 @@ import org.scijava.ops.spi.OpClass;
  * 
  * @author Gabriel Selzer
  */
-@OpClass(names = "simplify")
+@OpClass(names = "engine.simplify")
 public class PrimitiveListSimplifier<T extends Number> implements Function<List<T>, List<Number>>, Op {
 
 	@Override

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveLossReporters.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveLossReporters.java
@@ -58,7 +58,7 @@ public class PrimitiveLossReporters implements OpCollection {
 
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final IntToDecimalReporter<Long, Double> LongDoubleReporter = (from, to) -> {
 		long maxValue = Long.MAX_VALUE - 1;
 		double converted = maxValue;
@@ -66,7 +66,7 @@ public class PrimitiveLossReporters implements OpCollection {
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Double, Long> DoubleLongReporter = (from, to) -> {
 		double maxValue = Double.MAX_VALUE;
 		long converted = (long) maxValue;
@@ -74,7 +74,7 @@ public class PrimitiveLossReporters implements OpCollection {
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Long, Integer> LongIntegerReporter = (from, to) -> {
 		long maxValue = Long.MAX_VALUE;
 		int converted = (int) maxValue;
@@ -82,13 +82,13 @@ public class PrimitiveLossReporters implements OpCollection {
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Integer, Long> IntegerLongReporter = (from, to) -> {
 		return 0.;
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final IntToDecimalReporter<Integer, Double> IntegerDoubleReporter = (from, to) -> {
 		long maxValue = Integer.MAX_VALUE;
 		double converted = maxValue;
@@ -96,7 +96,7 @@ public class PrimitiveLossReporters implements OpCollection {
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Double, Integer> DoubleIntegerReporter = (from, to) -> {
 		double maxValue = Double.MAX_VALUE;
 		int converted = (int) maxValue;
@@ -104,12 +104,12 @@ public class PrimitiveLossReporters implements OpCollection {
 	};
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Number, Double> NumberDoubleReporter = (from,
 		to) -> LongDoubleReporter.apply(Nil.of(Long.class), Nil.of(Double.class));
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<Number, Long> NumberLongReporter = (from,
 		to) -> DoubleLongReporter.apply(Nil.of(Double.class), Nil.of(Long.class));
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveSimplifiers.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/PrimitiveSimplifiers.java
@@ -45,57 +45,57 @@ import org.scijava.ops.spi.OpField;
 public class PrimitiveSimplifiers implements OpCollection {
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Byte, Number> byteSimplifier = b -> b;
 	
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Byte> numberByteFocuser = n -> n.byteValue();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Integer, Number> integerSimplifier = i -> i;
 	
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Integer> numberIntegerFocuser = n -> n.intValue();
 	
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Short, Number> shortSimplifier = s -> s;
 	
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Short> numberShortFocuser = n -> n.shortValue();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Long, Number> longSimplifier = l -> l;
 
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Long> numberLongFocuser = n -> n.longValue();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Float, Number> floatSimplifier = f -> f;
 
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Float> numberFloatFocuser = n -> n.floatValue();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<Double, Number> doubleSimplifier = d -> d;
 
 	// TODO: move to separate class
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<Number, Double> numberDoubleFocuser = n -> n.doubleValue();
 
 }

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
@@ -182,7 +182,7 @@ public final class SimplificationUtils {
 			var inNil = Nil.of(arg);
 			try {
 				var focuser =
-						env.unary("focus", h).inType(Any.class).outType(inNil).function();
+						env.unary("engine.focus", h).inType(Any.class).outType(inNil).function();
 				inFocusers.add(org.scijava.ops.api.Ops.rich(focuser));
 			} catch (OpMatchingException e) {
 				var identity = env.unary("identity", h).inType(inNil).outType(inNil).function();
@@ -192,7 +192,7 @@ public final class SimplificationUtils {
 		var outNil = Nil.of(info.outputType());
 		RichOp<Function<?, ?>> outSimplifier;
 		try {
-			var simplifier = env.unary("simplify", h).inType(outNil).outType(
+			var simplifier = env.unary("engine.simplify", h).inType(outNil).outType(
 					Object.class).function();
 			outSimplifier = org.scijava.ops.api.Ops.rich(simplifier);
 		} catch (OpMatchingException e) {

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
@@ -30,6 +30,7 @@
 package org.scijava.ops.engine.matcher.simplify;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,13 @@ import org.scijava.priority.Priority;
 public class SimplifiedOpDescriptionGenerator implements
 	OpDescriptionGenerator
 {
+
+	private static final List<String> internalNamespaces = Arrays.asList( //
+			"adapt", //
+			"focus", //
+			"lossReporter", //
+			"simplify" //
+	);
 
 	@Override
 	public String simpleDescriptions(OpEnvironment env, OpRequest req) {
@@ -97,6 +105,8 @@ public class SimplifiedOpDescriptionGenerator implements
 				.flatMap(info -> info.names().stream()) //
 				// Map each name to its namespace
 				.map(name -> name.contains(".") ?  name.substring(0, name.indexOf(".")) : name) //
+				// Filter out "internal" namespaces
+				.filter(ns -> !internalNamespaces.contains(ns)) //
 				// Deduplicate, sort & collect
 				.distinct() //
 				.sorted() //
@@ -108,6 +118,8 @@ public class SimplifiedOpDescriptionGenerator implements
 		List<String> namespaces = env.infos().stream() //
 				// Get all names from each Op
 				.flatMap(info -> info.names().stream()) //
+				// Filter out "internal" namespaces
+				.filter(ns -> !internalNamespaces.contains(ns)) //
 				// Deduplicate, sort & collect
 				.distinct() //
 				.filter(n -> n.contains(name)) //

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
@@ -30,7 +30,6 @@
 package org.scijava.ops.engine.matcher.simplify;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,13 +50,6 @@ import org.scijava.priority.Priority;
 public class SimplifiedOpDescriptionGenerator implements
 	OpDescriptionGenerator
 {
-
-	private static final List<String> internalNamespaces = Arrays.asList( //
-			"adapt", //
-			"focus", //
-			"lossReporter", //
-			"simplify" //
-	);
 
 	@Override
 	public String simpleDescriptions(OpEnvironment env, OpRequest req) {
@@ -105,11 +97,11 @@ public class SimplifiedOpDescriptionGenerator implements
 				.flatMap(info -> info.names().stream()) //
 				// Map each name to its namespace
 				.map(name -> name.contains(".") ?  name.substring(0, name.indexOf(".")) : name) //
-				// Filter out "internal" namespaces
-				.filter(ns -> !internalNamespaces.contains(ns)) //
-				// Deduplicate, sort & collect
+				// Deduplicate & sort
 				.distinct() //
 				.sorted() //
+				// Filter out the engine namespaces
+				.filter(ns -> !ns.equals("engine")) //
 				.collect(Collectors.toList());
 		return "Namespaces:\n\t> " + String.join("\n\t> ", namespaces);
 	}
@@ -118,12 +110,13 @@ public class SimplifiedOpDescriptionGenerator implements
 		List<String> namespaces = env.infos().stream() //
 				// Get all names from each Op
 				.flatMap(info -> info.names().stream()) //
-				// Filter out "internal" namespaces
-				.filter(ns -> !internalNamespaces.contains(ns)) //
-				// Deduplicate, sort & collect
+				// Deduplicate & sort
 				.distinct() //
-				.filter(n -> n.contains(name)) //
 				.sorted() //
+				// Filter out the engine namespace
+				.filter(ns -> !ns.equals("engine")) //
+				// Filter by the predicate name
+				.filter(n -> n.contains(name)) //
 				.collect(Collectors.toList());
 		return "Names:\n\t> " + String.join("\n\t> ", namespaces);
 

--- a/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpRequest.java
+++ b/scijava/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpRequest.java
@@ -81,12 +81,12 @@ public class SimplifiedOpRequest implements OpRequest {
 		this.inSimplifiers = new ArrayList<>();
 		for(Type arg: req.getArgs()) {
 			var inNil = Nil.of(arg);
-			var simplifier = env.unary("simplify", h).inType(inNil).outType(Object.class).function();
+			var simplifier = env.unary("engine.simplify", h).inType(inNil).outType(Object.class).function();
 			inSimplifiers.add(Ops.rich(simplifier));
 		}
 		var inNil = Nil.of(new Any());
 		var outNil = Nil.of(req.getOutType());
-		var focuser = env.unary("focus", h).inType(inNil).outType(outNil).function();
+		var focuser = env.unary("engine.focus", h).inType(inNil).outType(outNil).function();
 		this.outFocuser = Ops.rich(focuser);
 
 		// Determine the new type

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
@@ -102,6 +102,24 @@ public class OpEnvironmentTest extends AbstractTestEnvironment {
 		Assertions.assertEquals(expected, descriptions);
 	}
 
+	@Test
+	public void testInternalNamespaceHelp() {
+		// NB We use a new OpEnvironment here for a clean list of Ops.
+		OpEnvironment helpEnv = barebonesEnvironment();
+		// Register an Op under an "internal" namespace and an "external" namespace
+		helpEnv.register( //
+				helpEnv.opify(OpifyOp.class, Priority.HIGH, "adapt", "help") //
+		);
+		// Make sure that only the "external" namespaces are visible
+		var actual = helpEnv.help();
+		String expected = "Namespaces:\n\t> help";
+		Assertions.assertEquals(expected, actual);
+		// ...but make sure that if we really need help with the internal namespace, we can get it
+		actual = helpEnv.help("adapt");
+		expected = "Ops:\n\t> adapt(\n\t\t Inputs:\n\t\t Outputs:\n\t\t\tString output1\n\t)\n\tAliases: [help]\n\t";
+		Assertions.assertEquals(expected, actual);
+	}
+
 }
 
 /**

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
@@ -108,15 +108,15 @@ public class OpEnvironmentTest extends AbstractTestEnvironment {
 		OpEnvironment helpEnv = barebonesEnvironment();
 		// Register an Op under an "internal" namespace and an "external" namespace
 		helpEnv.register( //
-				helpEnv.opify(OpifyOp.class, Priority.HIGH, "adapt", "help") //
+				helpEnv.opify(OpifyOp.class, Priority.HIGH, "engine.adapt", "help") //
 		);
 		// Make sure that only the "external" namespaces are visible
 		var actual = helpEnv.help();
 		String expected = "Namespaces:\n\t> help";
 		Assertions.assertEquals(expected, actual);
 		// ...but make sure that if we really need help with the internal namespace, we can get it
-		actual = helpEnv.help("adapt");
-		expected = "Ops:\n\t> adapt(\n\t\t Inputs:\n\t\t Outputs:\n\t\t\tString output1\n\t)\n\tAliases: [help]\n\t";
+		actual = helpEnv.help("engine.adapt");
+		expected = "Ops:\n\t> engine.adapt(\n\t\t Inputs:\n\t\t Outputs:\n\t\t\tString output1\n\t)\n\tAliases: [help]\n\t";
 		Assertions.assertEquals(expected, actual);
 	}
 

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/OpAdaptationPriorityTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/OpAdaptationPriorityTest.java
@@ -83,7 +83,7 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment implements
 		out.increasePriority(in);
 	};
 
-	@OpMethod(names = "adapt", type = Function.class, priority = Priority.HIGH)
+	@OpMethod(names = "engine.adapt", type = Function.class, priority = Priority.HIGH)
 	public static <I, O> Function<I, O> highPriorityAdaptor( //
 		@OpDependency(name = "create", adaptable = false) Function<I, O> creator, //
 		Computers.Arity1<I, O> computer //
@@ -95,7 +95,7 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment implements
 		};
 	}
 
-	@OpMethod(names = "adapt", type = Function.class, priority = Priority.LOW)
+	@OpMethod(names = "engine.adapt", type = Function.class, priority = Priority.LOW)
 	public static <I, O> Function<I, O> lowPriorityAdaptor( //
 		@OpDependency(name = "create", adaptable = false) Producer<O> creator, //
 		Computers.Arity1<I, O> computer //

--- a/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplificationPriorityTest.java
+++ b/scijava/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplificationPriorityTest.java
@@ -92,42 +92,42 @@ public class SimplificationPriorityTest extends AbstractTestEnvironment
 	}
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "simplify")
+	@OpField(names = "engine.simplify")
 	public final Function<FromThing, BasicThing> fromToBasic =
 		from -> new BasicThing();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<BasicThing, LosslessThing> basicToLossless =
 		basic -> new LosslessThing();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<BasicThing, SomewhatLossyThing> basicToSomewhat =
 		basic -> new SomewhatLossyThing();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<BasicThing, VeryLossyThing> basicToVery =
 		basic -> new VeryLossyThing();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "focus")
+	@OpField(names = "engine.focus")
 	public final Function<BasicThing, InconceivablyLossyThing> basicToInconceivable =
 		basic -> new InconceivablyLossyThing();
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<FromThing, LosslessThing> fromToLossless = (nil1,
 		nil2) -> 1.;
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<FromThing, SomewhatLossyThing> fromToSomewhat = (
 		nil1, nil2) -> 1e3;
 
 	@OpHints(hints = {Simplification.FORBIDDEN})
-	@OpField(names = "lossReporter")
+	@OpField(names = "engine.lossReporter")
 	public final LossReporter<FromThing, VeryLossyThing> fromToVery = (nil1,
 		nil2) -> 1e6;
 

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.vm
@@ -53,13 +53,13 @@ import org.scijava.priority.Priority;
 public class ComputersToFunctionsAndLift {
 
 #foreach($arity in [1..$maxArity])
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer${arity}ToFunction${arity}AndLiftViaSource$generics.call($arity)
 			implements Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)>, Op {
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$generics.call($arity)> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.vm
@@ -54,15 +54,15 @@ import org.scijava.priority.Priority;
 public class FunctionsToComputersAndLift {
 #foreach($arity in [1..$maxArity])
 
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Function${arity}ToComputer${arity}AndLiftAfter$generics.call($arity) implements
 		Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$generics.call($arity)> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$computerArity.call($arity)$generics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**
@@ -78,15 +78,15 @@ public class FunctionsToComputersAndLift {
 
 	}
 
-	@OpClass(names = "adapt", priority = Priority.LOW + 1)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW + 1)
 	public static class Function${arity}ToComputer${arity}AndLiftBefore$generics.call($arity) implements
 		Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)>,
 		Op
 	{
 
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionArity.call($arity)$iterableGenerics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)> adaptor;
-		@OpDependency(name = "adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", adaptable = false)
 		Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.vm
@@ -53,7 +53,7 @@ import org.scijava.ops.spi.OpClass;
 public class ComputersToFunctionsViaFunction {
 
 #foreach($arity in [1..$maxArity])
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Computer${arity}ToFunction${arity}ViaFunction$generics.call($arity)
 			implements Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$generics.call($arity)>,
 			Op

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.vm
@@ -55,7 +55,7 @@ import org.scijava.priority.Priority;
 public class ComputersToFunctionsViaSource {
 
 #foreach($arity in [0..$maxArity])
-	@OpClass(names = "adapt", priority = Priority.LOW)
+	@OpClass(names = "engine.adapt", priority = Priority.LOW)
 	public static class Computer${arity}ToFunction${arity}ViaSource$generics.call($arity)
 			implements Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$generics.call($arity)>, 
 			Op

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.vm
@@ -54,7 +54,7 @@ import org.scijava.ops.spi.OpClass;
 public class FunctionsToComputers {
 
 #foreach($arity in [0..$maxArity])
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Function${arity}ToComputer${arity}$generics.call($arity) implements Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$generics.call($arity)>, Op {
 
 		@OpDependency(name = "copy", adaptable = false)

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.vm
@@ -56,7 +56,7 @@ public class InplacesToFunctions$generics.call($classArity, $classArity) impleme
 
 #foreach($arity in [1..$maxArity])
 #foreach($a in [1..$arity])
-	@OpClass(names = "adapt")
+	@OpClass(names = "engine.adapt")
 	public static class Inplace$inplaceSuffix.call($arity, $a)ToFunction${arity}$generics.call($arity, $a) implements Function<$inplaceType.call($arity, $a)$generics.call($arity, $a), $functionArity.call($arity)$functionGenerics.call($arity, $a)>, Op {
 		
 		@OpDependency(name = "create", adaptable = false)

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/ComputerToArrays.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/ComputerToArrays.vm
@@ -56,7 +56,7 @@ public class ComputerToArrays$classGenerics.call($maxArity) implements OpCollect
 	}
 
 #foreach($arity in [0..$maxArity])
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<$computerArity.call($arity)$generics.call($arity), $computerArity.call($arity)$arrayGenerics.call($arity)> liftComputer$arity =
 		(computer) -> {
 			return ($computeArgs.call($arity)) -> {

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/ComputerToIterables.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/ComputerToIterables.vm
@@ -52,7 +52,7 @@ import org.scijava.ops.spi.OpCollection;
 public class ComputerToIterables$classGenerics.call($maxArity) implements OpCollection {
 
 #foreach($arity in [0..$maxArity])
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<$computerArity.call($arity)$generics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)> liftComputer$arity = 
 		(computer) -> {
 			return ($computeArgs.call($arity)) -> {

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/FunctionToArrays.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/FunctionToArrays.vm
@@ -66,7 +66,7 @@ public class FunctionToArrays$classGenerics.call($maxArity) implements OpCollect
 	// length of the output array
 
 #foreach($arity in [1..$maxArity])
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$arrayGenerics.call($arity)> liftFunction$arity =
 		(function) -> {
 			return ($applyArgs.call($arity)) -> {

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/FunctionToIterables.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/FunctionToIterables.vm
@@ -59,7 +59,7 @@ public class FunctionToIterables$classGenerics.call($maxArity) implements OpColl
 
 #foreach($arity in [1..$maxArity])
 	@SuppressWarnings("unchecked")
-	@OpField(names = "adapt")
+	@OpField(names = "engine.adapt")
 	public final Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)> liftFunction$arity =
 		(function) -> {
 			return ($iteratorInputs.call($arity)) -> lazyIterable(itrs -> function.apply(${funcItrsNext.call($arity)}), $iteratorInputs.call($arity));

--- a/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/InplaceToArrays.vm
+++ b/scijava/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/lift/InplaceToArrays.vm
@@ -59,7 +59,7 @@ public class InplaceToArrays$classGenerics.call($maxArity) implements OpCollecti
 	
 #foreach($arity in [1..$maxArity])
 #foreach($a in [1..$arity])
-	@OpField(names = "adapt", params = "fromOp, toOp")
+	@OpField(names = "engine.adapt", params = "fromOp, toOp")
 	public final Function<$inplaceType.call($arity, $a)$generics.call($arity, $a), $inplaceType.call($arity, $a)$arrayGenerics.call($arity, $a)> liftInplace$inplaceSuffix.call($arity, $a) =
 		(inplace) -> {
 			return ($mutateParams.call($arity, $a)) -> {


### PR DESCRIPTION
This PR adds the minimal changes required to hide a set of "internal" Op namespaces from broad `OpEnvironment.help` queries. Note that if you actually search for the namespace, relevant Ops will show up.

Currently, we hide 4 different namespaces:
* `adapt`
* `simplify`
* `focus`
* `lossReporter`

@ctrueden @hinerm please let me know if you are satisfied with these changes. We may have to extend this work in the case that (a) we want this behavior in a DRY way across multiple `OpDescriptionGenerator`s, or (b) we have a hidden namespace that "contains" Ops with a different name - i.e. we want to create some `adapt.foo` Op.

Closes scijava/scijava#168