### PR TITLE
Capture type variables from adapted OpCandidate

### DIFF
--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/AdaptationTypeVariableCaptureTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/adapt/AdaptationTypeVariableCaptureTest.java
@@ -1,0 +1,93 @@
+
+package org.scijava.ops.engine.adapt;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.scijava.function.Computers;
+import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.spi.*;
+import org.scijava.priority.Priority;
+import org.scijava.types.Any;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * When the user requests an {@link Any} as the output, we should ensure that an
+ * output is used that can satisfy the typing constraints of the underlying Op.
+ * In other words, ensure that when an Op is matched for adaptation, we test
+ * that its type variable assignments are captured and used for dependency
+ * matching.
+ *
+ * @param <N>
+ * @author Gabriel Selzer
+ */
+public class AdaptationTypeVariableCaptureTest<N extends Number> extends
+	AbstractTestEnvironment implements OpCollection
+{
+
+	@BeforeAll
+	public static void AddNeededOps() {
+		ops.register(new Computer1ToFunction1ViaFunction<>());
+		ops.register(new AdaptationTypeVariableCaptureTest<>());
+	}
+
+	/** Adaptor */
+	@OpClass(names = "engine.adapt")
+	public static class Computer1ToFunction1ViaFunction<I, O> implements
+		Function<Computers.Arity1<I, O>, Function<I, O>>, Op
+	{
+
+		@OpDependency(name = "engine.create", adaptable = false)
+		Function<I, O> creator;
+
+		/**
+		 * @param computer the Computer to adapt
+		 * @return computer, adapted into a Function
+		 */
+		@Override
+		public Function<I, O> apply(Computers.Arity1<I, O> computer) {
+			return (in) -> {
+				O out = creator.apply(in);
+				computer.compute(in, out);
+				return out;
+			};
+		}
+
+	}
+
+	/** Op that should be adapted */
+	@OpField(names = "test.adaptedCapture")
+	public final Computers.Arity1<List<N>, List<Double>> original = (in, out) -> {
+		out.clear();
+		for (var n : in) {
+			out.add(n.doubleValue());
+		}
+	};
+
+	/** Op that will match if type variables aren't captured */
+	@OpField(names = "engine.create", priority = Priority.HIGH)
+	public final Function<List<Byte>, List<Byte>> highCopier = (list) -> {
+		throw new IllegalStateException("This Op should not be called");
+	};
+
+	/** Op that should match if type variables are captured */
+	@OpField(names = "engine.create", priority = Priority.LOW)
+	public final Function<List<Byte>, List<Double>> lowCopier = (
+		list) -> new ArrayList<>();
+
+	@Test
+	public void testCapture() {
+		List<Byte> in = Arrays.asList((byte) 0, (byte) 1);
+		Object out = ops.op("test.adaptedCapture") //
+			.arity1() //
+			.input(in) //
+			.apply();
+		Assertions.assertInstanceOf(List.class, out);
+		Assertions.assertEquals(2, in.size());
+	}
+
+}


### PR DESCRIPTION
Currently, adaptor dependencies are matched *before* the adapted Op, i.e. if I try to match a `Function<I, O>` using the below adaptor, we will match the dependency *before* we find a `Computer` to apply this adaptor on.
```java
public class FooAdaptor<I, O> implements Function<Computer<I, O>, Function<I, O>> {
    @OpDependency(name="engine.create")
    public final Function<I, O> creator;

    @Override
    public Function<I, O> apply(Computer<I, O> computer) {
        ....
    }
}
```

This is particularly problematic if you want to call the Op using an `Any`, which @elevans has shown me people like to do :wink:

This might match a `Function<I, Any>` dependency, which can yield `ClassCastException`s when you match a `Computer<I, Any>` such that the `Any`s don't line up.

This PR solves the issue by instead matching the *adapted* `Computer<I, O>` first, and then *inferring* the `O` type variable to match the dependencies. In this way, we can ensure that the dependencies are suitable for the adapted Op.