### PR TITLE
Tweak symbols in Op Descriptions

### DIFF
--- a/docs/ops/doc/SearchingForOps.md
+++ b/docs/ops/doc/SearchingForOps.md
@@ -2,7 +2,7 @@
 
 As the `OpEnvironment` is fully extensible, different `OpEnvironment`s might contain different Ops, and it is important to be able to query an `OpEnvironment` about the available Ops.
 
-The `OpEnvironment.help()` API allows you to query an `OpEnvironment` about the types of Ops it contains, as we show in the following sections: 
+The `OpEnvironment.help()` API allows you to query an `OpEnvironment` about the types of Ops it contains, as we show in the following sections. **Note that the example printouts from the help API may not reflect the Ops available in *your* Op environment**. 
 
 ## Searching for operations
 
@@ -19,37 +19,25 @@ This gives the following printout:
 
 ```
 Namespaces:
-	> adapt
 	> coloc
 	> convert
 	> copy
-	> cp
 	> create
 	> deconvolve
-	> eval
+	> expression
 	> features
 	> filter
-	> focus
 	> geom
-	> identify
-	> identity
 	> image
 	> imageMoments
 	> labeling
 	> linalg
 	> logic
-	> lossReporter
 	> map
 	> math
 	> morphology
-	> project
 	> segment
-	> simplify
-	> slice
-	> source
-	> src
 	> stats
-	> test
 	> thread
 	> threshold
 	> topology
@@ -70,10 +58,11 @@ print(ops.help("filter"))
 This gives the following printout:
 
 ```
-Namespaces:
+Names:
 	> filter.DoG
 	> filter.addNoise
 	> filter.addPoissonNoise
+	> filter.addUniformNoise
 	> filter.applyCenterAware
 	> filter.bilateral
 	> filter.convolve
@@ -119,44 +108,11 @@ print(ops.help("filter.gauss"))
 ```
 
 ```
-Ops:
-	> filter.gauss(
-		 Inputs:
-			RandomAccessibleInterval<NumericType> null -> the input image
-			ObjectArray<Number> null -> the sigmas for the gaussian
-		 Containers (I/O):
-			RandomAccessibleInterval<NumericType> container1 -> the output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			RandomAccessibleInterval<NumericType> null -> the input image
-			ObjectArray<Number> null -> the sigmas for the gaussian
-			OutOfBoundsFactory<NumericType, RandomAccessibleInterval<NumericType>> null? -> the {@link OutOfBoundsFactory} that defines how the
-	          calculation is affected outside the input bounds. (required =
-	          false)
-		 Containers (I/O):
-			RandomAccessibleInterval<NumericType> container1 -> the output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			RandomAccessibleInterval<NumericType> null -> the input image
-			Number null -> the sigmas for the Gaussian
-		 Containers (I/O):
-			RandomAccessibleInterval<NumericType> container1 -> the preallocated output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			RandomAccessibleInterval<NumericType> null -> the input image
-			Number null -> the sigmas for the Gaussian
-			OutOfBoundsFactory<NumericType, RandomAccessibleInterval<NumericType>> null? -> the {@link OutOfBoundsFactory} that defines how the
-	          calculation is affected outside the input bounds. (required =
-	          false)
-		 Containers (I/O):
-			RandomAccessibleInterval<NumericType> container1 -> the preallocated output image
-	)
+filter.gauss:
+	- (input, sigmas, @CONTAINER container1) -> None
+	- (input, sigmas, outOfBounds = null, @CONTAINER container1) -> None
+	- (input, sigma, @CONTAINER container1) -> None
+	- (input, sigma, outOfBounds = null, @CONTAINER container1) -> None
 ```
 
 Note that these descriptions are simple, and you can obtain more verbose descriptions by instead using the method `OpEnvironment.helpVerbose()`:
@@ -169,43 +125,25 @@ print(ops.helpVerbose("filter.gauss"))
 ```
 
 ```
-Ops:
-	> filter.gauss(
-		 Inputs:
-			net.imglib2.RandomAccessibleInterval<I> null -> the input image
-			double[] null -> the sigmas for the gaussian
-			net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>> null? -> the {@link OutOfBoundsFactory} that defines how the
-	          calculation is affected outside the input bounds. (required =
-	          false)
-		 Containers (I/O):
-			net.imglib2.RandomAccessibleInterval<O> container1 -> the output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			net.imglib2.RandomAccessibleInterval<I> null -> the input image
-			double[] null -> the sigmas for the gaussian
-		 Containers (I/O):
-			net.imglib2.RandomAccessibleInterval<O> container1 -> the output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			net.imglib2.RandomAccessibleInterval<I> null -> the input image
-			java.lang.Double null -> the sigmas for the Gaussian
-			net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>> null? -> the {@link OutOfBoundsFactory} that defines how the
-	          calculation is affected outside the input bounds. (required =
-	          false)
-		 Containers (I/O):
-			net.imglib2.RandomAccessibleInterval<O> container1 -> the preallocated output image
-	)
-	
-	> filter.gauss(
-		 Inputs:
-			net.imglib2.RandomAccessibleInterval<I> null -> the input image
-			java.lang.Double null -> the sigmas for the Gaussian
-		 Containers (I/O):
-			net.imglib2.RandomAccessibleInterval<O> container1 -> the preallocated output image
-	)
-
+filter.gauss:
+	- org.scijava.ops.image.filter.gauss.Gaussians.defaultGaussRAI(net.imglib2.RandomAccessibleInterval<I>,double[],net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>>,net.imglib2.RandomAccessibleInterval<O>)
+		> input : net.imglib2.RandomAccessibleInterval<I>
+			the input image
+		> sigmas : double[]
+			the sigmas for the gaussian
+		> outOfBounds (optional) : net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>>
+			the {@link OutOfBoundsFactory} that defines how the
+			calculation is affected outside the input bounds.
+		> container1 : @CONTAINER net.imglib2.RandomAccessibleInterval<O>
+			the output image
+	- org.scijava.ops.image.filter.gauss.Gaussians.gaussRAISingleSigma(net.imglib2.RandomAccessibleInterval<I>,double,net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>>,net.imglib2.RandomAccessibleInterval<O>)
+		> input : net.imglib2.RandomAccessibleInterval<I>
+			the input image
+		> sigma : java.lang.Double
+			the sigmas for the Gaussian
+		> outOfBounds (optional) : net.imglib2.outofbounds.OutOfBoundsFactory<I, net.imglib2.RandomAccessibleInterval<I>>
+			the {@link OutOfBoundsFactory} that defines how the
+			calculation is affected outside the input bounds.
+		> container1 : @CONTAINER net.imglib2.RandomAccessibleInterval<O>
+			the preallocated output image
 ```

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/InfoTree.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/InfoTree.java
@@ -61,6 +61,8 @@ public class InfoTree {
 	public static final Character DEP_START_DELIM = '{';
 	public static final Character DEP_END_DELIM = '}';
 
+	public static final String DEPENDENCY_DELIM = "\n\tDepends upon: ";
+
 	private final List<InfoTree> dependencies;
 	private String id;
 
@@ -134,6 +136,15 @@ public class InfoTree {
 			s = s.concat(dependency.signature());
 		}
 		id = s.concat(String.valueOf(DEP_END_DELIM));
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder(info().implementationName());
+		for (var dep: dependencies()) {
+			sb.append(DEPENDENCY_DELIM).append(dep.toString().replace("\n", "\n\t"));
+		}
+		return sb.toString();
 	}
 
 }

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInstance.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInstance.java
@@ -93,7 +93,7 @@ public class OpInstance<T> implements GenericTyped {
 
 	@Override
 	public String toString() {
-		return infoTree().info().implementationName();
+		return infoTree().info().toString();
 	}
 
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/MatchingResult.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/MatchingResult.java
@@ -147,7 +147,7 @@ public class MatchingResult {
 		int count = 0;
 		for (final OpCandidate candidate : candidates) {
 			sb.append(++count + ". ");
-			sb.append("\t" + Infos.describeVerbose(candidate.opInfo(), candidate.getStatusItem()) + "\n");
+			sb.append("\t" + Infos.describeVerbose(candidate.opInfo()) + "\n");
 			final String status = candidate.getStatus();
 			if (status != null)
 				sb.append("\t" + status + "\n");

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfo.java
@@ -172,6 +172,16 @@ public class OpAdaptationInfo implements OpInfo {
 
 	@Override
 	public String toString() {
-		return Infos.describeVerbose(this);
+		// Get the original description
+		String description = Infos.describeVerbose(this);
+		// Make the name friendlier
+		StringBuilder sb = new StringBuilder();
+		sb.append(srcInfo.implementationName());
+		sb.append("\n\tAdaptor: ");
+		sb.append(adaptorChain.toString().replace("\n", "\n\t"));
+
+		int nameBreak = description.indexOf('\n');
+		sb.append(description.substring(nameBreak));
+		return sb.toString();
 	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
@@ -63,7 +63,7 @@ public class SimplifiedOpDescriptionGenerator implements
 		Optional<String> nsString = getNonOpString(env, name);
 		if (nsString.isPresent()) return nsString.get();
 		var infos = SimplificationMatchingRoutine.getInfos(env, name);
-		return buildOpString(infos, req, Infos::describeOneLine);
+		return buildOpString(infos, req, Infos::describe);
 	}
 
 	@Override
@@ -72,7 +72,7 @@ public class SimplifiedOpDescriptionGenerator implements
 		Optional<String> nsString = getNonOpString(env, name);
 		if (nsString.isPresent()) return nsString.get();
 		var infos = env.infos(name);
-		return buildOpString(infos, req, Infos::describeMultiLine);
+		return buildOpString(infos, req, Infos::describeVerbose);
 	}
 
 	private String buildOpString(Collection<OpInfo> infos, OpRequest req,

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpDescriptionGenerator.java
@@ -85,8 +85,7 @@ public class SimplifiedOpDescriptionGenerator implements
 				.distinct() //
 				.collect(Collectors.joining("\n\t- "));
 		if (opString.isEmpty()) return "No Ops found matching this request.";
-		var key = "Key: *=container, ^=mutable";
-		return req.getName() + ":\n\t- " + opString + "\n" + key;
+		return req.getName() + ":\n\t- " + opString;
 	}
 
 	/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
@@ -32,7 +32,6 @@ package org.scijava.ops.engine.util;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -138,147 +137,12 @@ public final class Infos {
 			.collect(Collectors.toList());
 	}
 
-
 	/**
-	 * Generates a {@link String} describing the given {@link OpInfo}
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describe(final OpInfo info) {
-		return describe(info, null, null);
-	}
-
-	/**
-	 * Generates a {@link String} describing the given {@link OpInfo}
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param name the name that the Op was searched by
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describe(final OpInfo info, final String name) {
-		return describe(info, name, null);
-	}
-
-	/**
-	 * Generates a verbose {@link String} describing the given {@link OpInfo}
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @return a descriptor for {@code info}
+	 * Forms a verbose description of {@code info}
+	 * @param info an {@link OpInfo}
+	 * @return a verbose description of {@code info}
 	 */
 	public static String describeVerbose(final OpInfo info) {
-			return describeVerbose(info, null, null);
-	}
-
-	/**
-	 * Generates a verbose {@link String} describing the given {@link OpInfo}
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param name the name that the Op was searched by
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describeVerbose(final OpInfo info, final String name) {
-		return describeVerbose(info, name, null);
-	}
-
-	/**
-	 * Writes a {@link String} describing the {@link OpInfo} of interest
-	 * <b>with a particular {@link Member} highlighted</b>.
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param special a {@link Member} to highlight
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describe(final OpInfo info, final Member<?> special) {
-		return describe(info, null, special);
-	}
-
-	/**
-	 * Writes a {@link String} describing the {@link OpInfo} of interest
-	 * <b>with a particular {@link Member} highlighted</b>.
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param name the name that the Op was searched by
-	 * @param special a {@link Member} to highlight
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describe(final OpInfo info, final String name, final Member<?> special) {
-		return description(info, name, special, false);
-	}
-
-	/**
-	 * Writes a verbose {@link String} describing the {@link OpInfo} of interest
-	 * <b>with a particular {@link Member} highlighted</b>.
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param special a {@link Member} to highlight
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describeVerbose(final OpInfo info, final Member<?> special) {
-			return describeVerbose(info, null, special);
-	}
-
-	/**
-	 * Writes a verbose {@link String} describing the {@link OpInfo} of interest
-	 * <b>with a particular {@link Member} highlighted</b>.
-	 *
-	 * @param info the {@link OpInfo} of interest
-	 * @param name the name that the Op was searched by
-	 * @param special a {@link Member} to highlight
-	 * @return a descriptor for {@code info}
-	 */
-	public static String describeVerbose(final OpInfo info, final String name, final Member<?> special) {
-		return description(info, name, special, true);
-	}
-
-	/**
-	 * Private method to describe {@code info}, optionally highlighting some member {@code special}. Description is verbose iff {@code verbose=true}.
-	 *
-	 * @param info the {@link OpInfo} to describe
-	 * @param special the {@link Member} to highlight
-	 * @param verbose iff {@code true}, returns a verbose description
-	 * @return a description of {@code info}
-	 */
-	private static String description(final OpInfo info, final String name, final Member<?> special,
-		boolean verbose)
-	{
-		final StringBuilder sb = new StringBuilder();
-		// Step 1: Name
-		if (name != null) {
-			if (!info.names().contains(name)) {
-				throw new IllegalArgumentException("OpInfo " + info.implementationName() + " has no name " + name);
-			}
-			sb.append(name);
-		}
-		else {
-			sb.append(info.names().get(0));
-		}
-		sb.append("(\n");
-		// Step 2: Inputs
-		List<Member<?>> members = info.inputs();
-		List<Member<?>> containers = new ArrayList<>();
-		if (!members.isEmpty()) {
-			sb.append("\t Inputs:\n");
-			for (final Member<?> arg : info.inputs()) {
-				if (arg.getIOType() == ItemIO.INPUT)
-					appendParam(sb, arg, special, verbose);
-				else containers.add(arg);
-			}
-		}
-		// Step 3: Output
-		if (containers.isEmpty()) {
-			sb.append("\t Output:\n");
-			appendParam(sb, info.output(), special, verbose);
-		}
-		else {
-			sb.append("\t Container (I/O):\n");
-			containers.forEach(c -> appendParam(sb, c, special, verbose));
-		}
-		sb.append(")\n");
-		return sb.toString();
-	}
-
-	public static String describeMultiLine(final OpInfo info) {
 		final StringBuilder sb = new StringBuilder(info.implementationName());
 		// Step 2: Inputs
 		for (var member: info.inputs()) {
@@ -306,7 +170,12 @@ public final class Infos {
 		return sb.toString();
 	}
 
-	public static String describeOneLine(final OpInfo info) {
+	/**
+	 * Forms a brief description of {@code info}
+	 * @param info an {@link OpInfo}
+	 * @return a brief description of {@code info}
+	 */
+	public static String describe(final OpInfo info) {
 		final StringBuilder sb = new StringBuilder("(");
 		// Step 2: Inputs
 		var inputs = info.inputs().stream().map(member-> {
@@ -348,30 +217,6 @@ public final class Infos {
 		return sb.toString();
 	}
 
-	/**
-	 * Appends a {@link Member} to the {@link StringBuilder} writing the Op
-	 * string.
-	 *
-	 * @param sb      the {@link StringBuilder}
-	 * @param arg     the {@link Member} being appended to {@code sb}
-	 * @param special the {@link Member} to highlight
-	 * @param verbose appends a verbose description iff {@code true}
-	 */
-	private static void appendParam(final StringBuilder sb, final Member<?> arg,
-													 final Member<?> special, final boolean verbose) {
-			if (arg == special) sb.append("==> \t"); // highlight special item
-			else sb.append("\t\t");
-			sb.append(typeString(arg.getType(), verbose));
-			sb.append(" ");
-			sb.append(arg.getKey());
-			if (!arg.isRequired()) sb.append(" = null");
-			if (!arg.getDescription().isEmpty()) {
-					sb.append(" -> ");
-					sb.append(arg.getDescription());
-			}
-			sb.append("\n");
-	}
-
 	private static String typeString(final Type input, final boolean verbose) {
 			var str = input.getTypeName();
 			if (verbose) return str;
@@ -379,17 +224,17 @@ public final class Infos {
 					var bounds = ((TypeVariable<?>)input).getBounds();
 					String[] s = new String[bounds.length];
 					for(int i = 0; i < s.length; i++) {
-							s[i] = typeString(Types.raw(bounds[i]), verbose);
+							s[i] = typeString(Types.raw(bounds[i]), false);
 					}
 					return String.join("+", s);
 			}
 			else if (input instanceof ParameterizedType) {
 					var pType = (ParameterizedType) input;
-					var raw = typeString(pType.getRawType(), verbose);
+					var raw = typeString(pType.getRawType(), false);
 					Type[] args = pType.getActualTypeArguments();
 					String[] s = new String[args.length];
 					for(int i = 0; i < args.length; i++) {
-							s[i] = typeString(args[i], verbose);
+							s[i] = typeString(args[i], false);
 					}
 					return raw + "<" + String.join(", ", s) + ">";
 			}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
@@ -281,41 +281,27 @@ public final class Infos {
 	public static String describeMultiLine(final OpInfo info) {
 		final StringBuilder sb = new StringBuilder(info.implementationName());
 		// Step 2: Inputs
-		String key;
 		for (var member: info.inputs()) {
 			sb.append("\n\t");
-			switch (member.getIOType()) {
-				case INPUT:
-					key = member.getKey();
-					break;
-				case MUTABLE:
-					key = "^" + member.getKey();
-					break;
-				case CONTAINER:
-					key = "*" + member.getKey();
-					break;
-				default:
-					throw new IllegalArgumentException("Invalid IO type: " + member.getIOType());
-			}
-			sb.append("> ").append(key) //
+			sb.append("> ").append(member.getKey()) //
 					.append(member.isRequired() ? "" : " (optional)")  //
-					.append(" : ") //
-					.append(typeString(member.getType(), true)); //
+					.append(" : ");
+			if (member.getIOType() == ItemIO.CONTAINER) {
+				sb.append("@CONTAINER ");
+			}
+			else if (member.getIOType() == ItemIO.MUTABLE) {
+				sb.append("@MUTABLE ");
+			}
+
+			sb.append(typeString(member.getType(), true)); //
 			if (!member.getDescription().isBlank()) {
 				sb.append("\n\t\t").append(member.getDescription().replaceAll("\n\\s*", "\n\t\t"));
 			}
 		}
 		// Step 3: Output
 		Member<?> output = info.output();
-		switch (output.getIOType()) {
-			case OUTPUT:
+		if (output.getIOType() == ItemIO.OUTPUT) {
 				sb.append("\n\tReturns : ").append(typeString(output.getType(), true));
-				break;
-			case MUTABLE:
-			case CONTAINER:
-				break;
-			default:
-				throw new IllegalArgumentException("Invalid IO type: " + output.getIOType());
 		}
 		return sb.toString();
 	}
@@ -330,10 +316,10 @@ public final class Infos {
 					str += member.getKey();
 					break;
 				case MUTABLE:
-					str += "^" + member.getKey();
+					str += "@MUTABLE " + member.getKey();
 					break;
 				case CONTAINER:
-					str += "*" + member.getKey();
+					str += "@CONTAINER " + member.getKey();
 					break;
 				default:
 					throw new IllegalArgumentException("Invalid IO type: " + member.getIOType());
@@ -353,12 +339,8 @@ public final class Infos {
 				sb.append(typeString(output.getType(), false));
 				break;
 			case MUTABLE:
-				sb.append("None");
-//				sb.append("None [Overwrites MUTABLE]");
-				break;
 			case CONTAINER:
 				sb.append("None");
-//				sb.append("None [Fills CONTAINER]");
 				break;
 			default:
 				throw new IllegalArgumentException("Invalid IO type: " + output.getIOType());

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
@@ -109,7 +109,7 @@ public class OpEnvironmentTest extends AbstractTestEnvironment {
 
 		// Get the Op matching the description
 		String descriptions = helpEnv.helpVerbose("help.verbose1");
-		String expected = "help.verbose1:\n\t- org.scijava.ops.engine.OpifyOp1\n\t\tReturns : java.lang.String\nKey: *=container, ^=mutable";
+		String expected = "help.verbose1:\n\t- org.scijava.ops.engine.OpifyOp1\n\t\tReturns : java.lang.String";
 		Assertions.assertEquals(expected, descriptions);
 	}
 
@@ -131,7 +131,7 @@ public class OpEnvironmentTest extends AbstractTestEnvironment {
 		Assertions.assertEquals(expected, actual);
 		// ...but make sure that if we really need help with the internal namespace, we can get it
 		actual = helpEnv.help("engine.adapt");
-		expected = "engine.adapt:\n\t- () -> String\nKey: *=container, ^=mutable";
+		expected = "engine.adapt:\n\t- () -> String";
 		Assertions.assertEquals(expected, actual);
 	}
 

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
@@ -75,7 +75,9 @@ public class OpAdaptationInfoTest extends AbstractTestEnvironment implements
 				.inType(Double.class, Double.class) //
 				.outType(double[].class) //
 				.computer();
-		String expected = "org.scijava.ops.engine.matcher.adapt.OpAdaptationInfoTest.adaptableOp(java.lang.Double,java.lang.Double)|Adaptor:|Info:org.scijava.ops.engine.adapt.functional.FunctionsToComputers$Function2ToComputer2@0-SNAPSHOT{|Info:org.scijava.ops.engine.copy.CopyOpCollection$copyDoubleArray@0-SNAPSHOT{}}\n\t" //
+		String expected = "org.scijava.ops.engine.matcher.adapt.OpAdaptationInfoTest.adaptableOp(java.lang.Double,java.lang.Double)\n\t" +
+				"Adaptor: org.scijava.ops.engine.adapt.functional.FunctionsToComputers$Function2ToComputer2\n\t\t" +
+				"Depends upon: org.scijava.ops.engine.copy.CopyOpCollection$copyDoubleArray\n\t" //
 				+ "> input1 : java.lang.Double\n\t" //
 				+ "> input2 : java.lang.Double\n\t" //
 				+ "> output1 : @CONTAINER double[]";

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
@@ -57,9 +57,10 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 		OpClassInfo info = new OpClassInfo(ClassOp.class, new Hints(),
 			"test.classDescription");
 
-		String expected = "test.classDescription(\n\t " //
-			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
-			+ "Output:\n\t\tjava.lang.Double output1\n)\n";
+		String expected = "org.scijava.ops.engine.matcher.impl.OpDescriptionTest$ClassOp\n\t" //
+			+ "> input1 : java.lang.Double\n\t" //
+			+ "> input2 : java.lang.Double\n\t" //
+			+ "Returns : java.lang.Double";
 		String actual = info.toString();
 		Assertions.assertEquals(expected, actual);
 	}
@@ -74,9 +75,10 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 			Double.class);
 		OpMethodInfo info = new OpMethodInfo(method, BiFunction.class,
 			new Hints(), "test.methodDescription");
-		String expected = "test.methodDescription(\n\t " //
-			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
-			+ "Output:\n\t\tjava.lang.Double output1\n)\n";
+		String expected = "org.scijava.ops.engine.matcher.impl.OpDescriptionTest.methodOp(java.lang.Double,java.lang.Double)\n\t" //
+			+ "> input1 : java.lang.Double\n\t" //
+			+ "> input2 : java.lang.Double\n\t" //
+			+ "Returns : java.lang.Double";
 		String actual = info.toString();
 		Assertions.assertEquals(expected, actual);
 	}
@@ -88,9 +90,10 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 		Field field = OpDescriptionTest.class.getDeclaredField("fieldOp");
 		OpFieldInfo info = new OpFieldInfo(this, field, new Hints(),
 			"test.fieldDescription");
-		String expected = "test.fieldDescription(\n\t " //
-			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
-			+ "Output:\n\t\tjava.lang.Double output1\n)\n";
+		String expected = "org.scijava.ops.engine.matcher.impl.OpDescriptionTest$fieldOp\n\t" //
+			+ "> input1 : java.lang.Double\n\t" //
+			+ "> input2 : java.lang.Double\n\t" //
+			+ "Returns : java.lang.Double";
 		String actual = info.toString();
 		Assertions.assertEquals(expected, actual);
 	}
@@ -103,24 +106,11 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 		Type opType = Types.parameterize(Function.class, new Type[] { Double.class,
 			Double.class });
 		ReducedOpInfo reduced = new ReducedOpInfo(info, opType, 1);
-		String expected = "test.reductionDescription(\n\t " //
-			+ "Inputs:\n\t\tjava.lang.Double input1\n\t " //
-			+ "Output:\n\t\tjava.lang.Double output1\n)\n";
+		String expected = "org.scijava.ops.engine.matcher.impl.OpDescriptionTest$ClassOpReduction1\n\t" //
+			+ "> input1 : java.lang.Double\n\t" //
+			+ "Returns : java.lang.Double";
 		String actual = reduced.toString();
 		Assertions.assertEquals(expected, actual);
-	}
-
-	@Test
-	public void testMultiNameOp() {
-		OpClassInfo info = new OpClassInfo(ClassOp.class, new Hints(),
-			"test.classDescription", "test.otherName");
-
-		String expected = "test.classDescription(\n\t " //
-			+ "Inputs:\n\t\tjava.lang.Double input1\n\t\tjava.lang.Double input2\n\t " //
-			+ "Output:\n\t\tjava.lang.Double output1\n)\n"; //
-		String actual = info.toString();
-		Assertions.assertEquals(expected, actual);
-
 	}
 
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpInfoTest.java
@@ -125,18 +125,17 @@ public class SimplifiedOpInfoTest extends AbstractTestEnvironment implements
 		String expected =  "test.coalesceSimpleDescription:\n" +
 				"\t- org.scijava.ops.engine.matcher.simplify.SimplifiedOpInfoTest$comp1\n" +
 				"\t\t> input1 : java.util.List<java.lang.Long>\n" +
-				"\t\t> *container1 : java.util.List<java.lang.Long>\n" +
+				"\t\t> container1 : @CONTAINER java.util.List<java.lang.Long>\n" +
 				"\t- org.scijava.ops.engine.matcher.simplify.SimplifiedOpInfoTest$func1\n" +
 				"\t\t> input1 : java.lang.Double\n" + "\t\tReturns : java.lang.Double\n" +
 				"\t- org.scijava.ops.engine.matcher.simplify.SimplifiedOpInfoTest$func2\n" +
-				"\t\t> input1 : java.lang.Long\n" + "\t\tReturns : java.lang.Long\n" +
-				"Key: *=container, ^=mutable";
+				"\t\t> input1 : java.lang.Long\n" + "\t\tReturns : java.lang.Long";
 
 		Assertions.assertEquals(expected, actual);
 
 		actual = ops.unary("test.coalesceSimpleDescription").help();
 		expected =  //
-				"test.coalesceSimpleDescription:\n\t- (input1, *container1) -> None\n\t- (input1) -> Number\nKey: *=container, ^=mutable";
+				"test.coalesceSimpleDescription:\n\t- (input1, @CONTAINER container1) -> None\n\t- (input1) -> Number";
 		Assertions.assertEquals(expected, actual);
 		// Finally test that different number of outputs doesn't retrieve the Ops
 		actual = ops.nullary("test.coalesceSimpleDescription").help();

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpInfoTest.java
@@ -81,10 +81,10 @@ public class SimplifiedOpInfoTest extends AbstractTestEnvironment implements
 	@Test
 	public void testSimplifiedDescription() {
 		SimplifiedOpInfo info = createSimpleInfo();
-		String expected = "test.simplifiedDescription(\n\t " //
-				+
-				"Inputs:\n\t\tjava.lang.Number input1\n\t\tjava.lang.Number input2\n\t " //
-				+ "Output:\n\t\torg.scijava.collections.ObjectArray<java.lang.Number> output1\n)\n";
+		String expected = "org.scijava.ops.engine.matcher.simplify.SimplifiedOpInfoTest$SimpleOp|simple\n\t" //
+				+ "> input1 : java.lang.Number\n\t" //
+				+ "> input2 : java.lang.Number\n\t" //
+				+ "Returns : org.scijava.collections.ObjectArray<java.lang.Number>";
 		String actual = info.toString();
 		Assertions.assertEquals(expected, actual);
 	}

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/InfosTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/util/InfosTest.java
@@ -31,7 +31,7 @@ public class InfosTest extends AbstractTestEnvironment implements OpCollection {
     @Test
     public void testDescriptionOfNullableParameter() {
         var actual = ops.help("test.nullableMethod");
-        var expected = "test.nullableMethod:\n\t- (input1, input2 = null) -> Integer\nKey: *=container, ^=mutable";
+        var expected = "test.nullableMethod:\n\t- (input1, input2 = null) -> Integer";
         Assertions.assertEquals(expected, actual);
     }
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
@@ -102,7 +102,7 @@ public class YAMLOpTest extends AbstractTestEnvironment {
 	@Test
 	public void testYAMLDescription() {
 		var actual = ops.help("example.mul");
-		var expected = "example.mul:\n\t- (a, b) -> Double\nKey: *=container, ^=mutable";
+		var expected = "example.mul:\n\t- (a, b) -> Double";
 		Assertions.assertEquals(expected, actual);
 	}
 


### PR DESCRIPTION
This PR makes slight changes to the default returns of `OpEnvironment.help()` and `OpEnvironment.helpVerbose()`, elimating smaller symbols (and the key describing them) in favor of Java-style annotations. Right now, that only means a `@CONTAINER` mark on any `Computer` output, and a `@MUTABLE` mark on any `Inplace` output.

This PR also consolidates down to two "describe" methods in the `Infos` utility class, as we added two new ones in #113 but did not remove any old ones.

Points of discussion:
* [x] As you can see in the associated test, the verbose descriptions for adapted Op infos are almost unusably long. How should we change them? For example:
```
org.scijava.ops.engine.matcher.adapt.OpAdaptationInfoTest.adaptableOp(java.lang.Double,java.lang.Double)|Adaptor:|Info:org.scijava.ops.engine.adapt.functional.FunctionsToComputers$Function2ToComputer2@0-SNAPSHOT{|Info:org.scijava.ops.engine.copy.CopyOpCollection$copyDoubleArray@0-SNAPSHOT{}}
    > input1 : java.lang.Double
    > input2 : java.lang.Double
    > output1 : @CONTAINER double[]
```

TODO:
* [x] Update documentation

Closes scijava/scijava#178 and scijava/scijava#179