### PR TITLE
Target Java 8 for the Op Indexer

### DIFF
--- a/scijava/scijava-ops-indexer/pom.xml
+++ b/scijava/scijava-ops-indexer/pom.xml
@@ -96,8 +96,7 @@
 
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>SciJava developers.</license.copyrightOwners>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<scijava.jvm.build.version>[11,)</scijava.jvm.build.version>
 	</properties>
 	<dependencies>
 		<!-- Third party dependencies -->

--- a/scijava/scijava-ops-indexer/pom.xml
+++ b/scijava/scijava-ops-indexer/pom.xml
@@ -96,6 +96,8 @@
 
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>SciJava developers.</license.copyrightOwners>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<!-- Third party dependencies -->


### PR DESCRIPTION
This will allow us to index libraries written in Java 8+, including imglib2-algorithm!