### PR TITLE
Add enclosing element in Method parsing errors

### DIFF
--- a/scijava/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/OpMethodImplData.java
+++ b/scijava/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/OpMethodImplData.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.NoType;
@@ -104,9 +105,13 @@ public class OpMethodImplData extends OpImplData {
 		if (opDependencies.size() + params.size() != exSource
 				.getParameters().size())
 		{
-			env.getMessager().printMessage(Diagnostic.Kind.ERROR,
+			var clsElement = exSource.getEnclosingElement();
+			while (clsElement.getKind() != ElementKind.CLASS) {
+				clsElement = clsElement.getEnclosingElement();
+			}
+			env.getMessager().printMessage(Diagnostic.Kind.ERROR, clsElement + " - " +
 					"The number of @param tags on " + exSource +
-							" does not match the number of parameters!");
+					" does not match the number of parameters!");
 		}
 
 		// Finally, parse the return
@@ -125,8 +130,12 @@ public class OpMethodImplData extends OpImplData {
 		}
 		// Validate number of outputs
 		if (!(exSource.getReturnType() instanceof NoType) && returnTag.isEmpty()) {
-			env.getMessager().printMessage(Diagnostic.Kind.ERROR, exSource +
-				" has a return, but no @return parameter");
+			var clsElement = exSource.getEnclosingElement();
+			while (clsElement.getKind() != ElementKind.CLASS) {
+				clsElement = clsElement.getEnclosingElement();
+			}
+			env.getMessager().printMessage(Diagnostic.Kind.ERROR, clsElement + " - " + exSource +
+					" has a return, but no @return parameter");
 		}
 	}
 


### PR DESCRIPTION
I was trying to clean up the [`ops-annotation`](https://github.com/imglib/imglib2-algorithm/tree/ops-annotations) branch of imglib2-algorithm, and I found that `scijava-ops-indexer`'s errors are really confusing when you don't know the library very well:
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] error: The number of @param tags on convolution(net.imglib2.algorithm.convolution.kernel.Kernel1D...) does not match the number of parameters!
[ERROR] error: convolution(net.imglib2.algorithm.convolution.kernel.Kernel1D...) has a return, but no @return parameter
[ERROR] error: The number of @param tags on convolution1d(net.imglib2.algorithm.convolution.kernel.Kernel1D,int) does not match the number of parameters!
[ERROR] error: convolution1d(net.imglib2.algorithm.convolution.kernel.Kernel1D,int) has a return, but no @return parameter
[ERROR] error: symmetric(double...) has a return, but no @return parameter
[ERROR] error: asymmetric(double[],int) has a return, but no @return parameter
[ERROR] error: periodicLine(long,int[]) has a return, but no @return parameter
[INFO] 7 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.784 s
[INFO] Finished at: 2023-12-20T15:00:14-06:00
[INFO] ------------------------------------------------------------------------
```
To aid users in finding these errors, I added the enclosing element to the printout, which now reads:
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution: The number of @param tags on convolution(net.imglib2.algorithm.convolution.kernel.Kernel1D...) does not match the number of parameters!
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution: convolution(net.imglib2.algorithm.convolution.kernel.Kernel1D...) has a return, but no @return parameter
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution: The number of @param tags on convolution1d(net.imglib2.algorithm.convolution.kernel.Kernel1D,int) does not match the number of parameters!
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.SeparableKernelConvolution: convolution1d(net.imglib2.algorithm.convolution.kernel.Kernel1D,int) has a return, but no @return parameter
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.Kernel1D: symmetric(double...) has a return, but no @return parameter
[ERROR] error: Error parsing net.imglib2.algorithm.convolution.kernel.Kernel1D: asymmetric(double[],int) has a return, but no @return parameter
[ERROR] error: Error parsing net.imglib2.algorithm.morphology.StructuringElements: periodicLine(long,int[]) has a return, but no @return parameter
[INFO] 7 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.856 s
[INFO] Finished at: 2023-12-20T15:41:41-06:00
[INFO] ------------------------------------------------------------------------
```