### PR TITLE
Improve Conversion with Anys & Other Types Goodness

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -578,7 +578,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 		Map<TypeVariable<?>, Type> dependencyTypeVarAssigns = new HashMap<>();
 		for (var entry : typeVarAssigns.entrySet()) {
 			var value = entry.getValue();
-			if (!value.equals(Any.class) && !(value instanceof Any)) {
+			if (!Any.is(value)) {
 				dependencyTypeVarAssigns.put(entry.getKey(), entry.getValue());
 			}
 		}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
@@ -186,9 +186,7 @@ public class AdaptationMatchingRoutine implements MatchingRoutine {
 					var existing = map.get(key);
 					var replacement = assigns.get(key);
 					// Ignore bounds that are weaker than current bounds.
-					if (Types.isAssignable(existing, replacement) && !existing.equals(
-						Any.class) && !(existing instanceof Any))
-					{
+					if (Types.isAssignable(existing, replacement) && !Any.is(existing)) {
 						continue;
 					}
 				}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
@@ -30,6 +30,7 @@
 package org.scijava.ops.engine.matcher.convert;
 
 import org.scijava.function.Inplaces;
+import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.BaseOpHints.Conversion;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
@@ -44,21 +45,23 @@ import java.util.function.Function;
  * @author Gabriel Selzer
  * @param <T>
  */
-public class IdentityCollection<T> implements OpCollection {
+public class IdentityCollection<T, U extends T> implements OpCollection {
 
 	/**
 	 * @input t the object to be converted
 	 * @output the converted object (since we are doing an identity conversion,
 	 *         this is just a reference to the input object).
 	 */
-	@OpHints(hints = { Conversion.FORBIDDEN })
-	@OpField(names = "engine.convert, engine.identity", priority = Priority.LAST)
-	public final Function<T, T> identity = (t) -> t;
+	@OpHints(hints = { Conversion.FORBIDDEN,
+		BaseOpHints.DependencyMatching.FORBIDDEN })
+	@OpField(names = "engine.convert, engine.identity", priority = Priority.FIRST)
+	public final Function<U, T> identity = (t) -> t;
 
 	/**
 	 * @mutable t the object to be "mutated"
 	 */
 	@OpHints(hints = { Conversion.FORBIDDEN })
-	@OpField(names = "engine.identity", priority = Priority.LAST)
+	@OpField(names = "engine.identity", priority = Priority.FIRST)
 	public final Inplaces.Arity1<T> inplace = (t) -> {};
+
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/MatchingUtils.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/MatchingUtils.java
@@ -105,7 +105,7 @@ public final class MatchingUtils {
 			Type from = froms[i];
 			Type to = tos[i];
 
-			if (to instanceof Any || to.equals(Any.class)) continue;
+			if (Any.is(to)) continue;
 
 			if (from instanceof TypeVariable) {
 				TypeVarInfo typeVarInfo = typeBounds.get(from);

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/convert/ConversionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/convert/ConversionTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Type;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -154,6 +155,18 @@ public class ConversionTest extends AbstractTestEnvironment implements
 			".foo(java.lang.Integer[],java.lang.Double[])|converted_Long_Arr_Byte_Arr";
 		var actImplName = info.implementationName();
 		Assertions.assertEquals(expImplName, actImplName);
+	}
+
+	@OpMethod(names = "test.anyConversion", type = Function.class)
+	public static Integer foo(Integer i1) {
+		return i1 * i1;
+	}
+
+	@Test
+	public void testConvertAnys() {
+		Double in = 2.0;
+		var out = ops.unary("test.anyConversion").input(in).apply();
+		Assertions.assertInstanceOf(Integer.class, out);
 	}
 
 }

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/LiftNeighborhoodComputersToImg.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/adapt/LiftNeighborhoodComputersToImg.java
@@ -65,8 +65,8 @@ public final class LiftNeighborhoodComputersToImg {
 	/**
 	 * @implNote op names='engine.adapt', priority='100.', type=Function
 	 */
-	public static <T, U, F extends RandomAccessibleInterval<T>>
-		Computers.Arity3<F, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
+	public static <T, U, F extends RandomAccessibleInterval<T>, G extends F>
+		Computers.Arity3<G, Shape, OutOfBoundsFactory<T, F>, RandomAccessibleInterval<U>>
 		adapt1UsingShapeAndOOBF(Computers.Arity1<Neighborhood<T>, U> op)
 	{
 		return (in, shape, oobf, out) -> {

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/filter/NonLinearFiltersTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/filter/NonLinearFiltersTest.java
@@ -192,7 +192,6 @@ public class NonLinearFiltersTest extends AbstractOpTest {
 	}
 
 	/**
-	 * @see SigmaFilterOp
 	 * @see DefaultSigmaFilter
 	 */
 	@Test

--- a/scijava-types/src/main/java/org/scijava/types/Any.java
+++ b/scijava-types/src/main/java/org/scijava/types/Any.java
@@ -119,4 +119,8 @@ public final class Any implements Type {
 		return true;
 	}
 
+	public static boolean is(Object o) {
+		return o instanceof Any || o.equals(Any.class);
+	}
+
 }

--- a/scijava-types/src/main/java/org/scijava/types/Types.java
+++ b/scijava-types/src/main/java/org/scijava/types/Types.java
@@ -280,8 +280,7 @@ public final class Types {
 		final boolean wildcardSingleIface)
 	{
 
-		types = Arrays.stream(types).filter(t -> !(t.equals(Any.class) ||
-			t instanceof Any)).toArray(Type[]::new);
+		types = Arrays.stream(types).filter(t -> !(Any.is(t))).toArray(Type[]::new);
 
 		// return answer quick if the answer is trivial
 		if (types.length == 0) return null;
@@ -679,7 +678,7 @@ public final class Types {
 	private static boolean isApplicableToRawTypes(final Type arg,
 		final Type param)
 	{
-		if (arg instanceof Any || arg.equals(Any.class)) return true;
+		if (Any.is(arg)) return true;
 		final List<Class<?>> srcClasses = Types.raws(arg);
 		final List<Class<?>> destClasses = Types.raws(param);
 		for (final Class<?> destClass : destClasses) {
@@ -729,7 +728,7 @@ public final class Types {
 			if (destType instanceof TypeVariable<?>) {
 				final Type srcType = srcTypes[i];
 				final TypeVariable<?> destTypeVar = (TypeVariable<?>) destType;
-				if (srcType instanceof Any || srcType.equals(Any.class)) continue;
+				if (Any.is(srcType)) continue;
 				if (!isApplicableToTypeParameter(srcType, destTypeVar, typeBounds))
 					return false;
 				ignoredIndices.add(i);
@@ -1674,7 +1673,7 @@ public final class Types {
 				return isAssignable(type, (TypeVariable<?>) toType, typeVarAssigns);
 			}
 
-			if (toType instanceof Any) {
+			if (Any.is(toType)) {
 				return isAssignable(type, (Any) toType, typeVarAssigns);
 			}
 
@@ -1787,7 +1786,7 @@ public final class Types {
 				return false;
 			}
 
-			if (type instanceof Any) return true;
+			if (Any.is(type)) return true;
 
 			throw new IllegalStateException("found an unhandled type: " + type);
 		}
@@ -1941,9 +1940,7 @@ public final class Types {
 				// parameters of the target type.
 				if (fromResolved != null && !fromResolved.equals(toResolved)) {
 					// check for anys
-					if (fromResolved instanceof Any || toResolved instanceof Any ||
-						fromResolved.equals(Any.class) || toResolved.equals(Any.class))
-						continue;
+					if (Any.is(fromResolved) || Any.is(toResolved)) continue;
 					if (fromResolved instanceof ParameterizedType &&
 						toResolved instanceof ParameterizedType)
 					{
@@ -1961,9 +1958,7 @@ public final class Types {
 								typeVarAssigns.put((TypeVariable<?>) toTypes[i], fromTypes[i]);
 								continue;
 							}
-							if (!(fromTypes[i] instanceof Any || toTypes[i] instanceof Any ||
-								fromTypes[i].equals(Any.class) || toTypes[i].equals(Any.class)))
-								return false;
+							if (!(Any.is(fromTypes[i]) || Any.is(toTypes[i]))) return false;
 						}
 						continue;
 					}
@@ -2131,7 +2126,7 @@ public final class Types {
 			final GenericArrayType toGenericArrayType,
 			final Map<TypeVariable<?>, Type> typeVarAssigns)
 		{
-			if (type == null || type instanceof Any || type.equals(Any.class)) {
+			if (type == null || Any.is(type)) {
 				return true;
 			}
 
@@ -2211,7 +2206,7 @@ public final class Types {
 			final WildcardType toWildcardType,
 			final Map<TypeVariable<?>, Type> typeVarAssigns)
 		{
-			if (type == null || type instanceof Any || type.equals(Any.class)) {
+			if (type == null || Any.is(type)) {
 				return true;
 			}
 
@@ -2350,11 +2345,12 @@ public final class Types {
 				for (final Type bound : toTypeVarBounds) {
 					if (!isAssignable(type, bound, typeVarAssigns)) return false;
 				}
+				typeVarAssigns.put(toTypeVariable, type);
 
 				return true;
 			}
 
-			if (type instanceof Any || type.equals(Any.class)) {
+			if (Any.is(type)) {
 				typeVarAssigns.put(toTypeVariable, new Any(toTypeVariable.getBounds()));
 				return true;
 			}
@@ -3495,7 +3491,7 @@ public final class Types {
 			if (type instanceof Class) {
 				return classToString((Class<?>) type, done);
 			}
-			if (type instanceof Any) {
+			if (Any.is(type)) {
 				return type.toString();
 			}
 			if (type instanceof ParameterizedType) {


### PR DESCRIPTION
This PR was originally designed to close scijava/scijava#202, however I found myself frustrated that the identity Op was not being properly respected. To that end, I made some changes to the `GenericAssignability` utility class to be a bit stricter, and more correct.

@elevans once this is cleaner I'd love it if you could test this.

TODO:
* [x] Clean
* [x] Test

Closes scijava/scijava#202