### PR TITLE
Ignore Unnecessary Simplification Pathways and other nice changes

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/MatchingConditions.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/MatchingConditions.java
@@ -70,4 +70,9 @@ public class MatchingConditions {
 		return Objects.hash(request(), hints());
 	}
 
+	@Override
+	public String toString() {
+		return request().toString();
+	}
+
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
@@ -80,7 +80,8 @@ public class DefaultOpMatcher implements OpMatcher {
 		final OpEnvironment env //
 	) {
 		// Develop help message
-		var msg = "No match found! Perhaps you meant: \n" + env.help(request);
+		var msg = "No match found! Perhaps you meant: \n" + env.helpVerbose(
+			request);
 		OpMatchingException agglomerated = new OpMatchingException(msg);
 		list.forEach(agglomerated::addSuppressed);
 		return agglomerated;

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
@@ -167,6 +167,12 @@ public class OpFieldInfo implements OpInfo {
 
 	@Override
 	public StructInstance<?> createOpInstance(List<?> dependencies) {
+		// NB: dependencies are not allowed on field Ops, since field Ops can only
+		// point to a single instance, which allows successive matching calls to
+		// overwrite the dependencies used on earlier matching calls.
+		// This can happen if (a) a single Field is matched multiple times, using
+		// different dependencies, or if (b) multiple fields point to the same
+		// object.
 		if (dependencies != null && !dependencies.isEmpty())
 			throw new IllegalArgumentException(
 				"Op fields are not allowed to have any Op dependencies.");

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplificationPathwayIgnoreTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/simplify/SimplificationPathwayIgnoreTest.java
@@ -1,0 +1,130 @@
+
+package org.scijava.ops.engine.matcher.simplify;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.scijava.function.Computers;
+import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.spi.OpCollection;
+import org.scijava.ops.spi.OpField;
+
+import java.util.function.Function;
+
+public class SimplificationPathwayIgnoreTest extends AbstractTestEnvironment
+	implements OpCollection
+{
+
+	/** Helper Field to keep track of whether a copy Op is called */
+	private static boolean COPIED = false;
+
+	@BeforeAll
+	public static void AddNeededOps() {
+		ops.register(new SimplificationPathwayIgnoreTest());
+	}
+
+	@BeforeEach
+	public void reset() {
+		COPIED = false;
+	}
+
+	@OpField(names = "test.a")
+	public final Computers.Arity1<FocusedA, FocusedA> opA = (a1, o) -> o.set(a1
+		.get() + 1);
+
+	@Test
+	public void testPathwaysNotIgnored() {
+		FocusedA in = new FocusedA(0);
+		FocusedB out = new FocusedB(0);
+		ops.op("test.a").arity1().input(in).output(out).compute();
+		Assertions.assertEquals(1, out.get());
+		Assertions.assertTrue(COPIED);
+	}
+
+	@Test
+	public void testPathwaysIgnored() {
+		FocusedB in = new FocusedB(0);
+		FocusedA out = new FocusedA(0);
+		ops.op("test.a").arity1().input(in).output(out).compute();
+		Assertions.assertEquals(1, out.get());
+		Assertions.assertFalse(COPIED);
+	}
+
+	// -- engine meta-ops -- //
+
+	@OpField(names = "engine.simplify")
+	public final Function<FocusedA, Simple> aSimplifier = (a) -> new Simple(a
+		.get());
+
+	@OpField(names = "engine.simplify")
+	public final Function<FocusedB, Simple> bSimplifier = (b) -> new Simple(b
+		.get());
+
+	@OpField(names = "engine.focus")
+	public final Function<Simple, FocusedA> aFocuser = (s) -> new FocusedA(s
+		.get());
+
+	@OpField(names = "engine.focus")
+	public final Function<Simple, FocusedB> bFocuser = (s) -> new FocusedB(s
+		.get());
+
+	@OpField(names = "engine.copy")
+	public final Computers.Arity1<FocusedA, FocusedA> aCopier = (a1, a2) -> {
+		COPIED = true;
+		a2.set(a1.get());
+	};
+
+	@OpField(names = "engine.copy")
+	public final Computers.Arity1<FocusedB, FocusedB> bCopier = (b1, b2) -> {
+		COPIED = true;
+		b2.set(b1.get());
+	};
+
+	@OpField(names = "engine.copy")
+	public final Computers.Arity1<Simple, Simple> sCopier = (s1, s2) -> {
+		COPIED = true;
+		s2.set(s1.get());
+	};
+
+	// -- Helper classes -- //
+
+	public static abstract class Base {
+
+		int x;
+
+		public Base(int x) {
+			this.set(x);
+		}
+
+		public int get() {
+			return x;
+		}
+
+		public void set(int x) {
+			this.x = x;
+		}
+
+	}
+
+	public static class FocusedA extends Base {
+
+		public FocusedA(int x) {
+			super(x);
+		}
+	}
+
+	public static class FocusedB extends Base {
+
+		public FocusedB(int x) {
+			super(x);
+		}
+	}
+
+	public static class Simple extends Base {
+
+		public Simple(int x) {
+			super(x);
+		}
+	}
+}


### PR DESCRIPTION
This PR makes a couple small changes that arose from work pertaining to #123 and #128, but were unrelated to both PRs and would be nice to share/utilize in both PRs. The major change added is the short-circuiting of unnecessary simplification pathways, which plagues the work in #123.

Unnecessary simplification pathways can be generated when simplification is required for only one parameter in an Op. For example, consider the Op `Computers.Arity3<Mat, Size, Double, Mat>`, which we'd like to call as a `Computers.Arity3<Mat, Size, Integer, Mat>`. The `SimplifiedOpInfo` generated is a `Computers.Arity3<RAI<?>, Size, Number, RAI<?>>`, which can be matched with adequate `engine.simplify`, `engine.focus` and `engine.copy` Ops. The resulting `Mat->RAI<?>->Mat` simplification pathways, however, are completely unnecessary. This PR short-circuits such pathways within the `FocusedOpInfo`, saving lots of computation.

A couple additional changes were made:
* `MatchingConditions.toString()` was added for debugging convenience.
* `DefaultOpMatcher.match`'s exception message no longer calls `OpEnvironment.help()` to avoid `StackOverflowException`s from repeated attempts at simplification.
* Comments were added to explain why `OpFieldInfo`s cannot have any dependencies.