### PR TITLE
Refactor OpEnvironment creation

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
@@ -32,7 +32,6 @@ package org.scijava.ops.api;
 import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.SortedSet;
 
 import org.scijava.discovery.Discoverer;
@@ -63,7 +62,7 @@ import org.scijava.types.Nil;
  */
 public interface OpEnvironment extends Prioritized<OpEnvironment> {
 
-	static OpEnvironment getBareEnvironment() {
+	static OpEnvironment buildEmpty() {
 		Optional<OpEnvironment> opsOptional = Discoverer //
 				.using(ServiceLoader::load) //
 				.discoverMax(OpEnvironment.class);
@@ -72,15 +71,9 @@ public interface OpEnvironment extends Prioritized<OpEnvironment> {
 		);
 	}
 
-	static OpEnvironment getEnvironment() {
-		OpEnvironment ops = getBareEnvironment();
+	static OpEnvironment build() {
+		OpEnvironment ops = buildEmpty();
 		ops.discoverEverything();
-		return ops;
-	}
-
-	static OpEnvironment getEnvironment(Discoverer... discoverers) {
-		OpEnvironment ops = getBareEnvironment();
-		ops.discoverUsing(discoverers);
 		return ops;
 	}
 

--- a/scijava-ops-benchmarks/src/main/java/org/scijava/ops/benchmarks/PerformanceBenchmark.java
+++ b/scijava-ops-benchmarks/src/main/java/org/scijava/ops/benchmarks/PerformanceBenchmark.java
@@ -39,7 +39,7 @@ public class PerformanceBenchmark {
 	 * </p>
 	 */
 	private final List< Map< String, Long > > results = new ArrayList<>();
-	private final OpEnvironment env = OpEnvironment.getEnvironment();
+	private final OpEnvironment env = OpEnvironment.build();
 
 	private final OpService ops;
 

--- a/scijava-ops-engine/src/it/test-ops-api/src/main/java/OpsAPITest.java
+++ b/scijava-ops-engine/src/it/test-ops-api/src/main/java/OpsAPITest.java
@@ -41,14 +41,14 @@ import org.scijava.ops.api.OpMatchingException;
 public class OpsAPITest {
 
 	public static void testOpEnvironmentObtainable() {
-		Assertions.assertNotNull(OpEnvironment.getEnvironment());
+		Assertions.assertNotNull(OpEnvironment.build());
 	}
 
 	/**
 	 * Tests that an Op can be matched and run
 	 */
 	public static void testOpExecutions() {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		var sum = ops.op("math.add").arity2().input(5., 6.).apply();
 		Assertions.assertEquals(sum, 11.);
 	}
@@ -57,7 +57,7 @@ public class OpsAPITest {
 	 * Tests that descriptions can be obtained
 	 */
 	public static void testOpHelp() {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		var descriptions = ops.help("math.add");
 		Assertions.assertInstanceOf(String.class, descriptions);
 	}
@@ -68,7 +68,7 @@ public class OpsAPITest {
 	public static void testOpHints() {
 		long in = 5;
 		long exponent = 5;
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// Assert there are no "math.pow" Ops that deal with longs
 		var help = ops.help("math.pow");
 		Assertions.assertNotEquals("No Ops found matching this request.", help,

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/AbstractTestEnvironment.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/AbstractTestEnvironment.java
@@ -82,7 +82,9 @@ public abstract class AbstractTestEnvironment {
 			OpInfo.class, //
 			OpCollection.class //
 		);
-		return OpEnvironment.getEnvironment(serviceLoading);
+		var ops =  OpEnvironment.buildEmpty();
+		ops.discoverUsing(serviceLoading);
+		return ops;
 	}
 
 	protected static boolean arrayEquals(double[] arr1, Double... arr2) {

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/OpCachingTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/OpCachingTest.java
@@ -74,7 +74,8 @@ public class OpCachingTest implements OpCollection {
 		discoverer.register(new OpCachingTest());
 		discoverer.register(new ComplicatedOp());
 
-		ops = OpEnvironment.getEnvironment(serviceLoading, discoverer);
+		ops = OpEnvironment.buildEmpty();
+		ops.discoverUsing(serviceLoading, discoverer);
 	}
 
 	/**

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/AbstractOpTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/AbstractOpTest.java
@@ -61,7 +61,7 @@ import net.imglib2.view.Views;
  */
 public abstract class AbstractOpTest{
 
-	protected static final OpEnvironment ops = OpEnvironment.getEnvironment();
+	protected static final OpEnvironment ops = OpEnvironment.build();
 
 
 	private int seed;

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/OpRegressionTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/OpRegressionTest.java
@@ -38,7 +38,7 @@ import org.scijava.ops.api.OpInfo;
 
 public class OpRegressionTest {
 
-	protected static final OpEnvironment ops = OpEnvironment.getEnvironment();
+	protected static final OpEnvironment ops = OpEnvironment.build();
 
 	@Test
 	public void opDiscoveryRegressionIT() {

--- a/scijava-ops-tutorial/notebooks/SciJavaOps.ipynb
+++ b/scijava-ops-tutorial/notebooks/SciJavaOps.ipynb
@@ -110,7 +110,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a407bbd5bb8d46d49c8d15074bed83cc",
+       "model_id": "15c2f974522f4be8aa3676ff190ac9d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -160,26 +160,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "16b9a5a7",
+   "execution_count": 6,
+   "id": "98bcc69d-0fb8-4e46-af83-8c7b1a9ef272",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "No matching overloads found for *static* org.scijava.discovery.Discoverer.all(), options are:\n\tpublic static java.util.List org.scijava.discovery.Discoverer.all(java.util.function.Function)\n\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[10], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m Discoverer \u001b[38;5;241m=\u001b[39m jimport(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124morg.scijava.discovery.Discoverer\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m----> 2\u001b[0m \u001b[43mDiscoverer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mall\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[0;31mTypeError\u001b[0m: No matching overloads found for *static* org.scijava.discovery.Discoverer.all(), options are:\n\tpublic static java.util.List org.scijava.discovery.Discoverer.all(java.util.function.Function)\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "Discoverer = jimport('org.scijava.discovery.Discoverer')\n",
-    "Discoverer.\n",
-    "Discoverer.all()"
+    "mean = ops.create.img(img)"
    ]
   },
   {
@@ -195,19 +181,7 @@
    "execution_count": 7,
    "id": "27a20cce",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'OpGateway' object has no attribute 'filter'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mops\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilter\u001b[49m\u001b[38;5;241m.\u001b[39mmean(img, Rect(\u001b[38;5;241m5\u001b[39m, \u001b[38;5;28;01mFalse\u001b[39;00m), OOBFactory(), out\u001b[38;5;241m=\u001b[39mmean)\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'OpGateway' object has no attribute 'filter'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ops.filter.mean(img, Rect(5, False), OOBFactory(), out=mean)"
    ]
@@ -222,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b3ec2b8f",
    "metadata": {},
    "outputs": [],
@@ -240,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "5ebe3002",
    "metadata": {},
    "outputs": [],
@@ -258,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "40d83e49",
    "metadata": {},
    "outputs": [],

--- a/scijava-ops-tutorial/notebooks/gateways.py
+++ b/scijava-ops-tutorial/notebooks/gateways.py
@@ -14,7 +14,7 @@ Variables:
 from scyjava import jimport
 from types import MethodType
 OpEnvironment = jimport('org.scijava.ops.api.OpEnvironment')
-env = OpEnvironment.getEnvironment()
+env = OpEnvironment.build()
 
 op_names={str(name) for info in env.infos() for name in info.names()}
 
@@ -28,7 +28,7 @@ class OpNamespace:
 
     def help(self, op_name=None):
         '''
-        Convenience wrapper for OpEnvironment.description(), for information about available ops. Prints all returned information, line-by-line.
+        Convenience wrapper for OpEnvironment.help(), for information about available ops. Prints all returned information, line-by-line.
         '''
         print(*self.env.help(op_name), sep = "\n")
 

--- a/scijava-ops-tutorial/scripts/gateways.py
+++ b/scijava-ops-tutorial/scripts/gateways.py
@@ -14,7 +14,7 @@ Variables:
 from scyjava import jimport
 from types import MethodType
 OpEnvironment = jimport('org.scijava.ops.api.OpEnvironment')
-env = OpEnvironment.getEnvironment()
+env = OpEnvironment.build()
 
 op_names={str(name) for info in env.infos() for name in info.names()}
 
@@ -28,9 +28,9 @@ class OpNamespace:
 
     def help(self, op_name=None):
         '''
-        Convenience wrapper for OpEnvironment.description(), for information about available ops. Prints all returned information, line-by-line.
+        Convenience wrapper for OpEnvironment.help(), for information about available ops. Prints all returned information, line-by-line.
         '''
-        print(*self.env.descriptions(op_name), sep = "\n")
+        print(*self.env.help(op_name), sep = "\n")
 
 class OpGateway(OpNamespace):
     '''

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpAdaptation.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpAdaptation.java
@@ -65,7 +65,7 @@ public class OpAdaptation implements OpCollection {
 
 	public static void main(String... args) {
 		// Create the OpEnvironment
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// Call the Op on some inputs
 		Double[] firstArray = new Double[] { 1., 2., 3. };
 		Double[] secondArray = new Double[] { 1., 2., 3. };

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpBuilder.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpBuilder.java
@@ -43,7 +43,7 @@ public class OpBuilder {
 
 	public static void main(String... args) {
 		// All Ops calls start from an OpEnvironment. This environment determines the available Ops.
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		/*
 		To run an Op we have to match it. Ops themselves have a name, some number of inputs, and potentially an output

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpDependencies.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpDependencies.java
@@ -47,7 +47,7 @@ public class OpDependencies implements OpCollection {
 	}
 
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// The mean of this array is 3.0
 		double[] arr = {1.0, 2.0, 3.0, 4.0, 5.0};
 

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpParallelization.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpParallelization.java
@@ -87,7 +87,7 @@ public class OpParallelization implements OpCollection {
 	}
 
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		// First, we show parallelization at work for our per-pixel Op.
 		// SciJava Ops understands how to apply that Op to each pixel of the input

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpPriorities.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpPriorities.java
@@ -73,7 +73,7 @@ public class OpPriorities implements OpCollection {
 	 * something else.
 	 */
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// Say we have a Collection of numbers
 		var ourNumbers = Arrays.asList(4, 8, 2, 3);
 

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpReduction.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpReduction.java
@@ -92,7 +92,7 @@ public class OpReduction implements OpCollection {
 
 	public static void main(String... args) {
 		// Create the OpEnvironment
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		// Define some data
 		Double first = 1.;

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpSimplification.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpSimplification.java
@@ -70,7 +70,7 @@ public class OpSimplification implements OpCollection {
 
 	public static void main(String... args) {
 		// Create the OpEnvironment
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// Call the Op on some inputs
 		Integer first = 1;
 		Integer second = 2;

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpTypes.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpTypes.java
@@ -57,7 +57,7 @@ public class OpTypes {
 		
 		We will showcase each of the types below.
 		 */
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		/**
 		 * The most basic category of Ops are Functions.

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpsIntro.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/OpsIntro.java
@@ -35,7 +35,6 @@ import org.scijava.types.Nil;
 import io.scif.img.ImgOpener;
 import net.imglib2.algorithm.neighborhood.RectangleShape;
 import net.imglib2.img.Img;
-import net.imglib2.outofbounds.OutOfBoundsBorderFactory;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
@@ -70,7 +69,7 @@ public class OpsIntro {
 		The easiest way to obtain an OpEnvironment is to use the following static
 		method.
 		*/
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		/*
 		OpEnvironments contain Ops, and there are a lot of them.

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/ParallelComputation.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/ParallelComputation.java
@@ -52,7 +52,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 public class ParallelComputation {
 
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 		// To compute tasks using Parallelization, we must first gather a list of
 		// parameters.
 		List<Double> fillValues = Arrays.asList(1.0, 2.0, 3.0, 4.0);

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/ReportingProgress.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/ReportingProgress.java
@@ -114,7 +114,7 @@ public class ReportingProgress implements OpCollection {
 	};
 
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		// ProgressListeners consume task updates.
 		// This ProgressListener simply logs to standard output, but we could print

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/UsingNils.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/UsingNils.java
@@ -40,7 +40,7 @@ public class UsingNils implements OpCollection {
 		() -> ArrayImgs.doubles(10, 10);
 
 	public static void main(String... args) {
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		// The following is the syntax used to create a Nil that encodes the type we
 		// want. Namely, if we want to ensure that the return is an Img<DoubleType>,

--- a/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/WritingOpCollections.java
+++ b/scijava-ops-tutorial/src/main/java/org/scijava/ops/tutorial/WritingOpCollections.java
@@ -80,7 +80,7 @@ public class WritingOpCollections implements OpCollection {
 	}
 
 	public static void main(String... args){
-		OpEnvironment ops = OpEnvironment.getEnvironment();
+		OpEnvironment ops = OpEnvironment.build();
 
 		Double result = ops.binary("test.opField.power") //
 				.input(2.0, 10.0) //


### PR DESCRIPTION
The existing static `OpEnvironment` constructors had some overlap, which caused problems from languages like Python. The API refactoring in this PR, described in scijava/scijava#175, avoids the overlap and makes the Jupyter Notebook work again.

Closes scijava/scijava#175