### PR TITLE
Progress enhancements

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/Hints.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/Hints.java
@@ -84,6 +84,23 @@ public class Hints {
 	}
 
 	/**
+	 * Reutrns a <b>new</b> {@link Hints} with:
+	 * <ol>
+	 * <li>All hints in this {@link Hints}</li>
+	 * <li>All hints in {@code other}</li>
+	 * </ol>
+	 *
+	 * @param other the other {@link Hints} object
+	 * @return a <b>new</b> {@link Hints} containing the union of the two sets of
+	 *         hints
+	 */
+	public Hints plus(Hints other) {
+		Set<String> newHints = new HashSet<>(this.hints);
+		newHints.addAll(other.hints);
+		return new Hints(newHints);
+	}
+
+	/**
 	 * Returns a <b>new</b> {@link Hints} with <b>only</b> the hints in this
 	 * {@link Hints} that are not also in {@code hints}
 	 *

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
@@ -86,4 +86,15 @@ public final class BaseOpHints {
 
 	}
 
+	public static final class Progress {
+
+		private Progress() {
+			// Prevent instantiation of static utility class
+		}
+
+		public static final String PREFIX = "progress";
+		public static final String TRACK = PREFIX + ".TRACK";
+
+	}
+
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpDependencyMember.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpDependencyMember.java
@@ -29,6 +29,7 @@
 
 package org.scijava.ops.engine;
 
+import org.scijava.ops.api.Hints;
 import org.scijava.struct.ItemIO;
 import org.scijava.struct.Member;
 
@@ -39,7 +40,7 @@ public interface OpDependencyMember<T> extends Member<T> {
 
 	String getDependencyName();
 
-	boolean isAdaptable();
+	Hints hints();
 
 	// -- Member methods --
 

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -58,9 +59,9 @@ public class ComputersToFunctionsAndLift {
 		Function<Computers.Arity1<I, O>, Function<Iterable<I>, Iterable<O>>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity1<I, O>, Function<I, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Function<I, O>, Function<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -82,9 +83,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<BiFunction<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -107,9 +108,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity3<I1, I2, I3, O>, Functions.Arity3<I1, I2, I3, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -133,9 +134,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<I1, I2, I3, I4, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -159,9 +160,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<I1, I2, I3, I4, I5, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -185,9 +186,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<I1, I2, I3, I4, I5, I6, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -211,9 +212,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -237,9 +238,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -263,9 +264,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -289,9 +290,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -316,9 +317,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -343,9 +344,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -370,9 +371,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -397,9 +398,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -424,9 +425,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -451,9 +452,9 @@ public class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -58,9 +59,9 @@ public class FunctionsToComputersAndLift {
 		Function<Function<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Function<I, O>, Computers.Arity1<I, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity1<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -81,9 +82,9 @@ public class FunctionsToComputersAndLift {
 		Function<Function<I, O>, Computers.Arity1<Iterable<I>, Iterable<O>>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Function<Iterable<I>, Iterable<O>>, Computers.Arity1<Iterable<I>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Function<I, O>, Function<Iterable<I>, Iterable<O>>> lifter;
 
 		/**
@@ -105,9 +106,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -129,9 +130,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>, Computers.Arity2<Iterable<I1>, Iterable<I2>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<BiFunction<I1, I2, O>, BiFunction<Iterable<I1>, Iterable<I2>, Iterable<O>>> lifter;
 
 		/**
@@ -153,9 +154,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -179,9 +180,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>, Computers.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<O>>> lifter;
 
 		/**
@@ -205,9 +206,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -231,9 +232,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>, Computers.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<O>>> lifter;
 
 		/**
@@ -257,9 +258,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -283,9 +284,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>, Computers.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<O>>> lifter;
 
 		/**
@@ -309,9 +310,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -335,9 +336,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>, Computers.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<O>>> lifter;
 
 		/**
@@ -361,9 +362,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -387,9 +388,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>, Computers.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<O>>> lifter;
 
 		/**
@@ -413,9 +414,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -439,9 +440,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>, Computers.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<O>>> lifter;
 
 		/**
@@ -465,9 +466,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -491,9 +492,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>, Computers.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<O>>> lifter;
 
 		/**
@@ -517,9 +518,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -544,9 +545,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>, Computers.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<O>>> lifter;
 
 		/**
@@ -571,9 +572,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -598,9 +599,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>, Computers.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<O>>> lifter;
 
 		/**
@@ -625,9 +626,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -652,9 +653,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>, Computers.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<O>>> lifter;
 
 		/**
@@ -679,9 +680,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -706,9 +707,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>, Computers.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<O>>> lifter;
 
 		/**
@@ -733,9 +734,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -760,9 +761,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>, Computers.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<O>>> lifter;
 
 		/**
@@ -787,9 +788,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -814,9 +815,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>, Computers.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<O>>> lifter;
 
 		/**
@@ -841,9 +842,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**
@@ -868,9 +869,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>, Computers.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { Adaptation.FORBIDDEN })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<Iterable<I1>, Iterable<I2>, Iterable<I3>, Iterable<I4>, Iterable<I5>, Iterable<I6>, Iterable<I7>, Iterable<I8>, Iterable<I9>, Iterable<I10>, Iterable<I11>, Iterable<I12>, Iterable<I13>, Iterable<I14>, Iterable<I15>, Iterable<I16>, Iterable<O>>> lifter;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -57,7 +58,7 @@ public class ComputersToFunctionsViaFunction {
 		Function<Computers.Arity1<I, O>, Function<I, O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I, O> creator;
 
 		/**
@@ -80,7 +81,7 @@ public class ComputersToFunctionsViaFunction {
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -104,7 +105,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -131,7 +132,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -158,7 +159,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -185,7 +186,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -212,7 +213,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -239,7 +240,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -266,7 +267,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -293,7 +294,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -321,7 +322,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -350,7 +351,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -381,7 +382,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -412,7 +413,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -443,7 +444,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**
@@ -474,7 +475,7 @@ public class ComputersToFunctionsViaFunction {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I1, O> creator;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Producer;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -59,7 +60,7 @@ public class ComputersToFunctionsViaSource {
 		Function<Computers.Arity0<O>, Producer<O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -82,7 +83,7 @@ public class ComputersToFunctionsViaSource {
 		Function<Computers.Arity1<I, O>, Function<I, O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -105,7 +106,7 @@ public class ComputersToFunctionsViaSource {
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<I1, I2, O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -129,7 +130,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -156,7 +157,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -183,7 +184,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -210,7 +211,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -237,7 +238,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -264,7 +265,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -291,7 +292,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -318,7 +319,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -346,7 +347,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -375,7 +376,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -406,7 +407,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -437,7 +438,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -468,7 +469,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**
@@ -499,7 +500,7 @@ public class ComputersToFunctionsViaSource {
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Producer<O> creator;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Producer;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -58,7 +59,7 @@ public class FunctionsToComputers {
 		Function<Producer<O>, Computers.Arity0<O>>, Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -80,7 +81,7 @@ public class FunctionsToComputers {
 		Function<Function<I, O>, Computers.Arity1<I, O>>, Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -102,7 +103,7 @@ public class FunctionsToComputers {
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>>, Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -125,7 +126,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -150,7 +151,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -175,7 +176,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -200,7 +201,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -226,7 +227,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -252,7 +253,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -278,7 +279,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -304,7 +305,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -331,7 +332,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -359,7 +360,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -389,7 +390,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -419,7 +420,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -449,7 +450,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**
@@ -479,7 +480,7 @@ public class FunctionsToComputers {
 		Op
 	{
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		Computers.Arity1<O, O> copyOp;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Inplaces;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
 import org.scijava.ops.spi.OpCollection;
@@ -60,9 +61,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Function<Inplaces.Arity1<IO>, Function<IO, IO>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -85,9 +86,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Function<Inplaces.Arity2_1<IO, I2>, BiFunction<IO, I2, IO>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -110,9 +111,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Function<Inplaces.Arity2_2<I1, IO>, BiFunction<I1, IO, IO>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -136,9 +137,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -164,9 +165,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -192,9 +193,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -220,9 +221,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -248,9 +249,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -276,9 +277,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -304,9 +305,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -332,9 +333,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -360,9 +361,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -388,9 +389,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -416,9 +417,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -444,9 +445,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -472,9 +473,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -500,9 +501,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -528,9 +529,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -556,9 +557,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -584,9 +585,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -612,9 +613,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -641,9 +642,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -670,9 +671,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -699,9 +700,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -728,9 +729,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -757,9 +758,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -786,9 +787,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -815,9 +816,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -844,9 +845,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -874,9 +875,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -904,9 +905,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -934,9 +935,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -964,9 +965,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -994,9 +995,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1024,9 +1025,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1054,9 +1055,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1084,9 +1085,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1114,9 +1115,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1144,9 +1145,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1174,9 +1175,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1204,9 +1205,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1234,9 +1235,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1264,9 +1265,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1294,9 +1295,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1324,9 +1325,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1354,9 +1355,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1384,9 +1385,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1414,9 +1415,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1444,9 +1445,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1474,9 +1475,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1504,9 +1505,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1534,9 +1535,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1564,9 +1565,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1594,9 +1595,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1624,9 +1625,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1654,9 +1655,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1684,9 +1685,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1714,9 +1715,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1744,9 +1745,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1774,9 +1775,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1804,9 +1805,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1834,9 +1835,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1864,9 +1865,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1894,9 +1895,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1924,9 +1925,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1954,9 +1955,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -1984,9 +1985,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2017,9 +2018,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2050,9 +2051,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2083,9 +2084,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2116,9 +2117,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2149,9 +2150,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2182,9 +2183,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2215,9 +2216,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2248,9 +2249,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2281,9 +2282,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2313,9 +2314,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2345,9 +2346,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2377,9 +2378,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2410,9 +2411,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2443,9 +2444,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2476,9 +2477,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2509,9 +2510,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2542,9 +2543,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2575,9 +2576,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2608,9 +2609,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2641,9 +2642,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2674,9 +2675,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2707,9 +2708,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2740,9 +2741,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2773,9 +2774,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2806,9 +2807,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2839,9 +2840,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2872,9 +2873,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2905,9 +2906,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2938,9 +2939,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -2971,9 +2972,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3004,9 +3005,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3037,9 +3038,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3070,9 +3071,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3103,9 +3104,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3136,9 +3137,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3169,9 +3170,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3202,9 +3203,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3235,9 +3236,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3268,9 +3269,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3301,9 +3302,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3334,9 +3335,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3367,9 +3368,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3400,9 +3401,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3433,9 +3434,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3466,9 +3467,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3499,9 +3500,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3532,9 +3533,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3565,9 +3566,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3598,9 +3599,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3631,9 +3632,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3664,9 +3665,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3697,9 +3698,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3730,9 +3731,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3763,9 +3764,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3797,9 +3798,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3831,9 +3832,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3865,9 +3866,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3899,9 +3900,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3933,9 +3934,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -3967,9 +3968,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4001,9 +4002,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4035,9 +4036,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4069,9 +4070,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4103,9 +4104,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4137,9 +4138,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4171,9 +4172,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4205,9 +4206,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4239,9 +4240,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**
@@ -4273,9 +4274,9 @@ public class InplacesToFunctions<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I
 		Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints = { Adaptation.FORBIDDEN })
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -35,6 +35,7 @@ import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInstance;
 import org.scijava.ops.api.RichOp;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.MatchingConditions;
 import org.scijava.progress.Progress;
 
@@ -88,7 +89,12 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	@Override
 	public void preprocess(Object... inputs) {
-		Progress.register(this, conditions.request().getName());
+		if (hints().contains(BaseOpHints.Progress.TRACK)) {
+			Progress.register(this, conditions.request().getName());
+		}
+		else {
+			Progress.ignore();
+		}
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/AnnotatedOpDependencyMember.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/AnnotatedOpDependencyMember.java
@@ -29,12 +29,13 @@
 
 package org.scijava.ops.engine.struct;
 
-import java.lang.reflect.Type;
-import java.util.function.Supplier;
-
+import org.scijava.ops.api.Hints;
 import org.scijava.ops.engine.OpDependencyMember;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.struct.Member;
+
+import java.lang.reflect.Type;
+import java.util.function.Supplier;
 
 /**
  * @author Marcel Wiedenmann
@@ -53,6 +54,7 @@ public abstract class AnnotatedOpDependencyMember<T> implements
 
 	private final Type type;
 	private final OpDependency annotation;
+	private final Hints hints;
 
 	/**
 	 * This constructor is ideal for situations where the key and description are
@@ -93,6 +95,7 @@ public abstract class AnnotatedOpDependencyMember<T> implements
 		this.descriptionGenerated = false;
 		this.type = type;
 		this.annotation = annotation;
+		this.hints = new Hints(annotation.hints());
 	}
 
 	public OpDependency getAnnotation() {
@@ -107,8 +110,8 @@ public abstract class AnnotatedOpDependencyMember<T> implements
 	}
 
 	@Override
-	public boolean isAdaptable() {
-		return annotation.adaptable();
+	public Hints hints() {
+		return hints;
 	}
 
 	// -- Member methods --

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/FieldOpDependencyMember.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/struct/FieldOpDependencyMember.java
@@ -31,7 +31,6 @@ package org.scijava.ops.engine.struct;
 
 import java.lang.reflect.Field;
 
-import org.scijava.function.Producer;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.struct.MemberInstance;
 import org.scijava.struct.ValueAccessible;

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/AdaptationTypeVariableCaptureTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/AdaptationTypeVariableCaptureTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.function.Computers;
 import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.*;
 import org.scijava.priority.Priority;
 import org.scijava.types.Any;
@@ -41,7 +42,7 @@ public class AdaptationTypeVariableCaptureTest<N extends Number> extends
 		Function<Computers.Arity1<I, O>, Function<I, O>>, Op
 	{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints = { Adaptation.FORBIDDEN })
 		Function<I, O> creator;
 
 		/**

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/OpAdaptationPriorityTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/OpAdaptationPriorityTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.scijava.function.Computers;
 import org.scijava.function.Producer;
 import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.OpField;
@@ -86,8 +87,8 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment implements
 	@OpMethod(names = "engine.adapt", type = Function.class,
 		priority = Priority.HIGH)
 	public static <I, O> Function<I, O> highPriorityAdaptor( //
-		@OpDependency(name = "engine.create",
-			adaptable = false) Function<I, O> creator, //
+		@OpDependency(name = "engine.create", hints = {
+			BaseOpHints.Adaptation.FORBIDDEN }) Function<I, O> creator, //
 		Computers.Arity1<I, O> computer //
 	) {
 		return (in) -> {
@@ -100,8 +101,8 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment implements
 	@OpMethod(names = "engine.adapt", type = Function.class,
 		priority = Priority.LOW)
 	public static <I, O> Function<I, O> lowPriorityAdaptor( //
-		@OpDependency(name = "engine.create",
-			adaptable = false) Producer<O> creator, //
+		@OpDependency(name = "engine.create", hints = {
+			BaseOpHints.Adaptation.FORBIDDEN }) Producer<O> creator, //
 		Computers.Arity1<I, O> computer //
 	) {
 		return (in) -> {
@@ -112,17 +113,19 @@ public class OpAdaptationPriorityTest extends AbstractTestEnvironment implements
 	}
 
 	@OpField(names = "engine.create")
-	public static final Producer<PriorityThing> priorityThingProducer =
+	public static final Producer<PriorityThing> priorityThingProducer = //
 		() -> new PriorityThing(10000);
 
 	@OpField(names = "engine.create")
-	public static final Function<Double, PriorityThing> priorityThingFunction = (
-		in) -> new PriorityThing(in);
+	public static final Function<Double, PriorityThing> priorityThingFunction = //
+		(in) -> new PriorityThing(in);
 
 	@Test
 	public void testPriority() {
-		PriorityThing pThing = ops.op("test.priorityOp").arity1().input(new Double(
-			10)).outType(PriorityThing.class).apply();
+		PriorityThing pThing = ops.op("test.priorityOp").arity1() //
+			.input(10.0) //
+			.outType(PriorityThing.class) //
+			.apply();
 		assertEquals(20, pThing.getPriority(), 0.);
 		// This would be the value of pThing if it were created using
 		// PriorityThingProducer

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/ComputersToFunctionsAndLift.vm
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -57,9 +58,9 @@ public class ComputersToFunctionsAndLift {
 	public static class Computer${arity}ToFunction${arity}AndLiftViaSource$generics.call($arity)
 			implements Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)>, Op {
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$computerArity.call($arity)$generics.call($arity), $functionArity.call($arity)$generics.call($arity)> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/complexLift/FunctionsToComputersAndLift.vm
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -60,9 +61,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$generics.call($arity)> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$computerArity.call($arity)$generics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**
@@ -84,9 +85,9 @@ public class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$functionArity.call($arity)$iterableGenerics.call($arity), $computerArity.call($arity)$iterableGenerics.call($arity)> adaptor;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={Adaptation.FORBIDDEN})
 		Function<$functionArity.call($arity)$generics.call($arity), $functionArity.call($arity)$iterableGenerics.call($arity)> lifter;
 
 		/**

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaFunction.vm
@@ -39,6 +39,7 @@ import java.util.function.Function;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -59,7 +60,7 @@ public class ComputersToFunctionsViaFunction {
 			Op
 		 {
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints={Adaptation.FORBIDDEN})
 		Function<I#if($arity == 1)#{else}1#end, O> creator;
 
 		/**

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/ComputersToFunctionsViaSource.vm
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Producer;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -61,7 +62,7 @@ public class ComputersToFunctionsViaSource {
 			Op
 		{
 
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints={Adaptation.FORBIDDEN})
 		Producer<O> creator;
 
 		/**

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/FunctionsToComputers.vm
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Producer;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.OpDependency;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
@@ -57,7 +58,7 @@ public class FunctionsToComputers {
 	@OpClass(names = "engine.adapt")
 	public static class Function${arity}ToComputer${arity}$generics.call($arity) implements Function<$functionArity.call($arity)$generics.call($arity), $computerArity.call($arity)$generics.call($arity)>, Op {
 
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints={Adaptation.FORBIDDEN})
 		Computers.Arity1<O, O> copyOp;
 
 		/**

--- a/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.vm
+++ b/scijava-ops-engine/templates/main/java/org/scijava/ops/engine/adapt/functional/InplacesToFunctions.vm
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
 import org.scijava.function.Inplaces;
+import org.scijava.ops.engine.BaseOpHints.Adaptation;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
 import org.scijava.ops.spi.OpCollection;
@@ -59,9 +60,9 @@ public class InplacesToFunctions$generics.call($classArity, $classArity) impleme
 	@OpClass(names = "engine.adapt")
 	public static class Inplace$inplaceSuffix.call($arity, $a)ToFunction${arity}$generics.call($arity, $a) implements Function<$inplaceType.call($arity, $a)$generics.call($arity, $a), $functionArity.call($arity)$functionGenerics.call($arity, $a)>, Op {
 		
-		@OpDependency(name = "engine.create", adaptable = false)
+		@OpDependency(name = "engine.create", hints={Adaptation.FORBIDDEN})
 		private Function<IO, IO> createOp;
-		@OpDependency(name = "engine.copy", adaptable = false)
+		@OpDependency(name = "engine.copy", hints={Adaptation.FORBIDDEN})
 		private Computers.Arity1<IO, IO> copyOp;
 
 		/**

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/ComputersToFunctionsAndLift.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/ComputersToFunctionsAndLift.java
@@ -61,9 +61,9 @@ public final class ComputersToFunctionsAndLift {
 		implements Function<Computers.Arity1<I1, O>, Function<RAII1, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity1<I1, O>, Computers.Arity1<RAII1, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity1<RAII1, RAIO>, Function<RAII1, RAIO>> adapter;
 
 		/**
@@ -90,9 +90,9 @@ public final class ComputersToFunctionsAndLift {
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<RAII1, I2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<RAII1, I2, RAIO>, BiFunction<RAII1, I2, RAIO>> adapter;
 
 		/**
@@ -121,9 +121,9 @@ public final class ComputersToFunctionsAndLift {
 		Function<Computers.Arity2<I1, I2, O>, BiFunction<RAII1, RAII2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<RAII1, RAII2, RAIO>, BiFunction<RAII1, RAII2, RAIO>> adapter;
 
 		/**
@@ -154,9 +154,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<RAII1, I2, I3, RAIO>, Functions.Arity3<RAII1, I2, I3, RAIO>> adapter;
 
 		/**
@@ -187,9 +187,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<RAII1, RAII2, I3, RAIO>, Functions.Arity3<RAII1, RAII2, I3, RAIO>> adapter;
 
 		/**
@@ -220,9 +220,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<RAII1, RAII2, RAII3, RAIO>, Functions.Arity3<RAII1, RAII2, RAII3, RAIO>> adapter;
 
 		/**
@@ -254,9 +254,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<RAII1, I2, I3, I4, RAIO>, Functions.Arity4<RAII1, I2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -288,9 +288,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>, Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -322,9 +322,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>, Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> adapter;
 
 		/**
@@ -356,9 +356,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>, Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> adapter;
 
 		/**
@@ -391,9 +391,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>, Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -426,9 +426,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -461,9 +461,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -496,9 +496,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> adapter;
 
 		/**
@@ -531,9 +531,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> adapter;
 
 		/**
@@ -567,9 +567,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -603,9 +603,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -639,9 +639,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -675,9 +675,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -711,9 +711,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> adapter;
 
 		/**
@@ -747,9 +747,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> adapter;
 
 		/**
@@ -784,9 +784,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -821,9 +821,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -858,9 +858,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -895,9 +895,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -932,9 +932,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -969,9 +969,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> adapter;
 
 		/**
@@ -1006,9 +1006,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> adapter;
 
 		/**
@@ -1045,9 +1045,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1083,9 +1083,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1121,9 +1121,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1159,9 +1159,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1197,9 +1197,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1235,9 +1235,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -1274,9 +1274,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> adapter;
 
 		/**
@@ -1313,9 +1313,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> adapter;
 
 		/**
@@ -1353,9 +1353,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1392,9 +1392,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1431,9 +1431,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1470,9 +1470,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1510,9 +1510,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1550,9 +1550,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1590,9 +1590,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -1630,9 +1630,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> adapter;
 
 		/**
@@ -1670,9 +1670,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> adapter;
 
 		/**
@@ -1711,9 +1711,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1752,9 +1752,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1794,9 +1794,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1836,9 +1836,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1878,9 +1878,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1920,9 +1920,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -1962,9 +1962,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2004,9 +2004,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -2046,9 +2046,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> adapter;
 
 		/**
@@ -2088,9 +2088,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> adapter;
 
 		/**
@@ -2131,9 +2131,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2174,9 +2174,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2217,9 +2217,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2260,9 +2260,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2303,9 +2303,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2346,9 +2346,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2389,9 +2389,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2432,9 +2432,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2475,9 +2475,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -2518,9 +2518,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> adapter;
 
 		/**
@@ -2561,9 +2561,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> adapter;
 
 		/**
@@ -2605,9 +2605,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2649,9 +2649,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2693,9 +2693,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2737,9 +2737,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2781,9 +2781,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2825,9 +2825,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2869,9 +2869,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2913,9 +2913,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -2957,9 +2957,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3001,9 +3001,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -3045,9 +3045,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> adapter;
 
 		/**
@@ -3089,9 +3089,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> adapter;
 
 		/**
@@ -3134,9 +3134,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3179,9 +3179,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3224,9 +3224,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3269,9 +3269,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3314,9 +3314,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3359,9 +3359,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3404,9 +3404,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3449,9 +3449,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3494,9 +3494,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3539,9 +3539,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3584,9 +3584,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -3629,9 +3629,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> adapter;
 
 		/**
@@ -3674,9 +3674,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> adapter;
 
 		/**
@@ -3720,9 +3720,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3766,9 +3766,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3812,9 +3812,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3858,9 +3858,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3904,9 +3904,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3950,9 +3950,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -3996,9 +3996,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4042,9 +4042,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4088,9 +4088,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4134,9 +4134,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4180,9 +4180,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4226,9 +4226,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -4272,9 +4272,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> adapter;
 
 		/**
@@ -4318,9 +4318,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> adapter;
 
 		/**
@@ -4365,9 +4365,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4412,9 +4412,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4459,9 +4459,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4506,9 +4506,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4553,9 +4553,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4600,9 +4600,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4647,9 +4647,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4694,9 +4694,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4741,9 +4741,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4788,9 +4788,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4835,9 +4835,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4882,9 +4882,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4929,9 +4929,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -4976,9 +4976,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> adapter;
 
 		/**
@@ -5023,9 +5023,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> adapter;
 
 		/**
@@ -5071,9 +5071,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5119,9 +5119,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5167,9 +5167,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5215,9 +5215,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5263,9 +5263,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5311,9 +5311,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5359,9 +5359,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5407,9 +5407,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5455,9 +5455,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5503,9 +5503,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5551,9 +5551,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5599,9 +5599,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5647,9 +5647,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5695,9 +5695,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -5743,9 +5743,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> adapter;
 
 		/**
@@ -5791,9 +5791,9 @@ public final class ComputersToFunctionsAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> adapter;
 
 		/**

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/FunctionsToComputersAndLift.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/FunctionsToComputersAndLift.java
@@ -61,9 +61,9 @@ public final class FunctionsToComputersAndLift {
 		implements Function<Function<I1, O>, Computers.Arity1<RAII1, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Function<I1, O>, Computers.Arity1<I1, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity1<I1, O>, Computers.Arity1<RAII1, RAIO>> lifter;
 
 		/**
@@ -88,9 +88,9 @@ public final class FunctionsToComputersAndLift {
 		implements Function<Function<I1, O>, Computers.Arity1<RAII1, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Function<I1, O>, Function<RAII1, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Function<RAII1, RAIO>, Computers.Arity1<RAII1, RAIO>> adapter;
 
 		/**
@@ -117,9 +117,9 @@ public final class FunctionsToComputersAndLift {
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>> lifter;
 
 		/**
@@ -148,9 +148,9 @@ public final class FunctionsToComputersAndLift {
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, I2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<I1, I2, O>, BiFunction<RAII1, I2, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<RAII1, I2, RAIO>, Computers.Arity2<RAII1, I2, RAIO>> adapter;
 
 		/**
@@ -179,9 +179,9 @@ public final class FunctionsToComputersAndLift {
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<I1, I2, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity2<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>> lifter;
 
 		/**
@@ -210,9 +210,9 @@ public final class FunctionsToComputersAndLift {
 		Function<BiFunction<I1, I2, O>, Computers.Arity2<RAII1, RAII2, RAIO>>, Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<I1, I2, O>, BiFunction<RAII1, RAII2, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<BiFunction<RAII1, RAII2, RAIO>, Computers.Arity2<RAII1, RAII2, RAIO>> adapter;
 
 		/**
@@ -243,9 +243,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, I2, I3, RAIO>> lifter;
 
 		/**
@@ -276,9 +276,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, I2, I3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<RAII1, I2, I3, RAIO>, Computers.Arity3<RAII1, I2, I3, RAIO>> adapter;
 
 		/**
@@ -309,9 +309,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
 
 		/**
@@ -342,9 +342,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, I3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<RAII1, RAII2, I3, RAIO>, Computers.Arity3<RAII1, RAII2, I3, RAIO>> adapter;
 
 		/**
@@ -375,9 +375,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Computers.Arity3<I1, I2, I3, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity3<I1, I2, I3, O>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
 
 		/**
@@ -408,9 +408,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<I1, I2, I3, O>, Functions.Arity3<RAII1, RAII2, RAII3, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity3<RAII1, RAII2, RAII3, RAIO>, Computers.Arity3<RAII1, RAII2, RAII3, RAIO>> adapter;
 
 		/**
@@ -442,9 +442,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
 
 		/**
@@ -476,9 +476,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, I2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<RAII1, I2, I3, I4, RAIO>, Computers.Arity4<RAII1, I2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -510,9 +510,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
 
 		/**
@@ -544,9 +544,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<RAII1, RAII2, I3, I4, RAIO>, Computers.Arity4<RAII1, RAII2, I3, I4, RAIO>> adapter;
 
 		/**
@@ -578,9 +578,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
 
 		/**
@@ -612,9 +612,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<RAII1, RAII2, RAII3, I4, RAIO>, Computers.Arity4<RAII1, RAII2, RAII3, I4, RAIO>> adapter;
 
 		/**
@@ -646,9 +646,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<I1, I2, I3, I4, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity4<I1, I2, I3, I4, O>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
 
 		/**
@@ -680,9 +680,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<I1, I2, I3, I4, O>, Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>, Computers.Arity4<RAII1, RAII2, RAII3, RAII4, RAIO>> adapter;
 
 		/**
@@ -715,9 +715,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -750,9 +750,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<RAII1, I2, I3, I4, I5, RAIO>, Computers.Arity5<RAII1, I2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -785,9 +785,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -820,9 +820,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, I3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -855,9 +855,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
 
 		/**
@@ -890,9 +890,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, I4, I5, RAIO>> adapter;
 
 		/**
@@ -925,9 +925,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
 
 		/**
@@ -960,9 +960,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, I5, RAIO>> adapter;
 
 		/**
@@ -995,9 +995,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<I1, I2, I3, I4, I5, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity5<I1, I2, I3, I4, I5, O>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
 
 		/**
@@ -1030,9 +1030,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<I1, I2, I3, I4, I5, O>, Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>, Computers.Arity5<RAII1, RAII2, RAII3, RAII4, RAII5, RAIO>> adapter;
 
 		/**
@@ -1066,9 +1066,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1102,9 +1102,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, I2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1138,9 +1138,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1174,9 +1174,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, I3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1210,9 +1210,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1246,9 +1246,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, I4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1282,9 +1282,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
 
 		/**
@@ -1318,9 +1318,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, I5, I6, RAIO>> adapter;
 
 		/**
@@ -1354,9 +1354,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
 
 		/**
@@ -1390,9 +1390,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, I6, RAIO>> adapter;
 
 		/**
@@ -1426,9 +1426,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<I1, I2, I3, I4, I5, I6, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity6<I1, I2, I3, I4, I5, I6, O>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
 
 		/**
@@ -1462,9 +1462,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<I1, I2, I3, I4, I5, I6, O>, Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>, Computers.Arity6<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAIO>> adapter;
 
 		/**
@@ -1499,9 +1499,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1536,9 +1536,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, I2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1573,9 +1573,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1610,9 +1610,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, I3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1647,9 +1647,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1684,9 +1684,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, I4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1721,9 +1721,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1758,9 +1758,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1795,9 +1795,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
 
 		/**
@@ -1832,9 +1832,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, RAIO>> adapter;
 
 		/**
@@ -1869,9 +1869,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
 
 		/**
@@ -1906,9 +1906,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, RAIO>> adapter;
 
 		/**
@@ -1943,9 +1943,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
 
 		/**
@@ -1981,9 +1981,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<I1, I2, I3, I4, I5, I6, I7, O>, Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>, Computers.Arity7<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAIO>> adapter;
 
 		/**
@@ -2020,9 +2020,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2058,9 +2058,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, I2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2096,9 +2096,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2134,9 +2134,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, I3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2172,9 +2172,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2210,9 +2210,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2248,9 +2248,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2286,9 +2286,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2324,9 +2324,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2362,9 +2362,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2400,9 +2400,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
 
 		/**
@@ -2439,9 +2439,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, RAIO>> adapter;
 
 		/**
@@ -2478,9 +2478,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
 
 		/**
@@ -2517,9 +2517,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, RAIO>> adapter;
 
 		/**
@@ -2556,9 +2556,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
 
 		/**
@@ -2595,9 +2595,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<I1, I2, I3, I4, I5, I6, I7, I8, O>, Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>, Computers.Arity8<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAIO>> adapter;
 
 		/**
@@ -2635,9 +2635,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2674,9 +2674,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -2713,9 +2713,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2752,9 +2752,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -2791,9 +2791,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2830,9 +2830,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -2869,9 +2869,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2909,9 +2909,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -2949,9 +2949,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -2989,9 +2989,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3029,9 +3029,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3069,9 +3069,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3109,9 +3109,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
 
 		/**
@@ -3149,9 +3149,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, RAIO>> adapter;
 
 		/**
@@ -3189,9 +3189,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
 
 		/**
@@ -3229,9 +3229,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, RAIO>> adapter;
 
 		/**
@@ -3269,9 +3269,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
 
 		/**
@@ -3309,9 +3309,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<I1, I2, I3, I4, I5, I6, I7, I8, I9, O>, Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>, Computers.Arity9<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAIO>> adapter;
 
 		/**
@@ -3350,9 +3350,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3391,9 +3391,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3432,9 +3432,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3474,9 +3474,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3516,9 +3516,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3558,9 +3558,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3600,9 +3600,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3642,9 +3642,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3684,9 +3684,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3726,9 +3726,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3768,9 +3768,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3810,9 +3810,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3852,9 +3852,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3894,9 +3894,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -3936,9 +3936,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
 
 		/**
@@ -3978,9 +3978,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, RAIO>> adapter;
 
 		/**
@@ -4020,9 +4020,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
 
 		/**
@@ -4062,9 +4062,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, RAIO>> adapter;
 
 		/**
@@ -4104,9 +4104,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
 
 		/**
@@ -4146,9 +4146,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, O>, Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>, Computers.Arity10<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAIO>> adapter;
 
 		/**
@@ -4189,9 +4189,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4232,9 +4232,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4275,9 +4275,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4318,9 +4318,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4361,9 +4361,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4404,9 +4404,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4447,9 +4447,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4490,9 +4490,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4533,9 +4533,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4576,9 +4576,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4619,9 +4619,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4662,9 +4662,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4705,9 +4705,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4748,9 +4748,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4791,9 +4791,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4834,9 +4834,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4877,9 +4877,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
 
 		/**
@@ -4920,9 +4920,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, RAIO>> adapter;
 
 		/**
@@ -4963,9 +4963,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
 
 		/**
@@ -5006,9 +5006,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, RAIO>> adapter;
 
 		/**
@@ -5049,9 +5049,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
 
 		/**
@@ -5092,9 +5092,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, O>, Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>, Computers.Arity11<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAIO>> adapter;
 
 		/**
@@ -5136,9 +5136,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5180,9 +5180,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5224,9 +5224,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5268,9 +5268,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5312,9 +5312,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5356,9 +5356,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5400,9 +5400,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5444,9 +5444,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5488,9 +5488,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5532,9 +5532,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5576,9 +5576,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5620,9 +5620,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5664,9 +5664,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5708,9 +5708,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5752,9 +5752,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5796,9 +5796,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5840,9 +5840,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5884,9 +5884,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -5928,9 +5928,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
 
 		/**
@@ -5972,9 +5972,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, RAIO>> adapter;
 
 		/**
@@ -6016,9 +6016,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
 
 		/**
@@ -6060,9 +6060,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, RAIO>> adapter;
 
 		/**
@@ -6104,9 +6104,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
 
 		/**
@@ -6148,9 +6148,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, O>, Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>, Computers.Arity12<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAIO>> adapter;
 
 		/**
@@ -6193,9 +6193,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6238,9 +6238,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6283,9 +6283,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6328,9 +6328,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6373,9 +6373,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6418,9 +6418,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6463,9 +6463,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6508,9 +6508,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6553,9 +6553,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6598,9 +6598,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6643,9 +6643,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6688,9 +6688,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6733,9 +6733,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6778,9 +6778,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6823,9 +6823,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6868,9 +6868,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -6913,9 +6913,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -6958,9 +6958,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7003,9 +7003,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7048,9 +7048,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7093,9 +7093,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
 
 		/**
@@ -7138,9 +7138,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, RAIO>> adapter;
 
 		/**
@@ -7183,9 +7183,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
 
 		/**
@@ -7228,9 +7228,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, RAIO>> adapter;
 
 		/**
@@ -7273,9 +7273,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
 
 		/**
@@ -7318,9 +7318,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, O>, Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>, Computers.Arity13<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAIO>> adapter;
 
 		/**
@@ -7364,9 +7364,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7410,9 +7410,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7456,9 +7456,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7502,9 +7502,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7548,9 +7548,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7594,9 +7594,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7640,9 +7640,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7686,9 +7686,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7732,9 +7732,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7778,9 +7778,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7824,9 +7824,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7870,9 +7870,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -7916,9 +7916,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -7962,9 +7962,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8008,9 +8008,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8054,9 +8054,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8100,9 +8100,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8146,9 +8146,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8192,9 +8192,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8238,9 +8238,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8284,9 +8284,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8330,9 +8330,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8376,9 +8376,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
 
 		/**
@@ -8422,9 +8422,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, RAIO>> adapter;
 
 		/**
@@ -8468,9 +8468,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
 
 		/**
@@ -8514,9 +8514,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, RAIO>> adapter;
 
 		/**
@@ -8560,9 +8560,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
 
 		/**
@@ -8606,9 +8606,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, O>, Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>, Computers.Arity14<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAIO>> adapter;
 
 		/**
@@ -8653,9 +8653,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -8700,9 +8700,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -8747,9 +8747,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -8794,9 +8794,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -8841,9 +8841,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -8888,9 +8888,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -8935,9 +8935,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -8982,9 +8982,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9029,9 +9029,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9076,9 +9076,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9123,9 +9123,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9170,9 +9170,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9217,9 +9217,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9264,9 +9264,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9311,9 +9311,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9358,9 +9358,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9405,9 +9405,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9452,9 +9452,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9499,9 +9499,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9546,9 +9546,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9593,9 +9593,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9640,9 +9640,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9687,9 +9687,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9734,9 +9734,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9781,9 +9781,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
 
 		/**
@@ -9828,9 +9828,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, RAIO>> adapter;
 
 		/**
@@ -9875,9 +9875,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
 
 		/**
@@ -9922,9 +9922,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, RAIO>> adapter;
 
 		/**
@@ -9969,9 +9969,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
 
 		/**
@@ -10016,9 +10016,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, O>, Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>, Computers.Arity15<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAIO>> adapter;
 
 		/**
@@ -10064,9 +10064,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10112,9 +10112,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10160,9 +10160,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10208,9 +10208,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10256,9 +10256,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10304,9 +10304,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10352,9 +10352,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10400,9 +10400,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10448,9 +10448,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10496,9 +10496,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10544,9 +10544,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10592,9 +10592,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10640,9 +10640,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10688,9 +10688,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, I8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10736,9 +10736,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10784,9 +10784,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, I9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10832,9 +10832,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10880,9 +10880,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, I10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -10928,9 +10928,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -10976,9 +10976,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, I11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11024,9 +11024,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11072,9 +11072,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, I12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11120,9 +11120,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11168,9 +11168,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, I13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11216,9 +11216,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11264,9 +11264,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, I14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11312,9 +11312,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
 
 		/**
@@ -11360,9 +11360,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, I15, I16, RAIO>> adapter;
 
 		/**
@@ -11408,9 +11408,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
 
 		/**
@@ -11456,9 +11456,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, I16, RAIO>> adapter;
 
 		/**
@@ -11504,9 +11504,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Computers.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
 
 		/**
@@ -11552,9 +11552,9 @@ public final class FunctionsToComputersAndLift {
 		Op
 	{
 
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<I1, I2, I3, I4, I5, I6, I7, I8, I9, I10, I11, I12, I13, I14, I15, I16, O>, Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints = { "adaptation.FORBIDDEN" })
 		Function<Functions.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>, Computers.Arity16<RAII1, RAII2, RAII3, RAII4, RAII5, RAII6, RAII7, RAII8, RAII9, RAII10, RAII11, RAII12, RAII13, RAII14, RAII15, RAII16, RAIO>> adapter;
 
 		/**

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/LiftNeighborhoodComputersToFunctionsOnImgs.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/complexLift/LiftNeighborhoodComputersToFunctionsOnImgs.java
@@ -62,8 +62,8 @@ public final class LiftNeighborhoodComputersToFunctionsOnImgs {
 	 *           type='java.util.function.Function'
 	 */
 	public static <T, U> BiFunction<RandomAccessibleInterval<T>, Shape, Img<T>>
-		adaptUsingShape(@OpDependency(name = "engine.create",
-			adaptable = false) BiFunction<Dimensions, T, Img<T>> creator,
+		adaptUsingShape(@OpDependency(name = "engine.create", hints = {
+			"adaptation.FORBIDDEN" }) BiFunction<Dimensions, T, Img<T>> creator,
 			Computers.Arity1<Neighborhood<T>, T> op)
 	{
 		OutOfBoundsMirrorFactory<T, RandomAccessibleInterval<T>> oobf //
@@ -86,8 +86,8 @@ public final class LiftNeighborhoodComputersToFunctionsOnImgs {
 	@OpMethod(names = "engine.adapt", type = Function.class)
 	public static <T, F extends RandomAccessibleInterval<T>>
 		Functions.Arity3<F, Shape, OutOfBoundsFactory<T, ? super F>, Img<T>>
-		adaptUsingShapeAndOOBF(@OpDependency(name = "engine.create",
-			adaptable = false) BiFunction<Dimensions, T, Img<T>> creator,
+		adaptUsingShapeAndOOBF(@OpDependency(name = "engine.create", hints = {
+			"adaptation.FORBIDDEN" }) BiFunction<Dimensions, T, Img<T>> creator,
 			Computers.Arity1<Neighborhood<T>, T> op)
 	{
 		return (in, shape, oobf) -> {

--- a/scijava-ops-image/templates/main/java/org/scijava/ops/image/adapt/complexLift/ComputersToFunctionsAndLift.vm
+++ b/scijava-ops-image/templates/main/java/org/scijava/ops/image/adapt/complexLift/ComputersToFunctionsAndLift.vm
@@ -71,9 +71,9 @@ public final class ComputersToFunctionsAndLift {
 		 implements Function<Computers.Arity$arity<#foreach($a in [1..$arity])I$a, #{end}O>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> adapter;
 
 		/**

--- a/scijava-ops-image/templates/main/java/org/scijava/ops/image/adapt/complexLift/FunctionsToComputersAndLift.vm
+++ b/scijava-ops-image/templates/main/java/org/scijava/ops/image/adapt/complexLift/FunctionsToComputersAndLift.vm
@@ -71,9 +71,9 @@ public final class FunctionsToComputersAndLift {
 		 implements Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O>, Computers.Arity$arity<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>> adapter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<Computers.Arity${arity}<#foreach($a in [1..$arity])I$a, #{end}O>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
 
 		/**
@@ -106,9 +106,9 @@ public final class FunctionsToComputersAndLift {
 		 implements Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a,#if($a < $arity) #end#end O>, Computers.Arity$arity<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>>,
 			Op
 	{
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])I$a, #{end}O>, $functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> lifter;
-		@OpDependency(name = "engine.adapt", adaptable = false)
+		@OpDependency(name = "engine.adapt", hints={"adaptation.FORBIDDEN"})
 		Function<$functionNames.call($arity)<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>, Computers.Arity${arity}<#foreach($a in [1..$arity])#if($a <= $rai)RAI#{end}I$a, #{end}RAIO>> adapter;
 
 		/**

--- a/scijava-ops-legacy/src/main/java/org/scijava/legacy/types/DatasetTypeExtractor.java
+++ b/scijava-ops-legacy/src/main/java/org/scijava/legacy/types/DatasetTypeExtractor.java
@@ -29,13 +29,12 @@
 
 package org.scijava.legacy.types;
 
-import java.lang.reflect.Type;
-
+import net.imagej.Dataset;
 import org.scijava.priority.Priority;
 import org.scijava.types.TypeExtractor;
 import org.scijava.types.TypeReifier;
 
-import net.imagej.Dataset;
+import java.lang.reflect.Type;
 
 public class DatasetTypeExtractor implements TypeExtractor {
 
@@ -55,4 +54,5 @@ public class DatasetTypeExtractor implements TypeExtractor {
 			object + " cannot be reified because it is not a Dataset!");
 		return r.reify(((Dataset) object).getImgPlus());
 	}
+
 }

--- a/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
+++ b/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
@@ -13,6 +13,8 @@ import org.scijava.event.EventSubscriber;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.script.ScriptService;
 
+import java.util.Collections;
+
 /**
  * Tests {@link OpEnvironmentService} API.
  *
@@ -97,5 +99,6 @@ public class OpEnvironmentServiceTest {
 		event.subscribe(e);
 		env.binary("math.div").input(2, 3).apply();
 		Assertions.assertEquals(5, totalPings[0]);
+		event.unsubscribe(Collections.singletonList(e));
 	}
 }

--- a/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpDependency.java
+++ b/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpDependency.java
@@ -43,5 +43,5 @@ public @interface OpDependency {
 	String name();
 
 	/** Set to false if the dependency should not be adapted */
-	boolean adaptable() default true;
+	String[] hints() default {};
 }

--- a/scijava-progress/src/main/java/org/scijava/progress/Task.java
+++ b/scijava-progress/src/main/java/org/scijava/progress/Task.java
@@ -44,6 +44,9 @@ public class Task {
 
 	// -- FIELDS -- //
 
+	/** The Object that will update its progress */
+	private final Object progressible;
+
 	/** Parent of this task */
 	private final Task parent;
 
@@ -84,14 +87,20 @@ public class Task {
 	private final String description;
 
 	/** Computation status as defined by the task */
-	private String status = "Executing...";
+	private String status = "";
 
-	public Task(final String description) {
-		this.parent = null;
-		this.description = description;
+	public Task( //
+		final Object progressible, //
+		final String description //
+	) {
+		this(progressible, null, description);
 	}
 
-	public Task(final Task parent, final String description) {
+	public Task(final Object progressible, //
+		final Task parent, //
+		final String description)
+	{
+		this.progressible = progressible;
 		this.parent = parent;
 		this.description = description;
 	}
@@ -117,8 +126,11 @@ public class Task {
 	 *
 	 * @return the subtask.
 	 */
-	public synchronized Task createSubtask(String description) {
-		final Task sub = new Task(this, description);
+	public synchronized Task createSubtask( //
+		Object progressible, //
+		String description //
+	) {
+		final Task sub = new Task(progressible, this, description);
 		subTasks.add(sub);
 		return sub;
 	}
@@ -256,10 +268,19 @@ public class Task {
 		if (!updateDefined) throw new IllegalStateException(
 			"Cannot update; progress has not yet been defined!");
 
-		current.addAndGet(numElements);
-		if (current.longValue() == max.longValue()) {
+		long c = current.addAndGet(numElements);
+		if (c == max.longValue()) {
 			resetStage();
 		}
 	}
 
+	/**
+	 * Gets the progressible {@link Object} contributing to this {@link Task}'s
+	 * progress.
+	 *
+	 * @return the progressible {@link Object}
+	 */
+	public Object progressible() {
+		return progressible;
+	}
 }


### PR DESCRIPTION
This PR enables a few enhancements designed to provide Ops more control over the way they report progress, namely:
* Providing access to the current `Task` object, allowing Ops to save it. This can be necessary where the `ThreadLocal` paradigm breaks down, namely within `LoopBuilder` calls.
* By default ignoring the progress updates of `OpDependency`, unless the Op developer wishes for them to be forwarded to the user. 