### PR TITLE
Uniform Noise Adder using LoopBuilder

### DIFF
--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/OpRegressionTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/OpRegressionTest.java
@@ -42,7 +42,7 @@ public class OpRegressionTest {
 
 	@Test
 	public void opDiscoveryRegressionIT() {
-		long expected = 1882;
+		long expected = 1884;
 		long actual = ops.infos().size();
 		assertEquals(expected, actual);
 	}

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/filter/addNoise/NoiseAddersTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/filter/addNoise/NoiseAddersTest.java
@@ -1,0 +1,29 @@
+package org.scijava.ops.image.filter.addNoise;
+
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.scijava.ops.image.AbstractOpTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class NoiseAddersTest extends AbstractOpTest {
+
+    @Test
+    public void testAddUniformNoiseRegression() {
+        var input = ArrayImgs.bytes(2, 2);
+        ops.unary("image.fill").input(new ByteType((byte) 1)).output(input).compute();
+        var output = ArrayImgs.bytes(2, 2);
+        var rangeMin = new ByteType((byte) -1);
+        var rangeMax = new ByteType((byte) 1);
+        ops.ternary("filter.addUniformNoise").input(input, rangeMin, rangeMax).output(output).compute();
+        var cursor = output.cursor();
+        List<Byte> expected = Arrays.asList((byte) 0, (byte) 2, (byte) 1, (byte) 1);
+        for(var e : expected) {
+            Assertions.assertEquals(e, cursor.next().get());
+        }
+        Assertions.assertFalse(cursor.hasNext());
+    }
+}


### PR DESCRIPTION
This work is a quick cleanup of a stale branch adding a uniform noise Op, as well as a simple regression test. Some points on design decisions:

* Unlike the design implemented in imagej/imagej-ops#554, this Op runs on `RandomAccessibleInterval`s and makes use of the `LoopBuilder` construct. For simplicity, computation is performed sequentially - I didn't see a clear pathway to run this in a multithreaded way, because we'd have to (a) use a thread-safe RNG object, which would be slower, and I didn't bother figuring out whether it would be worth it, or (b) create a `MersenneTwisterFast` per chunk, which is tricky because as far as I can tell `Chunk`s give you no discernible state that we could use to seed each `MersenneTwisterFast` differently. 
* This Op takes no stance on overflow behavior - it's left up to the `RealType` how out-of-bounds values are handled. There are also situations where we may have lossy behavior - for example, if the range provided is very large - but I think that's a hard problem to solve anyways.

I honestly think this is a pretty low-priority solve - but at the very least, we've moved broken code from a stale branch to a PR that could be closed without losing anything important.