### PR TITLE
Provide more helpful Op matching exceptions

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
@@ -71,17 +71,24 @@ public class DefaultOpMatcher implements OpMatcher {
 		}
 
 		// in the case of no matches, throw an agglomerated exception
-		throw agglomeratedException(exceptions);
+		throw agglomeratedException(conditions.request(), exceptions, env);
 	}
 
-	private OpMatchingException agglomeratedException(
-		List<OpMatchingException> list)
-	{
-		OpMatchingException agglomerated = new OpMatchingException(
-			"No MatchingRoutine was able to produce a match!");
-		for (int i = 0; i < list.size(); i++) {
-			agglomerated.addSuppressed(list.get(i));
+	private OpMatchingException agglomeratedException( //
+		final OpRequest request, //
+		final List<OpMatchingException> list, //
+		final OpEnvironment env //
+	) {
+		// Develop help message
+		var msg = "No match found!";
+		try {
+			// TODO: Remove try/catch.
+			msg += " Perhaps you meant: \n" + env.help(request);
+		} catch (StackOverflowError e) {
+			// No-op
 		}
+        OpMatchingException agglomerated = new OpMatchingException(msg);
+		list.forEach(agglomerated::addSuppressed);
 		return agglomerated;
 	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
@@ -80,14 +80,8 @@ public class DefaultOpMatcher implements OpMatcher {
 		final OpEnvironment env //
 	) {
 		// Develop help message
-		var msg = "No match found!";
-		try {
-			// TODO: Remove try/catch.
-			msg += " Perhaps you meant: \n" + env.help(request);
-		} catch (StackOverflowError e) {
-			// No-op
-		}
-        OpMatchingException agglomerated = new OpMatchingException(msg);
+		var msg = "No match found! Perhaps you meant: \n" + env.help(request);
+		OpMatchingException agglomerated = new OpMatchingException(msg);
 		list.forEach(agglomerated::addSuppressed);
 		return agglomerated;
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
@@ -205,7 +205,7 @@ public final class SimplificationUtils {
 			.opType()));
 		if (ioIndex > -1) {
 			var nil = Nil.of(outType(info.outputType(), outSimplifier));
-			var copier = env.unary("engine.copy").inType(nil).outType(nil).computer();
+			var copier = env.unary("engine.copy", h).inType(nil).outType(nil).computer();
 			copyOp = org.scijava.ops.api.Ops.rich(copier);
 		}
 		return new SimplifiedOpInfo(info, inFocusers, outSimplifier, copyOp);

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/OpMatchingExceptionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/OpMatchingExceptionTest.java
@@ -80,7 +80,7 @@ public class OpMatchingExceptionTest extends AbstractTestEnvironment implements 
 		}
 		catch (OpMatchingException e) {
 			Assertions.assertTrue(e.getMessage().startsWith(
-				"No MatchingRoutine was able to produce a match!"));
+				"No match found!"));
 			Assertions.assertTrue(Arrays.stream(e.getSuppressed()).anyMatch(s -> s
 				.getMessage().startsWith("Multiple 'test.duplicateOp/" +
 					"java.util.function.Function<java.lang.Double, java.lang.Double>' " +


### PR DESCRIPTION
This PR leans on the new `OpEnvironment.help()` API to enable more helpful `OpMatchingException`s.

This means that if the following Op call does not match:
```java
		var list = ops.binary("math.add").input(List.of(5.0), List.of(6.0)).apply();
```

You will now get an error like:
```java
org.scijava.ops.api.OpMatchingException: No match found! Perhaps you meant:
Ops:
	> math.add(
		 Inputs:
			Double input1
			Double input2
		 Outputs:
			Double output1
	)
	
	> math.add(
		 Inputs:
			Number input1
			Number input2
		 Outputs:
			Double output1
	)
	

	at org.scijava.ops.engine/org.scijava.ops.engine.matcher.impl.DefaultOpMatcher.agglomeratedException(DefaultOpMatcher.java:83)
	at org.scijava.ops.engine/org.scijava.ops.engine.matcher.impl.DefaultOpMatcher.match(DefaultOpMatcher.java:74)
	at ...
```
Of course, this output will change with #113, and we might want to make further alterations to the help functionality.

EDIT: Unfortunately, in SciJava Ops Image this change is being bitten by scijava/scijava#176, which means that the build increases by 2 minutes (because of one test file!). For now I'm going to try/catch this issue.