### PR TITLE
Add additional responsibilities to the DefaultOpEnvironmentService

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/RichOp.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/RichOp.java
@@ -52,6 +52,8 @@ public interface RichOp<T> extends GenericTyped {
 
 	Hints hints();
 
+	String name();
+
 	/**
 	 * Getter for this {@link RichOp}'s <b>raw</b> Op instance
 	 *

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpWrapper.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpWrapper.java
@@ -29,14 +29,13 @@
 
 package org.scijava.ops.engine;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-
-import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
 import org.scijava.ops.api.RichOp;
 import org.scijava.types.Types;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 
 /**
  * An object that can wrap an Op into a {@link RichOp}
@@ -50,10 +49,11 @@ public interface OpWrapper<T> {
 	 *
 	 * @param op an Op
 	 * @param env the {@link OpEnvironment} that produced the Op
-	 * @param hints the {@link Hints} used to produce the Op
+	 * @param conditions the {@link MatchingConditions} used to produce the Op
 	 * @return a {@link RichOp} wrapping {@code op}
 	 */
-	RichOp<T> wrap(OpInstance<T> op, OpEnvironment env, Hints hints);
+	RichOp<T> wrap(OpInstance<T> op, OpEnvironment env,
+		MatchingConditions conditions);
 
 	default Class<?> type() {
 		Type wrapperType = getClass().getGenericInterfaces()[0];

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -276,10 +276,12 @@ public class DefaultOpEnvironment implements OpEnvironment {
 		@SuppressWarnings("unchecked")
 		OpInstance<T> instance = (OpInstance<T>) tree.newInstance(specialType
 			.getType());
-		Hints hints = getDefaultHints();
-		RichOp<T> wrappedOp = wrapOp(instance, hints);
+		var conditions = MatchingConditions.from( //
+			new InfoMatchingOpRequest(tree.info(), Nil.of(tree.info().opType())), //
+			getDefaultHints() //
+		);
+		RichOp<T> wrappedOp = wrapOp(instance, conditions);
 		return wrappedOp.asOpType();
-
 	}
 
 	@Override
@@ -540,12 +542,12 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	 * Wraps the matched op into an Op that knows its generic typing.
 	 *
 	 * @param instance - the {@link OpInstance} to wrap.
-	 * @param hints - the {@link Hints} used to create the {@link OpInstance}
+	 * @param conditions - the {@link Hints} used to create the {@link OpInstance}
 	 * @return an Op wrapping of op.
 	 */
 	@SuppressWarnings("unchecked")
-	private <T> RichOp<T> wrapOp(OpInstance<T> instance, Hints hints)
-		throws IllegalArgumentException
+	private <T> RichOp<T> wrapOp(OpInstance<T> instance,
+		MatchingConditions conditions) throws IllegalArgumentException
 	{
 		if (wrappers == null) initWrappers();
 
@@ -572,7 +574,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 			// wrap the Op
 			final OpWrapper<T> opWrapper = (OpWrapper<T>) wrappers.get(Types.raw(
 				reifiedSuperType));
-			return opWrapper.wrap(instance, this, hints);
+			return opWrapper.wrap(instance, this, conditions);
 		}
 		catch (IllegalArgumentException | SecurityException exc) {
 			throw new IllegalArgumentException(exc.getMessage() != null ? exc
@@ -670,11 +672,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 
 	private RichOp<?> wrapViaCache(MatchingConditions conditions) {
 		OpInstance<?> instance = getInstance(conditions);
-		return wrap(instance, conditions.hints());
-	}
-
-	private RichOp<?> wrap(OpInstance<?> instance, Hints hints) {
-		return wrapOp(instance, hints);
+		return wrapOp(instance, conditions);
 	}
 
 	/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -35,6 +35,7 @@ import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
 import org.scijava.ops.api.RichOp;
+import org.scijava.ops.engine.MatchingConditions;
 import org.scijava.progress.Progress;
 
 /**
@@ -51,16 +52,16 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	private final OpInstance<T> instance;
 	private final OpEnvironment env;
-	private final Hints hints;
+	private final MatchingConditions conditions;
 
 	public boolean record = true;
 
 	public AbstractRichOp(final OpInstance<T> instance, final OpEnvironment env,
-		final Hints hints)
+		final MatchingConditions conditions)
 	{
 		this.instance = instance;
 		this.env = env;
-		this.hints = hints;
+		this.conditions = conditions;
 
 		this.env.history().logOp(this);
 	}
@@ -72,7 +73,12 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	@Override
 	public Hints hints() {
-		return hints;
+		return conditions.hints();
+	}
+
+	@Override
+	public String name() {
+		return conditions.request().getName();
 	}
 
 	@Override
@@ -82,7 +88,7 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	@Override
 	public void preprocess(Object... inputs) {
-		Progress.register(this);
+		Progress.register(this, conditions.request().getName());
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/InfoMatchingOpRequest.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/InfoMatchingOpRequest.java
@@ -29,17 +29,17 @@
 
 package org.scijava.ops.engine.matcher.impl;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpRequest;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
 import org.scijava.types.inference.GenericAssignability;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InfoMatchingOpRequest implements OpRequest {
 
@@ -75,10 +75,18 @@ public class InfoMatchingOpRequest implements OpRequest {
 			if (!Types.isAssignable(from, this.type, this.map))
 				throw new IllegalArgumentException();
 		}
-		args = info.inputs().stream().map(m -> Types.substituteTypeVariables(m
-			.getType(), this.map)).toArray(Type[]::new);
-		outType = Types.substituteTypeVariables(info.output().getType(), this.map);
+		args = info.inputs().stream().map(m -> mappedType(m.getType(), this.map))
+			.toArray(Type[]::new);
+		outType = mappedType(info.outputType(), this.map);
+	}
 
+	private Type mappedType(Type t, Map<TypeVariable<?>, Type> map) {
+		try {
+			return Types.substituteTypeVariables(t, map);
+		}
+		catch (Exception e) {
+			return t;
+		}
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/LossReporterWrapper.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/LossReporterWrapper.java
@@ -29,10 +29,10 @@
 
 package org.scijava.ops.engine.matcher.impl;
 
-import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
 import org.scijava.ops.api.RichOp;
+import org.scijava.ops.engine.MatchingConditions;
 import org.scijava.ops.engine.OpWrapper;
 import org.scijava.ops.engine.conversionLoss.LossReporter;
 import org.scijava.types.Nil;
@@ -53,7 +53,7 @@ public class LossReporterWrapper<I, O> //
 	@Override
 	public RichOp<LossReporter<I, O>> wrap( //
 		final OpInstance<LossReporter<I, O>> instance, OpEnvironment env,
-		Hints hints)
+		MatchingConditions conditions)
 	{
 		class GenericTypedLossReporter //
 			extends AbstractRichOp<LossReporter<I, O>> //
@@ -61,7 +61,7 @@ public class LossReporterWrapper<I, O> //
 		{
 
 			public GenericTypedLossReporter() {
-				super(instance, env, hints);
+				super(instance, env, conditions);
 			}
 
 			@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpWrappers.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpWrappers.java
@@ -13,11 +13,11 @@ import org.scijava.function.Container;
 import org.scijava.function.Functions;
 import org.scijava.function.Inplaces;
 import org.scijava.function.Producer;
-import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
-import org.scijava.ops.engine.OpWrapper;
 import org.scijava.ops.api.RichOp;
+import org.scijava.ops.engine.OpWrapper;
+import org.scijava.ops.engine.MatchingConditions;
 
 public class OpWrappers {
 
@@ -29,7 +29,7 @@ public class OpWrappers {
 		public RichOp<Producer<T>> wrap( //
 			final OpInstance<Producer<T>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedProducer //
 				extends AbstractRichOp<Producer<T>> //
@@ -37,7 +37,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedProducer() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -73,7 +73,7 @@ public class OpWrappers {
 		public RichOp<Function<I, O>> wrap( //
 			final OpInstance<Function<I, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction1 //
 				extends AbstractRichOp<Function<I, O>> //
@@ -81,7 +81,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -115,7 +115,7 @@ public class OpWrappers {
 		public RichOp<BiFunction<I1, I2, O>> wrap( //
 			final OpInstance<BiFunction<I1, I2, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction2 //
 				extends AbstractRichOp<BiFunction<I1, I2, O>> //
@@ -123,7 +123,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -157,7 +157,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity3<I1, I2, I3, O>> wrap( //
 			final OpInstance<Functions.Arity3<I1, I2, I3, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction3 //
 				extends AbstractRichOp<Functions.Arity3<I1, I2, I3, O>> //
@@ -165,7 +165,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -199,7 +199,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity4<I1, I2, I3, I4, O>> wrap( //
 			final OpInstance<Functions.Arity4<I1, I2, I3, I4, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction4 //
 				extends AbstractRichOp<Functions.Arity4<I1, I2, I3, I4, O>> //
@@ -207,7 +207,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -241,7 +241,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity5<I1, I2, I3, I4, I5, O>> wrap( //
 			final OpInstance<Functions.Arity5<I1, I2, I3, I4, I5, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction5 //
 				extends AbstractRichOp<Functions.Arity5<I1, I2, I3, I4, I5, O>> //
@@ -249,7 +249,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -283,7 +283,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>> wrap( //
 			final OpInstance<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction6 //
 				extends AbstractRichOp<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>> //
@@ -291,7 +291,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -325,7 +325,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> wrap( //
 			final OpInstance<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction7 //
 				extends AbstractRichOp<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> //
@@ -333,7 +333,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -367,7 +367,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> wrap( //
 			final OpInstance<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction8 //
 				extends
@@ -376,7 +376,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -411,7 +411,7 @@ public class OpWrappers {
 		public RichOp<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> wrap( //
 			final OpInstance<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction9 //
 				extends
@@ -420,7 +420,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -459,7 +459,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction10 //
 				extends
@@ -468,7 +468,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -508,7 +508,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction11 //
 				extends
@@ -518,7 +518,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -559,7 +559,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction12 //
 				extends
@@ -569,7 +569,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -611,7 +611,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction13 //
 				extends
@@ -621,7 +621,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -663,7 +663,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction14 //
 				extends
@@ -673,7 +673,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction14() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -715,7 +715,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction15 //
 				extends
@@ -725,7 +725,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction15() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -768,7 +768,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedFunction16 //
 				extends
@@ -778,7 +778,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedFunction16() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -821,7 +821,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity0<O>> wrap( //
 			final OpInstance<Computers.Arity0<O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer0 //
 				extends AbstractRichOp<Computers.Arity0<O>> //
@@ -829,7 +829,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer0() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -862,7 +862,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity1<I, O>> wrap( //
 			final OpInstance<Computers.Arity1<I, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer1 //
 				extends AbstractRichOp<Computers.Arity1<I, O>> //
@@ -870,7 +870,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -903,7 +903,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity2<I1, I2, O>> wrap( //
 			final OpInstance<Computers.Arity2<I1, I2, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer2 //
 				extends AbstractRichOp<Computers.Arity2<I1, I2, O>> //
@@ -911,7 +911,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -944,7 +944,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity3<I1, I2, I3, O>> wrap( //
 			final OpInstance<Computers.Arity3<I1, I2, I3, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer3 //
 				extends AbstractRichOp<Computers.Arity3<I1, I2, I3, O>> //
@@ -952,7 +952,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -985,7 +985,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity4<I1, I2, I3, I4, O>> wrap( //
 			final OpInstance<Computers.Arity4<I1, I2, I3, I4, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer4 //
 				extends AbstractRichOp<Computers.Arity4<I1, I2, I3, I4, O>> //
@@ -993,7 +993,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1026,7 +1026,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity5<I1, I2, I3, I4, I5, O>> wrap( //
 			final OpInstance<Computers.Arity5<I1, I2, I3, I4, I5, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer5 //
 				extends AbstractRichOp<Computers.Arity5<I1, I2, I3, I4, I5, O>> //
@@ -1034,7 +1034,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1068,7 +1068,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> wrap( //
 			final OpInstance<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer6 //
 				extends AbstractRichOp<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> //
@@ -1076,7 +1076,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1110,7 +1110,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> wrap( //
 			final OpInstance<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer7 //
 				extends AbstractRichOp<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> //
@@ -1118,7 +1118,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1152,7 +1152,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> wrap( //
 			final OpInstance<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer8 //
 				extends
@@ -1161,7 +1161,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1195,7 +1195,7 @@ public class OpWrappers {
 		public RichOp<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> wrap( //
 			final OpInstance<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer9 //
 				extends
@@ -1204,7 +1204,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1242,7 +1242,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer10 //
 				extends
@@ -1251,7 +1251,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1290,7 +1290,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer11 //
 				extends
@@ -1300,7 +1300,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1341,7 +1341,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer12 //
 				extends
@@ -1351,7 +1351,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1393,7 +1393,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer13 //
 				extends
@@ -1403,7 +1403,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1445,7 +1445,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer14 //
 				extends
@@ -1455,7 +1455,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer14() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1497,7 +1497,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer15 //
 				extends
@@ -1507,7 +1507,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer15() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1549,7 +1549,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedComputer16 //
 				extends
@@ -1559,7 +1559,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedComputer16() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1601,7 +1601,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity1<IO>> wrap( //
 			final OpInstance<Inplaces.Arity1<IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace1 //
 				extends AbstractRichOp<Inplaces.Arity1<IO>> //
@@ -1609,7 +1609,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1643,7 +1643,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity2_1<IO, I2>> wrap( //
 			final OpInstance<Inplaces.Arity2_1<IO, I2>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace2_1 //
 				extends AbstractRichOp<Inplaces.Arity2_1<IO, I2>> //
@@ -1651,7 +1651,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace2_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1685,7 +1685,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity2_2<I1, IO>> wrap( //
 			final OpInstance<Inplaces.Arity2_2<I1, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace2_2 //
 				extends AbstractRichOp<Inplaces.Arity2_2<I1, IO>> //
@@ -1693,7 +1693,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace2_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1727,7 +1727,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity3_1<IO, I2, I3>> wrap( //
 			final OpInstance<Inplaces.Arity3_1<IO, I2, I3>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace3_1 //
 				extends AbstractRichOp<Inplaces.Arity3_1<IO, I2, I3>> //
@@ -1735,7 +1735,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace3_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1769,7 +1769,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity3_2<I1, IO, I3>> wrap( //
 			final OpInstance<Inplaces.Arity3_2<I1, IO, I3>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace3_2 //
 				extends AbstractRichOp<Inplaces.Arity3_2<I1, IO, I3>> //
@@ -1777,7 +1777,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace3_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1811,7 +1811,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity3_3<I1, I2, IO>> wrap( //
 			final OpInstance<Inplaces.Arity3_3<I1, I2, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace3_3 //
 				extends AbstractRichOp<Inplaces.Arity3_3<I1, I2, IO>> //
@@ -1819,7 +1819,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace3_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1853,7 +1853,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity4_1<IO, I2, I3, I4>> wrap( //
 			final OpInstance<Inplaces.Arity4_1<IO, I2, I3, I4>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace4_1 //
 				extends AbstractRichOp<Inplaces.Arity4_1<IO, I2, I3, I4>> //
@@ -1861,7 +1861,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace4_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1895,7 +1895,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity4_2<I1, IO, I3, I4>> wrap( //
 			final OpInstance<Inplaces.Arity4_2<I1, IO, I3, I4>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace4_2 //
 				extends AbstractRichOp<Inplaces.Arity4_2<I1, IO, I3, I4>> //
@@ -1903,7 +1903,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace4_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1937,7 +1937,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity4_3<I1, I2, IO, I4>> wrap( //
 			final OpInstance<Inplaces.Arity4_3<I1, I2, IO, I4>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace4_3 //
 				extends AbstractRichOp<Inplaces.Arity4_3<I1, I2, IO, I4>> //
@@ -1945,7 +1945,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace4_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -1979,7 +1979,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity4_4<I1, I2, I3, IO>> wrap( //
 			final OpInstance<Inplaces.Arity4_4<I1, I2, I3, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace4_4 //
 				extends AbstractRichOp<Inplaces.Arity4_4<I1, I2, I3, IO>> //
@@ -1987,7 +1987,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace4_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2021,7 +2021,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity5_1<IO, I2, I3, I4, I5>> wrap( //
 			final OpInstance<Inplaces.Arity5_1<IO, I2, I3, I4, I5>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace5_1 //
 				extends AbstractRichOp<Inplaces.Arity5_1<IO, I2, I3, I4, I5>> //
@@ -2029,7 +2029,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace5_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2064,7 +2064,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity5_2<I1, IO, I3, I4, I5>> wrap( //
 			final OpInstance<Inplaces.Arity5_2<I1, IO, I3, I4, I5>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace5_2 //
 				extends AbstractRichOp<Inplaces.Arity5_2<I1, IO, I3, I4, I5>> //
@@ -2072,7 +2072,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace5_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2107,7 +2107,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity5_3<I1, I2, IO, I4, I5>> wrap( //
 			final OpInstance<Inplaces.Arity5_3<I1, I2, IO, I4, I5>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace5_3 //
 				extends AbstractRichOp<Inplaces.Arity5_3<I1, I2, IO, I4, I5>> //
@@ -2115,7 +2115,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace5_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2150,7 +2150,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity5_4<I1, I2, I3, IO, I5>> wrap( //
 			final OpInstance<Inplaces.Arity5_4<I1, I2, I3, IO, I5>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace5_4 //
 				extends AbstractRichOp<Inplaces.Arity5_4<I1, I2, I3, IO, I5>> //
@@ -2158,7 +2158,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace5_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2193,7 +2193,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity5_5<I1, I2, I3, I4, IO>> wrap( //
 			final OpInstance<Inplaces.Arity5_5<I1, I2, I3, I4, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace5_5 //
 				extends AbstractRichOp<Inplaces.Arity5_5<I1, I2, I3, I4, IO>> //
@@ -2201,7 +2201,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace5_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2236,7 +2236,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_1<IO, I2, I3, I4, I5, I6>> wrap( //
 			final OpInstance<Inplaces.Arity6_1<IO, I2, I3, I4, I5, I6>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_1 //
 				extends AbstractRichOp<Inplaces.Arity6_1<IO, I2, I3, I4, I5, I6>> //
@@ -2244,7 +2244,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2280,7 +2280,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_2<I1, IO, I3, I4, I5, I6>> wrap( //
 			final OpInstance<Inplaces.Arity6_2<I1, IO, I3, I4, I5, I6>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_2 //
 				extends AbstractRichOp<Inplaces.Arity6_2<I1, IO, I3, I4, I5, I6>> //
@@ -2288,7 +2288,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2324,7 +2324,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_3<I1, I2, IO, I4, I5, I6>> wrap( //
 			final OpInstance<Inplaces.Arity6_3<I1, I2, IO, I4, I5, I6>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_3 //
 				extends AbstractRichOp<Inplaces.Arity6_3<I1, I2, IO, I4, I5, I6>> //
@@ -2332,7 +2332,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2368,7 +2368,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_4<I1, I2, I3, IO, I5, I6>> wrap( //
 			final OpInstance<Inplaces.Arity6_4<I1, I2, I3, IO, I5, I6>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_4 //
 				extends AbstractRichOp<Inplaces.Arity6_4<I1, I2, I3, IO, I5, I6>> //
@@ -2376,7 +2376,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2412,7 +2412,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_5<I1, I2, I3, I4, IO, I6>> wrap( //
 			final OpInstance<Inplaces.Arity6_5<I1, I2, I3, I4, IO, I6>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_5 //
 				extends AbstractRichOp<Inplaces.Arity6_5<I1, I2, I3, I4, IO, I6>> //
@@ -2420,7 +2420,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2456,7 +2456,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity6_6<I1, I2, I3, I4, I5, IO>> wrap( //
 			final OpInstance<Inplaces.Arity6_6<I1, I2, I3, I4, I5, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace6_6 //
 				extends AbstractRichOp<Inplaces.Arity6_6<I1, I2, I3, I4, I5, IO>> //
@@ -2464,7 +2464,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace6_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2500,7 +2500,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_1<IO, I2, I3, I4, I5, I6, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_1<IO, I2, I3, I4, I5, I6, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_1 //
 				extends AbstractRichOp<Inplaces.Arity7_1<IO, I2, I3, I4, I5, I6, I7>> //
@@ -2508,7 +2508,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2545,7 +2545,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_2<I1, IO, I3, I4, I5, I6, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_2<I1, IO, I3, I4, I5, I6, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_2 //
 				extends AbstractRichOp<Inplaces.Arity7_2<I1, IO, I3, I4, I5, I6, I7>> //
@@ -2553,7 +2553,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2590,7 +2590,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_3<I1, I2, IO, I4, I5, I6, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_3<I1, I2, IO, I4, I5, I6, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_3 //
 				extends AbstractRichOp<Inplaces.Arity7_3<I1, I2, IO, I4, I5, I6, I7>> //
@@ -2598,7 +2598,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2635,7 +2635,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_4<I1, I2, I3, IO, I5, I6, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_4<I1, I2, I3, IO, I5, I6, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_4 //
 				extends AbstractRichOp<Inplaces.Arity7_4<I1, I2, I3, IO, I5, I6, I7>> //
@@ -2643,7 +2643,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2680,7 +2680,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_5<I1, I2, I3, I4, IO, I6, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_5<I1, I2, I3, I4, IO, I6, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_5 //
 				extends AbstractRichOp<Inplaces.Arity7_5<I1, I2, I3, I4, IO, I6, I7>> //
@@ -2688,7 +2688,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2725,7 +2725,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_6<I1, I2, I3, I4, I5, IO, I7>> wrap( //
 			final OpInstance<Inplaces.Arity7_6<I1, I2, I3, I4, I5, IO, I7>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_6 //
 				extends AbstractRichOp<Inplaces.Arity7_6<I1, I2, I3, I4, I5, IO, I7>> //
@@ -2733,7 +2733,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2770,7 +2770,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, IO>> wrap( //
 			final OpInstance<Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace7_7 //
 				extends AbstractRichOp<Inplaces.Arity7_7<I1, I2, I3, I4, I5, I6, IO>> //
@@ -2778,7 +2778,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace7_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2815,7 +2815,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_1<IO, I2, I3, I4, I5, I6, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_1 //
 				extends
@@ -2824,7 +2824,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2861,7 +2861,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_2<I1, IO, I3, I4, I5, I6, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_2 //
 				extends
@@ -2870,7 +2870,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2907,7 +2907,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_3<I1, I2, IO, I4, I5, I6, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_3 //
 				extends
@@ -2916,7 +2916,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2953,7 +2953,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_4<I1, I2, I3, IO, I5, I6, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_4 //
 				extends
@@ -2962,7 +2962,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -2999,7 +2999,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_5<I1, I2, I3, I4, IO, I6, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_5 //
 				extends
@@ -3008,7 +3008,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3045,7 +3045,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_6<I1, I2, I3, I4, I5, IO, I7, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_6 //
 				extends
@@ -3054,7 +3054,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3091,7 +3091,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8>> wrap( //
 			final OpInstance<Inplaces.Arity8_7<I1, I2, I3, I4, I5, I6, IO, I8>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_7 //
 				extends
@@ -3100,7 +3100,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3137,7 +3137,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO>> wrap( //
 			final OpInstance<Inplaces.Arity8_8<I1, I2, I3, I4, I5, I6, I7, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace8_8 //
 				extends
@@ -3146,7 +3146,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace8_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3183,7 +3183,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_1<IO, I2, I3, I4, I5, I6, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_1 //
 				extends
@@ -3192,7 +3192,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3231,7 +3231,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_2<I1, IO, I3, I4, I5, I6, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_2 //
 				extends
@@ -3240,7 +3240,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3279,7 +3279,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_3<I1, I2, IO, I4, I5, I6, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_3 //
 				extends
@@ -3288,7 +3288,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3327,7 +3327,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_4<I1, I2, I3, IO, I5, I6, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_4 //
 				extends
@@ -3336,7 +3336,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3375,7 +3375,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_5<I1, I2, I3, I4, IO, I6, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_5 //
 				extends
@@ -3384,7 +3384,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3423,7 +3423,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_6<I1, I2, I3, I4, I5, IO, I7, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_6 //
 				extends
@@ -3432,7 +3432,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3471,7 +3471,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_7<I1, I2, I3, I4, I5, I6, IO, I8, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_7 //
 				extends
@@ -3480,7 +3480,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3519,7 +3519,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9>> wrap( //
 			final OpInstance<Inplaces.Arity9_8<I1, I2, I3, I4, I5, I6, I7, IO, I9>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_8 //
 				extends
@@ -3528,7 +3528,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3567,7 +3567,7 @@ public class OpWrappers {
 		public RichOp<Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO>> wrap( //
 			final OpInstance<Inplaces.Arity9_9<I1, I2, I3, I4, I5, I6, I7, I8, IO>> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace9_9 //
 				extends
@@ -3576,7 +3576,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace9_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3616,7 +3616,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_1 //
 				extends
@@ -3625,7 +3625,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3666,7 +3666,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_2 //
 				extends
@@ -3675,7 +3675,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3716,7 +3716,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_3 //
 				extends
@@ -3725,7 +3725,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3766,7 +3766,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_4 //
 				extends
@@ -3775,7 +3775,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3816,7 +3816,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_5 //
 				extends
@@ -3825,7 +3825,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3866,7 +3866,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_6 //
 				extends
@@ -3875,7 +3875,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3916,7 +3916,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_7 //
 				extends
@@ -3925,7 +3925,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -3966,7 +3966,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_8 //
 				extends
@@ -3975,7 +3975,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4016,7 +4016,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_9 //
 				extends
@@ -4025,7 +4025,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4066,7 +4066,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity10_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace10_10 //
 				extends
@@ -4075,7 +4075,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace10_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4116,7 +4116,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_1 //
 				extends
@@ -4126,7 +4126,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4168,7 +4168,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_2 //
 				extends
@@ -4178,7 +4178,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4220,7 +4220,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_3 //
 				extends
@@ -4230,7 +4230,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4272,7 +4272,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_4 //
 				extends
@@ -4282,7 +4282,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4324,7 +4324,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_5 //
 				extends
@@ -4334,7 +4334,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4376,7 +4376,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_6 //
 				extends
@@ -4386,7 +4386,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4428,7 +4428,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_7 //
 				extends
@@ -4438,7 +4438,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4480,7 +4480,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_8 //
 				extends
@@ -4490,7 +4490,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4532,7 +4532,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_9 //
 				extends
@@ -4542,7 +4542,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4584,7 +4584,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_10 //
 				extends
@@ -4594,7 +4594,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4636,7 +4636,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity11_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace11_11 //
 				extends
@@ -4646,7 +4646,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace11_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4688,7 +4688,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_1 //
 				extends
@@ -4698,7 +4698,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4741,7 +4741,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_2 //
 				extends
@@ -4751,7 +4751,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4794,7 +4794,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_3 //
 				extends
@@ -4804,7 +4804,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4847,7 +4847,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_4 //
 				extends
@@ -4857,7 +4857,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4900,7 +4900,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_5 //
 				extends
@@ -4910,7 +4910,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -4953,7 +4953,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_6 //
 				extends
@@ -4963,7 +4963,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5006,7 +5006,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_7 //
 				extends
@@ -5016,7 +5016,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5059,7 +5059,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_8 //
 				extends
@@ -5069,7 +5069,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5112,7 +5112,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_9 //
 				extends
@@ -5122,7 +5122,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5165,7 +5165,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_10 //
 				extends
@@ -5175,7 +5175,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5218,7 +5218,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_11 //
 				extends
@@ -5228,7 +5228,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5271,7 +5271,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity12_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace12_12 //
 				extends
@@ -5281,7 +5281,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace12_12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5324,7 +5324,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_1 //
 				extends
@@ -5334,7 +5334,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5378,7 +5378,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_2 //
 				extends
@@ -5388,7 +5388,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5432,7 +5432,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_3 //
 				extends
@@ -5442,7 +5442,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5486,7 +5486,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_4 //
 				extends
@@ -5496,7 +5496,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5540,7 +5540,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_5 //
 				extends
@@ -5550,7 +5550,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5594,7 +5594,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_6 //
 				extends
@@ -5604,7 +5604,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5648,7 +5648,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_7 //
 				extends
@@ -5658,7 +5658,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5702,7 +5702,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_8 //
 				extends
@@ -5712,7 +5712,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5756,7 +5756,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_9 //
 				extends
@@ -5766,7 +5766,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5810,7 +5810,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_10 //
 				extends
@@ -5820,7 +5820,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5864,7 +5864,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_11 //
 				extends
@@ -5874,7 +5874,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5918,7 +5918,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_12 //
 				extends
@@ -5928,7 +5928,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -5972,7 +5972,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity13_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace13_13 //
 				extends
@@ -5982,7 +5982,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace13_13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6026,7 +6026,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_1 //
 				extends
@@ -6036,7 +6036,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6081,7 +6081,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_2 //
 				extends
@@ -6091,7 +6091,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6136,7 +6136,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_3 //
 				extends
@@ -6146,7 +6146,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6191,7 +6191,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_4 //
 				extends
@@ -6201,7 +6201,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6246,7 +6246,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_5 //
 				extends
@@ -6256,7 +6256,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6301,7 +6301,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_6 //
 				extends
@@ -6311,7 +6311,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6356,7 +6356,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_7 //
 				extends
@@ -6366,7 +6366,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6411,7 +6411,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_8 //
 				extends
@@ -6421,7 +6421,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6466,7 +6466,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_9 //
 				extends
@@ -6476,7 +6476,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6521,7 +6521,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_10 //
 				extends
@@ -6531,7 +6531,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6576,7 +6576,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_11 //
 				extends
@@ -6586,7 +6586,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6631,7 +6631,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_12 //
 				extends
@@ -6641,7 +6641,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6686,7 +6686,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_13 //
 				extends
@@ -6696,7 +6696,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6741,7 +6741,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity14_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace14_14 //
 				extends
@@ -6751,7 +6751,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace14_14() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6796,7 +6796,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_1 //
 				extends
@@ -6806,7 +6806,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6852,7 +6852,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_2 //
 				extends
@@ -6862,7 +6862,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6908,7 +6908,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_3 //
 				extends
@@ -6918,7 +6918,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -6964,7 +6964,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_4 //
 				extends
@@ -6974,7 +6974,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7020,7 +7020,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_5 //
 				extends
@@ -7030,7 +7030,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7076,7 +7076,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_6 //
 				extends
@@ -7086,7 +7086,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7132,7 +7132,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_7 //
 				extends
@@ -7142,7 +7142,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7188,7 +7188,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_8 //
 				extends
@@ -7198,7 +7198,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7244,7 +7244,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_9 //
 				extends
@@ -7254,7 +7254,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7300,7 +7300,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_10 //
 				extends
@@ -7310,7 +7310,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7355,7 +7355,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_11 //
 				extends
@@ -7365,7 +7365,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7411,7 +7411,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_12 //
 				extends
@@ -7421,7 +7421,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7467,7 +7467,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_13 //
 				extends
@@ -7477,7 +7477,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7523,7 +7523,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_14 //
 				extends
@@ -7533,7 +7533,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_14() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7579,7 +7579,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity15_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace15_15 //
 				extends
@@ -7589,7 +7589,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace15_15() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7635,7 +7635,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_1<IO, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_1 //
 				extends
@@ -7645,7 +7645,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_1() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7691,7 +7691,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_2<I1, IO, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_2 //
 				extends
@@ -7701,7 +7701,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_2() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7747,7 +7747,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_3<I1, I2, IO, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_3 //
 				extends
@@ -7757,7 +7757,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_3() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7803,7 +7803,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_4<I1, I2, I3, IO, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_4 //
 				extends
@@ -7813,7 +7813,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_4() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7859,7 +7859,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_5<I1, I2, I3, I4, IO, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_5 //
 				extends
@@ -7869,7 +7869,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_5() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7915,7 +7915,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_6<I1, I2, I3, I4, I5, IO, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_6 //
 				extends
@@ -7925,7 +7925,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_6() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -7971,7 +7971,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_7<I1, I2, I3, I4, I5, I6, IO, I8, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_7 //
 				extends
@@ -7981,7 +7981,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_7() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8027,7 +8027,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_8<I1, I2, I3, I4, I5, I6, I7, IO, I9, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_8 //
 				extends
@@ -8037,7 +8037,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_8() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8083,7 +8083,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_9<I1, I2, I3, I4, I5, I6, I7, I8, IO, I10, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_9 //
 				extends
@@ -8093,7 +8093,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_9() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8139,7 +8139,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_10<I1, I2, I3, I4, I5, I6, I7, I8, I9, IO, I11, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_10 //
 				extends
@@ -8149,7 +8149,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_10() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8195,7 +8195,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, IO, I12, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_11 //
 				extends
@@ -8205,7 +8205,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_11() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8251,7 +8251,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, IO, I13, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_12 //
 				extends
@@ -8261,7 +8261,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_12() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8307,7 +8307,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, IO, I14, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_13 //
 				extends
@@ -8317,7 +8317,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_13() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8363,7 +8363,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, IO, I15, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_14 //
 				extends
@@ -8373,7 +8373,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_14() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8419,7 +8419,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, IO, I16>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_15 //
 				extends
@@ -8429,7 +8429,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_15() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -8475,7 +8475,7 @@ public class OpWrappers {
 			wrap( //
 				final OpInstance<Inplaces.Arity16_16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, IO>> instance, //
 				final OpEnvironment env, //
-				final Hints hints)
+				final MatchingConditions conditions)
 		{
 			class GenericTypedInplace16_16 //
 				extends
@@ -8485,7 +8485,7 @@ public class OpWrappers {
 			{
 
 				public GenericTypedInplace16_16() {
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/matcher/impl/OpWrappers.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/matcher/impl/OpWrappers.vm
@@ -13,11 +13,11 @@ import org.scijava.function.Container;
 import org.scijava.function.Functions;
 import org.scijava.function.Inplaces;
 import org.scijava.function.Producer;
-import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
-import org.scijava.ops.engine.OpWrapper;
 import org.scijava.ops.api.RichOp;
+import org.scijava.ops.engine.OpWrapper;
+import org.scijava.ops.engine.MatchingConditions;
 
 public class OpWrappers {
 
@@ -29,7 +29,7 @@ public class OpWrappers {
 		public RichOp<Producer<T>> wrap( //
             final OpInstance<Producer<T>> instance, //
             final OpEnvironment env, //
-            final Hints hints)
+            final MatchingConditions conditions)
 		{
 			class GenericTypedProducer //
 				extends AbstractRichOp<Producer<T>> //
@@ -38,7 +38,7 @@ public class OpWrappers {
 
 				public GenericTypedProducer()
 				{
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -76,7 +76,7 @@ public class OpWrappers {
 		public RichOp<$fg> wrap( //
 			final OpInstance<$fg> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedFunction${arity} //
 				extends AbstractRichOp<$fg> //
@@ -85,7 +85,7 @@ public class OpWrappers {
 
 				public GenericTypedFunction${arity}()
 				{
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -124,7 +124,7 @@ public class OpWrappers {
 		public RichOp<$cg> wrap( //
 			final OpInstance<$cg> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedComputer${arity} //
 				extends AbstractRichOp<$cg> //
@@ -132,7 +132,7 @@ public class OpWrappers {
 			{
 				public GenericTypedComputer${arity}()
 				{
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override
@@ -171,7 +171,7 @@ public class OpWrappers {
 		public RichOp<$ig> wrap( //
 			final OpInstance<$ig> instance, //
 			final OpEnvironment env, //
-			final Hints hints)
+			final MatchingConditions conditions)
 		{
 			class GenericTypedInplace${inplaceSuffix.call($arity, $a)} //
 				extends AbstractRichOp<$ig> //
@@ -179,7 +179,7 @@ public class OpWrappers {
 			{
 				public GenericTypedInplace${inplaceSuffix.call($arity, $a)}()
 				{
-					super(instance, env, hints);
+					super(instance, env, conditions);
 				}
 
 				@Override

--- a/scijava-ops-legacy/src/main/java/module-info.java
+++ b/scijava-ops-legacy/src/main/java/module-info.java
@@ -33,6 +33,7 @@ open module org.scijava.legacy {
 	requires org.scijava.types;
 	requires org.scijava.priority;
 	requires org.scijava.ops.api;
+	requires org.scijava.progress;
 
 	provides org.scijava.types.TypeExtractor with org.scijava.legacy.types.DatasetTypeExtractor;
 }

--- a/scijava-ops-legacy/src/main/java/org/scijava/legacy/service/DefaultOpEnvironmentService.java
+++ b/scijava-ops-legacy/src/main/java/org/scijava/legacy/service/DefaultOpEnvironmentService.java
@@ -1,13 +1,22 @@
 
 package org.scijava.legacy.service;
 
+import org.scijava.app.StatusService;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.plugin.Attr;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.progress.Progress;
+import org.scijava.progress.ProgressListener;
+import org.scijava.progress.Task;
 import org.scijava.script.ScriptService;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
+import org.scijava.task.TaskService;
+
+import java.io.ObjectInputFilter;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Default implementation of {@link OpEnvironmentService}
@@ -22,6 +31,9 @@ public class DefaultOpEnvironmentService extends AbstractService implements
 	@Parameter(required = false)
 	private ScriptService scriptService;
 
+	@Parameter(required = false)
+	private TaskService taskService;
+
 	private OpEnvironment env;
 
 	@Override
@@ -32,6 +44,38 @@ public class DefaultOpEnvironmentService extends AbstractService implements
 		// Set up alias, if ScriptService available
 		if (scriptService != null) {
 			scriptService.addAlias(OpEnvironment.class);
+		}
+
+		// Set up progress, if StatusService available
+		if (taskService != null) {
+			Progress.addGlobalListener(new SciJavaProgressListener(taskService));
+		}
+	}
+
+	private class SciJavaProgressListener implements ProgressListener {
+
+		private final Map<Task, org.scijava.task.Task> taskMap;
+		private TaskService tasks;
+
+		public SciJavaProgressListener(TaskService tasks) {
+			this.tasks = tasks;
+			this.taskMap = new WeakHashMap<>();
+		}
+
+		@Override
+		public void acknowledgeUpdate(Task task) {
+			var sjTask = taskMap.computeIfAbsent( //
+				task, //
+				(t) -> { //
+					var value = this.tasks.createTask(t.description());
+					value.start();
+					value.setProgressMaximum(100L);
+					return value;
+				});
+			sjTask.setProgressValue((long) (task.progress() * 100));
+			if (task.isComplete()) {
+				sjTask.finish();
+			}
 		}
 	}
 

--- a/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
+++ b/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
@@ -4,6 +4,12 @@ package org.scijava.legacy.service;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.scijava.Context;
+import org.scijava.app.StatusService;
+import org.scijava.task.Task;
+import org.scijava.task.TaskService;
+import org.scijava.task.event.TaskEvent;
+import org.scijava.event.EventService;
+import org.scijava.event.EventSubscriber;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.script.ScriptService;
 
@@ -48,4 +54,48 @@ public class OpEnvironmentServiceTest {
 		ctx.dispose();
 	}
 
+	/**
+	 * Tests that SciJava Progress updates propagate to SciJava Common's
+	 * {@link TaskService}.
+	 */
+	@Test
+	public void testTaskForwarding() {
+		Context ctx = new Context(OpEnvironmentService.class, TaskService.class,
+			EventService.class);
+		OpEnvironmentService opService = ctx.getService(OpEnvironmentService.class);
+		OpEnvironment env = opService.env();
+		EventService event = ctx.getService(EventService.class);
+
+		// Expected Pings:
+		// 1 - When the task is started
+		// 2 - When the task maximum is set
+		// 3 - When the task value is set to 0
+		// 4 - When the task value is set to maximum
+		// 5 - When the task is finished
+		int[] totalPings = { 0 };
+		EventSubscriber<TaskEvent> e = new EventSubscriber<>() {
+
+			@Override
+			public void onEvent(TaskEvent event) {
+				Task t = event.getTask();
+				totalPings[0]++;
+				// Assert that the max progress is set on the SECOND event
+				Assertions.assertEquals(totalPings[0] < 2 ? 0L : 100L, t
+					.getProgressMaximum());
+				// Assert that the current progress is set on the FOURTH event
+				long expectedValue = totalPings[0] < 4 ? 0L : 100L;
+				Assertions.assertEquals(expectedValue, t.getProgressValue());
+				// Assert that the task is finished on the FIFTH event
+				Assertions.assertEquals(totalPings[0] == 5, t.isDone());
+			}
+
+			@Override
+			public Class<TaskEvent> getEventClass() {
+				return TaskEvent.class;
+			}
+		};
+		event.subscribe(e);
+		env.binary("math.div").input(2, 3).apply();
+		Assertions.assertEquals(5, totalPings[0]);
+	}
 }

--- a/scijava-progress/src/main/java/org/scijava/progress/Progress.java
+++ b/scijava-progress/src/main/java/org/scijava/progress/Progress.java
@@ -187,6 +187,8 @@ public final class Progress {
 			t = parent.task().createSubtask(description);
 		}
 		deque.push(new ProgressibleObject(progressible, t));
+		// Ping Listeners about the registration of progressible
+		pingListeners(deque.peek());
 	}
 
 	/**

--- a/scijava-progress/src/main/java/org/scijava/progress/ProgressListener.java
+++ b/scijava-progress/src/main/java/org/scijava/progress/ProgressListener.java
@@ -29,6 +29,19 @@
 
 package org.scijava.progress;
 
+/**
+ * An object that can subscribe to {@link Task} updates through the
+ * {@link Progress} class. Its singular method,
+ * {@link ProgressListener#acknowledgeUpdate(Task)} is called when an
+ * {@link Object} it is listening to:
+ * <ul>
+ * <li>is registered via {@link Progress#register(Object)}</li>
+ * <li>Updates its progress using e.g. {@link Progress#update()}</li>
+ * <li>is completed via {@link Progress#complete()}</li>
+ * </ul>
+ *
+ * @author Gabriel Selzer
+ */
 @FunctionalInterface
 public interface ProgressListener {
 

--- a/scijava-progress/src/test/java/org/scijava/progress/StatusBasedProgressTest.java
+++ b/scijava-progress/src/test/java/org/scijava/progress/StatusBasedProgressTest.java
@@ -49,13 +49,18 @@ public class StatusBasedProgressTest {
 		int numIterations = 10;
 		Progress.addListener(progressible, new ProgressListener() {
 
+			boolean registered = false;
 			int numUpdates = 0;
 
 			@Override
 			public void acknowledgeUpdate(Task task) {
+				if (!registered) {
+					registered = true;
+					return;
+				}
 				if (numUpdates++ < numIterations) {
-					Assertions.assertTrue(task.status().equals("Setting status: " +
-						(numUpdates)));
+					Assertions.assertEquals(task.status(), "Setting status: " +
+						(numUpdates));
 				}
 				else {
 					Assertions.assertEquals(1., task.progress(), 1e-6);

--- a/scijava-progress/src/test/java/org/scijava/progress/SubtaskProgressTest.java
+++ b/scijava-progress/src/test/java/org/scijava/progress/SubtaskProgressTest.java
@@ -75,10 +75,15 @@ public class SubtaskProgressTest {
 
 			int subtasksCompleted = 0;
 			double middleStageCurrent = 1;
-			double middleStageMax = numIterations;
+			final double middleStageMax = numIterations;
+			boolean started = false;
 
 			@Override
 			public void acknowledgeUpdate(Task task) {
+				if (!started) {
+					started = true;
+					return;
+				}
 				if (subtasksCompleted == 0) {
 					Assertions.assertEquals(1. / 3, task.progress(), 1e-6);
 					subtasksCompleted++;
@@ -115,16 +120,20 @@ public class SubtaskProgressTest {
 		String id = "Running a task with subtasks";
 		Progress.addListener(progressible, new ProgressListener() {
 
-			double currentIterations = 1;
-			double maxIterations = 3;
+			double currentIterations = 0;
+			final double maxIterations = 3;
 
 			@Override
 			public void acknowledgeUpdate(Task task) {
-				Assertions.assertEquals(Math.min(1., currentIterations / maxIterations),
-					task.progress(), 1e-6);
+				if (!task.isComplete()) {
+					Assertions.assertEquals( //
+						Math.min(currentIterations, maxIterations) / maxIterations, //
+						task.progress(), //
+						1e-6 //
+					);
+					currentIterations++;
+				}
 				Assertions.assertEquals(id, task.description());
-				currentIterations++;
-
 			}
 
 		});

--- a/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
+++ b/scijava-progress/src/test/java/org/scijava/progress/TestSuiteProgressListener.java
@@ -9,11 +9,11 @@ public class TestSuiteProgressListener implements ProgressListener {
 	private final long expectedIterations;
 	private double currentIterations = 0;
 
+	private boolean registered = false;
 	private boolean completed = false;
 
 	public TestSuiteProgressListener(final long expectedIterations) {
-		this.id = null;
-		this.expectedIterations = expectedIterations;
+		this(expectedIterations, null);
 	}
 
 	public TestSuiteProgressListener(final long expectedIterations,
@@ -26,10 +26,17 @@ public class TestSuiteProgressListener implements ProgressListener {
 	@Override
 	public void acknowledgeUpdate(Task task) {
 		if (id != null && !task.description().equals(id)) return;
+		// Registration ping
+		if (!registered) {
+			registered = true;
+			return;
+		}
+		// Progress pings
 		if (!task.isComplete()) {
 			Assertions.assertEquals(++currentIterations / expectedIterations, task
 				.progress(), 1e-6);
 		}
+		// Completion ping
 		else {
 			Assertions.assertFalse(completed);
 			Assertions.assertEquals(1., task.progress(), 1e-6);
@@ -43,6 +50,7 @@ public class TestSuiteProgressListener implements ProgressListener {
 
 	public void reset() {
 		this.currentIterations = 0;
+		this.registered = false;
 		this.completed = false;
 	}
 


### PR DESCRIPTION
This PR adds additional benefits to the `DefaultOpEnvironmentService`, namely:
* highly concurrent, lazy `OpEnvironment` initialization using the [Initialization-on-demand holder pattern](https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom)
* Progress forwarding to SciJava Common's `TaskService` (cc @NicoKiaru)