### PR TITLE
Use Anys, not wildcards, for converter output types

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConversionMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConversionMatchingRoutine.java
@@ -77,17 +77,11 @@ public class ConversionMatchingRoutine extends RuntimeSafeMatchingRoutine {
 			.hints()))
 		{
 			Conversions.tryConvert(env, info, request).ifPresent(converted -> {
-				Map<TypeVariable<?>, Type> map = new HashMap<>();
-				GenericAssignability.inferTypeVariables( //
-					new Type[] { converted.opType() }, //
-					new Type[] { request.getType() }, //
-					map //
-				);
 				candidates.add(new OpCandidate( //
 					env, //
 					request, //
 					converted, //
-					map //
+					converted.typeVarAssigns() //
 				));
 			});
 		}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedOpInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedOpInfo.java
@@ -94,6 +94,7 @@ public class ConvertedOpInfo implements OpInfo {
 
 	private final OpInfo info;
 	private final OpEnvironment env;
+	private final Map<TypeVariable<?>, Type> typeVarAssigns;
 	final List<RichOp<Function<?, ?>>> preconverters;
 	final List<Type> inTypes;
 	final RichOp<Function<?, ?>> postconverter;
@@ -116,7 +117,8 @@ public class ConvertedOpInfo implements OpInfo {
 			Arrays.asList(inTypes(info.inputTypes(), preconverters)), //
 			postconverter, //
 			outType(info.outputType(), postconverter), copyOp, //
-			env //
+			env, //
+			Collections.emptyMap() //
 		);
 	}
 
@@ -138,7 +140,8 @@ public class ConvertedOpInfo implements OpInfo {
 		RichOp<Function<?, ?>> postconverter, //
 		Type reqOutput, //
 		final RichOp<Computers.Arity1<?, ?>> copyOp, //
-		OpEnvironment env //
+		OpEnvironment env, //
+		Map<TypeVariable<?>, Type> typeVarAssigns //
 	) {
 		this.info = info;
 		this.opType = mapAnys(opType, info);
@@ -153,6 +156,7 @@ public class ConvertedOpInfo implements OpInfo {
 			BaseOpHints.Conversion.FORBIDDEN, //
 			"converted" //
 		);
+		this.typeVarAssigns = typeVarAssigns;
 	}
 
 	/**
@@ -943,4 +947,7 @@ public class ConvertedOpInfo implements OpInfo {
 		return sb.toString();
 	}
 
+	public Map<TypeVariable<?>, Type> typeVarAssigns() {
+		return this.typeVarAssigns;
+	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
@@ -45,7 +45,7 @@ import java.util.function.Function;
  * @author Gabriel Selzer
  * @param <T>
  */
-public class IdentityCollection<T, U extends T> implements OpCollection {
+public class IdentityCollection<T> implements OpCollection {
 
 	/**
 	 * @input t the object to be converted
@@ -55,7 +55,7 @@ public class IdentityCollection<T, U extends T> implements OpCollection {
 	@OpHints(hints = { Conversion.FORBIDDEN,
 		BaseOpHints.DependencyMatching.FORBIDDEN })
 	@OpField(names = "engine.convert, engine.identity", priority = Priority.FIRST)
-	public final Function<U, T> identity = (t) -> t;
+	public final Function<T, T> identity = (t) -> t;
 
 	/**
 	 * @mutable t the object to be "mutated"


### PR DESCRIPTION
Wildcard types are problematic due to the restrictions on e.g. the number of bounds. `Any`s are more flexible in this regard, and better reflect our needs.

TODO:
* [x] Test changeset.