### PR TITLE
Add Hint to control writing to Op history

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
@@ -183,7 +183,11 @@ public interface OpEnvironment extends Prioritized<OpEnvironment> {
 	InfoTree infoTree(final String opName, final Nil<?> specialType,
 		final Nil<?>[] inTypes, final Nil<?> outType, Hints hints);
 
-	<T> T opFromInfoChain(InfoTree tree, Nil<T> specialType);
+	default <T> T opFromInfoChain(InfoTree tree, Nil<T> specialType) {
+		return opFromInfoChain(tree, specialType, getDefaultHints());
+	}
+
+	<T> T opFromInfoChain(InfoTree tree, Nil<T> specialType, Hints hints);
 
 	/**
 	 * Returns an Op fitting the provided arguments.

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpHistory.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpHistory.java
@@ -77,29 +77,7 @@ public interface OpHistory extends Prioritized<OpHistory> {
 	 */
 	List<RichOp<?>> executionsUpon(Object o);
 
-	/**
-	 * Returns the hierarchy of {@link OpInfo}s describing the dependency tree of
-	 * the {@link Object} {@code op}.
-	 *
-	 * @param op the {@link Object} returned by a matching call. NB {@code op}
-	 *          <b>must</b> be the {@link Object} returned by the outermost
-	 *          matching call, as the dependency {@link Object}s are not recorded.
-	 * @return the {@link InfoTree} describing the dependency tree
-	 */
-	InfoTree infoTree(Object op);
-
-	default String signatureOf(Object op) {
-		return infoTree(op).signature();
-	}
-
 	// -- HISTORY MAINTENANCE API -- //
-
-	/**
-	 * Logs the creation of {@link RichOp}
-	 *
-	 * @param op the {@link RichOp} containing relevant information
-	 */
-	void logOp(RichOp<?> op);
 
 	/**
 	 * Logs the {@link Object} output of the {@link RichOp} {@code op}.

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/Ops.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/Ops.java
@@ -67,15 +67,37 @@ public final class Ops {
 	}
 
 	/**
+	 * Convenience function for getting the {@link InfoTree} behind {@code op}
+	 *
+	 * @param op the Op
+	 * @return the {@link InfoTree} of {@code op}
+	 * @throws IllegalArgumentException if {@code op} is not an Op
+	 */
+	public static InfoTree infoTree(Object op) {
+		return rich(op).instance().infoTree();
+	}
+
+	/**
 	 * Convenience function for getting the {@link OpInfo} of {@code op}
 	 *
 	 * @param op the Op
 	 * @return the {@link OpInfo} that generated {@code op}
-	 * @param <T> the type of {@code op}
 	 * @throws IllegalArgumentException if {@code op} is not an Op
 	 */
-	public static <T> OpInfo info(T op) {
-		return rich(op).instance().infoTree().info();
+	public static OpInfo info(Object op) {
+		return infoTree(op).info();
+	}
+
+	/**
+	 * Convenience function for getting the signature of {@code op}
+	 *
+	 * @param op the Op
+	 * @return the signature of {@code op}, which can be used to completely
+	 *         restore {@code op}
+	 * @throws IllegalArgumentException if {@code op} is not an Op
+	 */
+	public static String signature(Object op) {
+		return infoTree(op).signature();
 	}
 
 }

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/Ops.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/Ops.java
@@ -78,27 +78,4 @@ public final class Ops {
 		return rich(op).instance().infoTree().info();
 	}
 
-	/**
-	 * Convenience function for accessing {@link RichOp#recordExecutions(boolean)}
-	 *
-	 * @param op the Op
-	 * @param record true iff {@code op} should record its executions
-	 * @param <T> the type of the Op
-	 * @throws IllegalArgumentException if {@code op} is not an Op
-	 */
-	public static <T> void recordExecutions(T op, boolean record) {
-		rich(op).recordExecutions(record);
-	}
-
-	/**
-	 * Convenience function for accessing {@link RichOp#isRecordingExecutions()}
-	 *
-	 * @param op the Op
-	 * @param <T> the type of the Op
-	 * @return true iff Op is recording its executions
-	 */
-	public static <T> boolean isRecordingExecutions(T op) {
-		return isRich(op) && rich(op).isRecordingExecutions();
-	}
-
 }

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/RichOp.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/RichOp.java
@@ -107,20 +107,4 @@ public interface RichOp<T> extends GenericTyped {
 	default void postprocess(Object output) {
 		// By default, do nothing
 	}
-
-	/**
-	 * Returns true iff this {@link RichOp} is logging its executions in its
-	 * {@link OpHistory}
-	 *
-	 * @return true iff it is recording its executions
-	 */
-	boolean isRecordingExecutions();
-
-	/**
-	 * Designates whether this {@link RichOp} should log its executions to its
-	 * {@link OpHistory}
-	 *
-	 * @param record tells this {@link RichOp} to record its executions iff true.
-	 */
-	void recordExecutions(boolean record);
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
@@ -97,4 +97,15 @@ public final class BaseOpHints {
 
 	}
 
+	public static final class History {
+
+		private History() {
+			// Prevent instantiation of static utility class
+		}
+
+		public static final String PREFIX = "history";
+		public static final String RECORD = PREFIX + ".RECORD";
+
+	}
+
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/BaseOpHints.java
@@ -104,7 +104,7 @@ public final class BaseOpHints {
 		}
 
 		public static final String PREFIX = "history";
-		public static final String RECORD = PREFIX + ".RECORD";
+		public static final String IGNORE = PREFIX + ".IGNORE";
 
 	}
 

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -238,7 +238,9 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	}
 
 	@Override
-	public <T> T opFromInfoChain(final InfoTree tree, final Nil<T> specialType) {
+	public <T> T opFromInfoChain(final InfoTree tree, final Nil<T> specialType,
+		Hints hints)
+	{
 		if (!(specialType.getType() instanceof ParameterizedType))
 			throw new IllegalArgumentException("TODO");
 		@SuppressWarnings("unchecked")
@@ -246,7 +248,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 			.getType());
 		var conditions = MatchingConditions.from( //
 			new InfoMatchingOpRequest(tree.info(), Nil.of(tree.info().opType())), //
-			getDefaultHints() //
+			hints //
 		);
 		RichOp<T> wrappedOp = wrapOp(instance, conditions);
 		return wrappedOp.asOpType();
@@ -623,7 +625,8 @@ public class DefaultOpEnvironment implements OpEnvironment {
 		Hints baseDepHints = hints //
 			.plus( //
 				BaseOpHints.DependencyMatching.IN_PROGRESS, //
-				BaseOpHints.Simplification.FORBIDDEN //
+				BaseOpHints.Simplification.FORBIDDEN, //
+				BaseOpHints.History.IGNORE //
 			).minus(BaseOpHints.Progress.TRACK);
 		// Then, match dependencies
 		final List<RichOp<?>> dependencyChains = new ArrayList<>();

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -769,7 +769,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	@Override
 	public Hints getDefaultHints() {
 		if (environmentHints != null) return environmentHints.copy();
-		return new Hints(BaseOpHints.Progress.TRACK);
+		return new Hints();
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpHistory.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpHistory.java
@@ -64,13 +64,6 @@ public class DefaultOpHistory implements OpHistory {
 
 	// -- DATA STRCUTURES -- //
 
-	/**
-	 * {@link Map} responsible for recording the {@link InfoTree} of
-	 * {@link OpInfo}s involved to produce the result of a particular matching
-	 * call
-	 */
-	private final Map<RichOp<?>, InfoTree> dependencyChain = new WeakHashMap<>();
-
 	private final Map<Object, List<RichOp<?>>> mutationMap = new WeakHashMap<>();
 
 	// -- USER API -- //
@@ -89,21 +82,7 @@ public class DefaultOpHistory implements OpHistory {
 		return mutationMap.getOrDefault(o, Collections.emptyList());
 	}
 
-	@Override
-	public InfoTree infoTree(Object op) {
-		if (op instanceof RichOp<?>) {
-			return dependencyChain.get(op);
-		}
-		throw new IllegalArgumentException("Object " + op +
-			" is not an Op known to this OpHistory!");
-	}
-
 	// -- HISTORY MAINTENANCE API -- //
-
-	@Override
-	public void logOp(RichOp<?> op) {
-		dependencyChain.put(op, op.infoTree());
-	}
 
 	@Override
 	public void logOutput(RichOp<?> op, Object output) {

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
@@ -45,15 +45,11 @@ import java.util.stream.Collectors;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.InfoTree;
 import org.scijava.ops.api.OpMatchingException;
-import org.scijava.ops.engine.OpCandidate;
+import org.scijava.ops.engine.*;
 import org.scijava.ops.engine.OpCandidate.StatusCode;
-import org.scijava.ops.engine.OpDependencyMember;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.OpRequest;
-import org.scijava.ops.engine.BaseOpHints.Adaptation;
-import org.scijava.ops.engine.DependencyMatchingException;
-import org.scijava.ops.engine.MatchingConditions;
 import org.scijava.ops.engine.matcher.MatchingRoutine;
 import org.scijava.ops.engine.matcher.OpMatcher;
 import org.scijava.ops.engine.matcher.impl.DefaultOpRequest;
@@ -73,8 +69,10 @@ public class AdaptationMatchingRoutine implements MatchingRoutine {
 	public void checkSuitability(MatchingConditions conditions)
 		throws OpMatchingException
 	{
-		if (conditions.hints().containsAny(Adaptation.IN_PROGRESS,
-			Adaptation.FORBIDDEN)) //
+		if (conditions.hints().containsAny( //
+			BaseOpHints.Adaptation.IN_PROGRESS, //
+			BaseOpHints.Adaptation.FORBIDDEN //
+		)) //
 			throw new OpMatchingException(
 				"Adaptation is not suitable: Adaptation is disabled");
 	}
@@ -103,7 +101,10 @@ public class AdaptationMatchingRoutine implements MatchingRoutine {
 	public OpCandidate findMatch(MatchingConditions conditions, OpMatcher matcher,
 		OpEnvironment env) throws OpMatchingException
 	{
-		Hints adaptationHints = conditions.hints().plus(Adaptation.IN_PROGRESS);
+		Hints adaptationHints = conditions.hints().plus( //
+			BaseOpHints.Adaptation.IN_PROGRESS, //
+			BaseOpHints.History.IGNORE //
+		);
 		List<Exception> matchingExceptions = new ArrayList<>();
 		List<DependencyMatchingException> depExceptions = new ArrayList<>();
 		for (final OpInfo adaptor : env.infos("engine.adapt")) {

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -99,20 +99,10 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	@Override
 	public void postprocess(Object output) {
-		if (record) {
+		if (hints().contains(BaseOpHints.History.RECORD)) {
 			env.history().logOutput(this, output);
 		}
 		Progress.complete();
-	}
-
-	@Override
-	public boolean isRecordingExecutions() {
-		return record;
-	}
-
-	@Override
-	public void recordExecutions(boolean record) {
-		this.record = record;
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -97,7 +97,7 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 
 	@Override
 	public void postprocess(Object output) {
-		if (hints().contains(BaseOpHints.History.RECORD)) {
+		if (!hints().contains(BaseOpHints.History.IGNORE)) {
 			env.history().logOutput(this, output);
 		}
 		Progress.complete();

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/AbstractRichOp.java
@@ -63,8 +63,6 @@ public abstract class AbstractRichOp<T> implements RichOp<T> {
 		this.instance = instance;
 		this.env = env;
 		this.conditions = conditions;
-
-		this.env.history().logOp(this);
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedInfoTreeGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedInfoTreeGenerator.java
@@ -37,11 +37,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.scijava.function.Computers;
-import org.scijava.ops.api.InfoTree;
-import org.scijava.ops.api.OpEnvironment;
-import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.Ops;
-import org.scijava.ops.api.RichOp;
+import org.scijava.ops.api.*;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.InfoTreeGenerator;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
@@ -66,6 +63,7 @@ public class FocusedInfoTreeGenerator implements InfoTreeGenerator {
 		// Proceed to input simplifiers
 		List<RichOp<Function<?, ?>>> reqSimplifiers = new ArrayList<>();
 		String reqSimpComp = components.get(compIndex);
+		Hints dependencyHints = new Hints(BaseOpHints.History.IGNORE);
 		while (reqSimpComp.startsWith(FocusedOpInfo.INPUT_SIMPLIFIER_DELIMITER)) {
 			String reqSimpSignature = reqSimpComp.substring(
 				FocusedOpInfo.INPUT_SIMPLIFIER_DELIMITER.length());
@@ -73,7 +71,7 @@ public class FocusedInfoTreeGenerator implements InfoTreeGenerator {
 				reqSimpSignature, idMap, generators);
 			reqSimplifiers.add(Ops.rich(env.opFromInfoChain(reqSimpChain,
 				new Nil<>()
-				{})));
+				{}, dependencyHints)));
 			reqSimpComp = components.get(++compIndex);
 		}
 
@@ -89,7 +87,7 @@ public class FocusedInfoTreeGenerator implements InfoTreeGenerator {
 			outFocuserSignature, idMap, generators);
 		RichOp<Function<?, ?>> outputFocuser = Ops.rich(env.opFromInfoChain(
 			outputFocuserTree, new Nil<>()
-			{}));
+			{}, dependencyHints));
 
 		// Proceed to output copier
 		RichOp<Computers.Arity1<?, ?>> copier = null;
@@ -103,7 +101,8 @@ public class FocusedInfoTreeGenerator implements InfoTreeGenerator {
 		if (!outCopySignature.isEmpty()) {
 			InfoTree copierTree = InfoTreeGenerator.generateDependencyTree(env,
 				outCopySignature, idMap, generators);
-			copier = Ops.rich(env.opFromInfoChain(copierTree, new Nil<>() {}));
+			copier = Ops.rich(env.opFromInfoChain(copierTree, new Nil<>() {},
+				dependencyHints));
 		}
 
 		// Proceed to original info

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedOpInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/FocusedOpInfo.java
@@ -381,7 +381,7 @@ public class FocusedOpInfo implements OpInfo {
 		Type copyType = args.get(mutableIndex);
 		// prevent further simplification/adaptation
 		Hints hints = new Hints(BaseOpHints.Adaptation.FORBIDDEN,
-			BaseOpHints.Simplification.FORBIDDEN);
+			BaseOpHints.Simplification.FORBIDDEN, BaseOpHints.History.IGNORE);
 		Nil<?> copyNil = Nil.of(copyType);
 		var op = env.unary("engine.copy", hints).inType(copyNil).outType(copyNil)
 			.computer();
@@ -457,8 +457,11 @@ public class FocusedOpInfo implements OpInfo {
 				.getType() });
 			Type nilToType = Types.parameterize(Nil.class, new Type[] { to
 				.getType() });
-			Hints h = new Hints(BaseOpHints.Adaptation.FORBIDDEN,
-				BaseOpHints.Simplification.FORBIDDEN);
+			Hints h = new Hints( //
+				BaseOpHints.Adaptation.FORBIDDEN, //
+				BaseOpHints.Simplification.FORBIDDEN, //
+				BaseOpHints.History.IGNORE //
+			);
 			LossReporter<T, R> op = env.op("engine.lossReporter", specialTypeNil,
 				new Nil[] { Nil.of(nilFromType), Nil.of(nilToType) }, Nil.of(
 					Double.class), h);

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplificationUtils.java
@@ -168,8 +168,11 @@ public final class SimplificationUtils {
 	}
 
 	public static SimplifiedOpInfo simplifyInfo(OpEnvironment env, OpInfo info) {
-		Hints h = new Hints(BaseOpHints.Adaptation.FORBIDDEN,
-			BaseOpHints.Simplification.FORBIDDEN);
+		Hints h = new Hints( //
+			BaseOpHints.Adaptation.FORBIDDEN, //
+			BaseOpHints.Simplification.FORBIDDEN, //
+			BaseOpHints.History.IGNORE //
+		);
 		List<RichOp<Function<?, ?>>> inFocusers = new ArrayList<>();
 		Type[] args = info.inputTypes().toArray(Type[]::new);
 		for (Type arg : args) {

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedInfoTreeGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedInfoTreeGenerator.java
@@ -36,11 +36,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.scijava.function.Computers;
-import org.scijava.ops.api.InfoTree;
-import org.scijava.ops.api.OpEnvironment;
-import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.Ops;
-import org.scijava.ops.api.RichOp;
+import org.scijava.ops.api.*;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.InfoTreeGenerator;
 import org.scijava.types.Nil;
 
@@ -63,6 +60,7 @@ public class SimplifiedInfoTreeGenerator implements InfoTreeGenerator {
 
 		List<RichOp<Function<?, ?>>> reqFocusers = new ArrayList<>();
 		String reqFocuserComp = components.get(compIndex);
+		Hints dependencyHints = new Hints(BaseOpHints.History.IGNORE);
 		while (reqFocuserComp.startsWith(
 			SimplifiedOpInfo.INPUT_FOCUSER_DELIMITER))
 		{
@@ -73,7 +71,7 @@ public class SimplifiedInfoTreeGenerator implements InfoTreeGenerator {
 
 			reqFocusers.add(Ops.rich(env.opFromInfoChain(reqFocuserChain,
 				new Nil<>()
-				{})));
+				{}, dependencyHints)));
 			reqFocuserComp = components.get(++compIndex);
 		}
 		// Proceed to output simplifier
@@ -88,7 +86,7 @@ public class SimplifiedInfoTreeGenerator implements InfoTreeGenerator {
 			env, outSimpSignature, idMap, generators);
 		RichOp<Function<?, ?>> outSimplifier = Ops.rich(env.opFromInfoChain(
 			outputSimplifierChain, new Nil<>()
-			{}));
+			{}, dependencyHints));
 
 		// Proceed to output copier
 		RichOp<Computers.Arity1<?, ?>> copier = null;
@@ -102,7 +100,8 @@ public class SimplifiedInfoTreeGenerator implements InfoTreeGenerator {
 		if (!outCopySignature.isEmpty()) {
 			InfoTree copierTree = InfoTreeGenerator.generateDependencyTree(env,
 				outCopySignature, idMap, generators);
-			copier = Ops.rich(env.opFromInfoChain(copierTree, new Nil<>() {}));
+			copier = Ops.rich(env.opFromInfoChain(copierTree, new Nil<>() {},
+				dependencyHints));
 		}
 
 		// Proceed to original info

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpRequest.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/simplify/SimplifiedOpRequest.java
@@ -46,8 +46,7 @@ import org.scijava.ops.api.OpMatchingException;
 import org.scijava.ops.api.OpRequest;
 import org.scijava.ops.api.Ops;
 import org.scijava.ops.api.RichOp;
-import org.scijava.ops.engine.BaseOpHints.Adaptation;
-import org.scijava.ops.engine.BaseOpHints.Simplification;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.types.Any;
 import org.scijava.types.Nil;
 import org.scijava.types.Types;
@@ -73,7 +72,11 @@ public class SimplifiedOpRequest implements OpRequest {
 	private final RichOp<Computers.Arity1<?, ?>> outputCopier;
 
 	public SimplifiedOpRequest(OpRequest req, OpEnvironment env) {
-		Hints h = new Hints(Adaptation.FORBIDDEN, Simplification.FORBIDDEN);
+		Hints h = new Hints( //
+			BaseOpHints.Adaptation.FORBIDDEN, //
+			BaseOpHints.Simplification.FORBIDDEN, //
+			BaseOpHints.History.IGNORE //
+		);
 		this.name = req.getName();
 		this.srcReq = req;
 		// Find the simplifiers and focusers
@@ -160,7 +163,11 @@ public class SimplifiedOpRequest implements OpRequest {
 		OpEnvironment env, Type copyType) throws OpMatchingException
 	{
 		// prevent further simplification/adaptation
-		Hints hints = new Hints(Adaptation.FORBIDDEN, Simplification.FORBIDDEN);
+		Hints hints = new Hints( //
+			BaseOpHints.Adaptation.FORBIDDEN, //
+			BaseOpHints.Simplification.FORBIDDEN, //
+			BaseOpHints.History.IGNORE //
+		);
 		Nil<?> copyNil = Nil.of(copyType);
 		var op = env.unary("engine.copy", hints).inType(copyNil).outType(copyNil)
 			.computer();

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/InfoTreeGeneratorTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/InfoTreeGeneratorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.scijava.ops.api.InfoTree;
 import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInfo;
+import org.scijava.ops.api.Ops;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
 import org.scijava.priority.Priority;
@@ -33,7 +34,7 @@ public class InfoTreeGeneratorTest extends AbstractTestEnvironment implements
 		// and by our dummy generator
 		var op = ops.unary("test.infoTreeGeneration").inType(Double.class).outType(
 			Double.class).function();
-		String signature = ops.history().signatureOf(op);
+		String signature = Ops.signature(op);
 		// Run treeFromID to make sure our generator doesn't run
 		var infoTree = ops.treeFromID(signature);
 		// Assert non-null output

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/ProvenanceTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/ProvenanceTest.java
@@ -29,23 +29,13 @@
 
 package org.scijava.ops.engine.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.function.Function;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.collections.ObjectArray;
 import org.scijava.function.Computers;
 import org.scijava.function.Producer;
-import org.scijava.ops.api.Hints;
-import org.scijava.ops.api.InfoTree;
-import org.scijava.ops.api.OpEnvironment;
-import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.RichOp;
+import org.scijava.ops.api.*;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.adapt.functional.ComputersToFunctionsViaFunction;
@@ -55,13 +45,15 @@ import org.scijava.ops.engine.create.CreateOpCollection;
 import org.scijava.ops.engine.matcher.simplify.PrimitiveArraySimplifiers;
 import org.scijava.ops.engine.matcher.simplify.PrimitiveLossReporters;
 import org.scijava.ops.engine.matcher.simplify.PrimitiveSimplifiers;
-import org.scijava.ops.spi.Op;
-import org.scijava.ops.spi.OpClass;
-import org.scijava.ops.spi.OpCollection;
-import org.scijava.ops.spi.OpDependency;
-import org.scijava.ops.spi.OpField;
+import org.scijava.ops.spi.*;
 import org.scijava.priority.Priority;
 import org.scijava.types.Nil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
 
 public class ProvenanceTest extends AbstractTestEnvironment implements
 	OpCollection
@@ -71,11 +63,11 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 	public static void AddNeededOps() {
 		ops.register(new ProvenanceTest());
 		ops.register(new MapperFunc());
-		ops.register(new FunctionToArrays());
+		ops.register(new FunctionToArrays<>());
 		ops.register(new PrimitiveSimplifiers());
-		ops.register(new PrimitiveArraySimplifiers());
+		ops.register(new PrimitiveArraySimplifiers<>());
 		ops.register(new PrimitiveLossReporters());
-		ops.register(new CopyOpCollection());
+		ops.register(new CopyOpCollection<>());
 		ops.register(new CreateOpCollection());
 		Object[] adaptors = objsFromNoArgConstructors(
 			ComputersToFunctionsViaFunction.class.getDeclaredClasses());
@@ -151,7 +143,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 		List<RichOp<?>> executionsUpon = ops.history().executionsUpon(s);
 		Assertions.assertEquals(1, executionsUpon.size());
 		// Assert only one info in the execution hierarchy
-		InfoTree executionHierarchy = ops.history().infoTree(executionsUpon.get(0));
+		InfoTree executionHierarchy = Ops.infoTree(executionsUpon.get(0));
 		Assertions.assertEquals(0, executionHierarchy.dependencies().size());
 		OpInfo info = executionHierarchy.info();
 		Assertions.assertTrue(info.implementationName().contains(this.getClass()
@@ -180,7 +172,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 		List<RichOp<?>> history2 = ops.history().executionsUpon(out2);
 
 		Assertions.assertEquals(1, history1.size());
-		InfoTree opExecutionChain = ops.history().infoTree(history1.get(0));
+		InfoTree opExecutionChain = Ops.infoTree(history1.get(0));
 		Assertions.assertEquals(0, opExecutionChain.dependencies().size());
 		String expected =
 			"public final java.util.function.Function org.scijava.ops.engine.impl.ProvenanceTest.baz";
@@ -188,7 +180,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.getAnnotationBearer().toString());
 
 		Assertions.assertEquals(1, history2.size());
-		opExecutionChain = ops.history().infoTree(history2.get(0));
+		opExecutionChain = Ops.infoTree(history2.get(0));
 		Assertions.assertEquals(0, opExecutionChain.dependencies().size());
 		expected =
 			"public final java.util.function.Function org.scijava.ops.engine.impl.ProvenanceTest.bar";
@@ -221,7 +213,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.input(array).outType(Thing.class).function();
 
 		// Get the InfoTree associated with the above call
-		InfoTree tree = ops.history().infoTree(mapper);
+		InfoTree tree = Ops.infoTree(mapper);
 
 		// Assert the mapper is in the tree
 		Iterator<OpInfo> mapperInfos = ops.infos("test.provenanceMapper")
@@ -275,7 +267,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Thing.class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(mapper);
+		String signature = Ops.signature(mapper);
 		// Generate the Op from the signature and an Op type
 		Nil<Function<Double, Thing>> specialType = new Nil<>() {};
 		Function<Double, Thing> actual = ops //
@@ -298,7 +290,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Thing.class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(mapper);
+		String signature = Ops.signature(mapper);
 		// Generate the Op from the signature and an Op type
 		Nil<Function<Double, Thing>> specialType = new Nil<>() {};
 		Function<Double, Thing> actual = ops //
@@ -321,7 +313,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Thing[].class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(f);
+		String signature = Ops.signature(f);
 		// Generate the Op from the signature and an Op type
 		Nil<Function<Double[], Thing[]>> special = new Nil<>() {};
 		Function<Double[], Thing[]> actual = ops. //
@@ -344,7 +336,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Thing[].class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(f);
+		String signature = Ops.signature(f);
 		// Generate the Op from the signature and an Op type
 		Nil<Function<Double[][], Thing[]>> special = new Nil<>() {};
 		Function<Double[][], Thing[]> actual = ops //
@@ -369,7 +361,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			{}) //
 			.computer();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(c);
+		String signature = Ops.signature(c);
 		// Generate the Op from the signature and an Op type
 		Nil<Computers.Arity1<ObjectArray<Number>, ObjectArray<Number>>> special =
 			new Nil<>()
@@ -401,7 +393,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Integer[].class) //
 			.computer();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(c);
+		String signature = Ops.signature(c);
 		// Generate the Op from the signature and an Op typ
 		Nil<Computers.Arity1<Integer[], Integer[]>> special = new Nil<>() {};
 		Computers.Arity1<Integer[], Integer[]> fromString = ops.opFromSignature(
@@ -428,7 +420,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Integer[].class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(c);
+		String signature = Ops.signature(c);
 		// Generate the Op from the signature and the Op type
 		Nil<Function<Integer[], Integer[]>> special = new Nil<>() {};
 		Function<Integer[], Integer[]> fromString = ops //
@@ -456,7 +448,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 			.outType(Double[].class) //
 			.function();
 		// Get the signature from the Op
-		String signature = ops.history().signatureOf(f);
+		String signature = Ops.signature(f);
 		// Generate the Op from the signature and the Op type
 		Nil<Function<Double[], Double[]>> special = new Nil<>() {};
 		Function<Double[], Double[]> actual = ops //

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/ProvenanceTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/ProvenanceTest.java
@@ -47,6 +47,7 @@ import org.scijava.ops.api.OpEnvironment;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.api.RichOp;
 import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.adapt.functional.ComputersToFunctionsViaFunction;
 import org.scijava.ops.engine.adapt.lift.FunctionToArrays;
 import org.scijava.ops.engine.copy.CopyOpCollection;
@@ -79,6 +80,7 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 		Object[] adaptors = objsFromNoArgConstructors(
 			ComputersToFunctionsViaFunction.class.getDeclaredClasses());
 		ops.register(adaptors);
+		ops.setDefaultHints(new Hints(BaseOpHints.History.RECORD));
 	}
 
 	// -- Test Ops -- //
@@ -238,20 +240,19 @@ public class ProvenanceTest extends AbstractTestEnvironment implements
 	@Test
 	public void testMappingProvenanceAndCaching() {
 		// call (and run) the Op
-		Hints hints = new Hints();
 		int length = 200;
 		Double[] array = new Double[length];
 		Arrays.fill(array, 1.);
-		Thing out = ops.op("test.provenanceMapper", hints).arity1().input(array)
-			.outType(Thing.class).apply();
+		Thing out = ops.op("test.provenanceMapper").arity1().input(array).outType(
+			Thing.class).apply();
 
 		// Assert that two Ops operated on the return.
 		List<RichOp<?>> mutators = ops.history().executionsUpon(out);
 		Assertions.assertEquals(2, mutators.size());
 
 		// Run the mapped Op, assert still two runs on the mapper
-		Thing out1 = ops.op("test.provenanceMapped", hints).arity1().input(2.)
-			.outType(Thing.class).apply();
+		Thing out1 = ops.op("test.provenanceMapped").arity1().input(2.).outType(
+			Thing.class).apply();
 		mutators = ops.history().executionsUpon(out);
 		Assertions.assertEquals(2, mutators.size());
 		// Assert one run on the mapped Op as well

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/map/neighborhood/DefaultMapNeighborhood.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/map/neighborhood/DefaultMapNeighborhood.java
@@ -114,19 +114,8 @@ class MapNeighborhoodAllRAI<I, O> implements
 		RandomAccessibleInterval<Neighborhood<I>> neighborhoodInput = Views
 			.interval(in2.neighborhoodsRandomAccessibleSafe(in1), in1);
 
-		// Temporarily disable recording history
-		boolean isRecording = Ops.isRecordingExecutions(op);
-		if (isRecording) {
-			Ops.recordExecutions(op, false);
-		}
-
 		LoopBuilder.setImages(neighborhoodInput, out).multiThreaded().forEachPixel(
 			op::compute);
-
-		// Re-enable recording history if necessary
-		if (isRecording) {
-			Ops.recordExecutions(op, true);
-		}
 	}
 
 }

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/map/neighborhood/MapNeighborhoodWithCenter.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/map/neighborhood/MapNeighborhoodWithCenter.java
@@ -124,19 +124,8 @@ class MapNeighborhoodWithCenterAllRAI<I, O> implements
 		RandomAccessibleInterval<Neighborhood<I>> neighborhoodInput = Views
 			.interval(in2.neighborhoodsRandomAccessibleSafe(in1), in1);
 
-		// Temporarily disable recording history
-		boolean isRecording = Ops.isRecordingExecutions(centerAwareOp);
-		if (isRecording) {
-			Ops.recordExecutions(centerAwareOp, false);
-		}
-
 		LoopBuilder.setImages(neighborhoodInput, in1, out).multiThreaded()
 			.forEachPixel(centerAwareOp::compute);
-
-		// Re-enable recording history if necessary
-		if (isRecording) {
-			Ops.recordExecutions(centerAwareOp, true);
-		}
 	}
 
 }

--- a/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
+++ b/scijava-ops-legacy/src/test/java/org/scijava/legacy/service/OpEnvironmentServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.scijava.Context;
 import org.scijava.app.StatusService;
+import org.scijava.ops.api.Hints;
 import org.scijava.task.Task;
 import org.scijava.task.TaskService;
 import org.scijava.task.event.TaskEvent;
@@ -97,7 +98,8 @@ public class OpEnvironmentServiceTest {
 			}
 		};
 		event.subscribe(e);
-		env.binary("math.div").input(2, 3).apply();
+		var hints = new Hints("progress.TRACK");
+		env.binary("math.div", hints).input(2, 3).apply();
 		Assertions.assertEquals(5, totalPings[0]);
 		event.unsubscribe(Collections.singletonList(e));
 	}


### PR DESCRIPTION
This PR modifies the behavior of each `AbstractRichOp` to *only* record their executions within the `OpHistory` if a new Op hint `"History.RECORD"` is set. The previous mechanism for recording history, a field `boolean AbstractRichOp.record`, has been removed in favor of adopting the `Hints` paradigm.

The more important change is that recording  to the `OpHistory` is now **opt-in**, where it was opt-out before. This provides performance benefits (anecodotal, found in the process of unrelated benchmarking)

An additional change that is worth scrutiny is the fact that the aspect of History reporting is no longer a mutable property of a `RichOp`. Note there is (should be) nothing stopping users from re-matching an Op with this `Hint`.