### PR TITLE
Add custom Groovy lexer to sphinx/rtd

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,11 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- General configuration ---------------------------------------------------
-
+import sys
+import os
 from multiproject.utils import get_project
+
+sys.path.insert(0, os.path.abspath('.'))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -55,6 +58,13 @@ exclude_patterns = [
 # -- MyST-Parser/MyST-NB configuration ---------------------------------------
 myst_heading_anchors = 4
 nb_execution_mode = "off"
+
+# -- Custom Lexers -----------------------------------------------------------
+
+from lexers import FijiGroovyLexer
+
+def setup(app):
+    app.add_lexer('fijigroovy', FijiGroovyLexer)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,10 +61,10 @@ nb_execution_mode = "off"
 
 # -- Custom Lexers -----------------------------------------------------------
 
-from lexers import FijiGroovyLexer
+from lexers import SciJavaGroovyLexer
 
 def setup(app):
-    app.add_lexer('fijigroovy', FijiGroovyLexer)
+    app.add_lexer('scijava-groovy', SciJavaGroovyLexer)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/lexers.py
+++ b/docs/lexers.py
@@ -1,82 +1,11 @@
-import re
-from pygments.lexer import RegexLexer, bygroups, using, this, default
-from pygments.token import Comment, Operator, Keyword, Name, String, Number, Whitespace
-from pygments.util import shebang_matches
+from pygments.lexer import inherit
+from pygments.lexers.jvm import GroovyLexer
+from pygments.token import Comment
 
-class FijiGroovyLexer(RegexLexer):
-    """
-    For Groovy source code.
-
-    .. versionadded:: 1.5
-    """
-
-    name = 'Groovy'
-    url = 'https://groovy-lang.org/'
-    aliases = ['fijigroovy']
-    filenames = ['*.groovy','*.gradle']
-    mimetypes = ['text/x-groovy']
-
-    flags = re.MULTILINE | re.DOTALL
-
+class SciJavaGroovyLexer(GroovyLexer):
     tokens = {
-        'root': [
-            # Groovy allows a file to start with a shebang
-            (r'#!(.*?)$', Comment.Preproc, 'base'),
-            default('base'),
-        ],
         'base': [
-            (r'[^\S\n]+', Whitespace),
             (r'#@.*?$', Comment.Single),
-            (r'(//.*?)(\n)', bygroups(Comment.Single, Whitespace)),
-            (r'/\*.*?\*/', Comment.Multiline),
-            # keywords: go before method names to avoid lexing "throw new XYZ"
-            # as a method signature
-            (r'(assert|break|case|catch|continue|default|do|else|finally|for|'
-             r'if|goto|instanceof|new|return|switch|this|throw|try|while|in|as)\b',
-             Keyword),
-            # method names
-            (r'^(\s*(?:[a-zA-Z_][\w.\[\]]*\s+)+?)'  # return arguments
-             r'('
-             r'[a-zA-Z_]\w*'                        # method name
-             r'|"(?:\\\\|\\[^\\]|[^"\\])*"'         # or double-quoted method name
-             r"|'(?:\\\\|\\[^\\]|[^'\\])*'"         # or single-quoted method name
-             r')'
-             r'(\s*)(\()',                          # signature start
-             bygroups(using(this), Name.Function, Whitespace, Operator)),
-            (r'@[a-zA-Z_][\w.]*', Name.Decorator),
-            (r'(abstract|const|enum|extends|final|implements|native|private|'
-             r'protected|public|static|strictfp|super|synchronized|throws|'
-             r'transient|volatile)\b', Keyword.Declaration),
-            (r'(def|boolean|byte|char|double|float|int|long|short|void)\b',
-             Keyword.Type),
-            (r'(package)(\s+)', bygroups(Keyword.Namespace, Whitespace)),
-            (r'(true|false|null)\b', Keyword.Constant),
-            (r'(class|interface)(\s+)', bygroups(Keyword.Declaration, Whitespace),
-             'class'),
-            (r'(import)(\s+)', bygroups(Keyword.Namespace, Whitespace), 'import'),
-            (r'""".*?"""', String.Double),
-            (r"'''.*?'''", String.Single),
-            (r'"(\\\\|\\[^\\]|[^"\\])*"', String.Double),
-            (r"'(\\\\|\\[^\\]|[^'\\])*'", String.Single),
-            (r'\$/((?!/\$).)*/\$', String),
-            (r'/(\\\\|\\[^\\]|[^/\\])*/', String),
-            (r"'\\.'|'[^\\]'|'\\u[0-9a-fA-F]{4}'", String.Char),
-            (r'(\.)([a-zA-Z_]\w*)', bygroups(Operator, Name.Attribute)),
-            (r'[a-zA-Z_]\w*:', Name.Label),
-            (r'[a-zA-Z_$]\w*', Name),
-            (r'[~^*!%&\[\](){}<>|+=:;,./?-]', Operator),
-            (r'[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?', Number.Float),
-            (r'0x[0-9a-fA-F]+', Number.Hex),
-            (r'[0-9]+L?', Number.Integer),
-            (r'\n', Whitespace)
-        ],
-        'class': [
-            (r'[a-zA-Z_]\w*', Name.Class, '#pop')
-        ],
-        'import': [
-            (r'[\w.]+\*?', Name.Namespace, '#pop')
-        ],
+            inherit,
+        ]
     }
-
-    def analyse_text(text):
-        return shebang_matches(text, r'groovy')

--- a/docs/lexers.py
+++ b/docs/lexers.py
@@ -1,0 +1,82 @@
+import re
+from pygments.lexer import RegexLexer, bygroups, using, this, default
+from pygments.token import Comment, Operator, Keyword, Name, String, Number, Whitespace
+from pygments.util import shebang_matches
+
+class FijiGroovyLexer(RegexLexer):
+    """
+    For Groovy source code.
+
+    .. versionadded:: 1.5
+    """
+
+    name = 'Groovy'
+    url = 'https://groovy-lang.org/'
+    aliases = ['fijigroovy']
+    filenames = ['*.groovy','*.gradle']
+    mimetypes = ['text/x-groovy']
+
+    flags = re.MULTILINE | re.DOTALL
+
+    tokens = {
+        'root': [
+            # Groovy allows a file to start with a shebang
+            (r'#!(.*?)$', Comment.Preproc, 'base'),
+            default('base'),
+        ],
+        'base': [
+            (r'[^\S\n]+', Whitespace),
+            (r'#@.*?$', Comment.Single),
+            (r'(//.*?)(\n)', bygroups(Comment.Single, Whitespace)),
+            (r'/\*.*?\*/', Comment.Multiline),
+            # keywords: go before method names to avoid lexing "throw new XYZ"
+            # as a method signature
+            (r'(assert|break|case|catch|continue|default|do|else|finally|for|'
+             r'if|goto|instanceof|new|return|switch|this|throw|try|while|in|as)\b',
+             Keyword),
+            # method names
+            (r'^(\s*(?:[a-zA-Z_][\w.\[\]]*\s+)+?)'  # return arguments
+             r'('
+             r'[a-zA-Z_]\w*'                        # method name
+             r'|"(?:\\\\|\\[^\\]|[^"\\])*"'         # or double-quoted method name
+             r"|'(?:\\\\|\\[^\\]|[^'\\])*'"         # or single-quoted method name
+             r')'
+             r'(\s*)(\()',                          # signature start
+             bygroups(using(this), Name.Function, Whitespace, Operator)),
+            (r'@[a-zA-Z_][\w.]*', Name.Decorator),
+            (r'(abstract|const|enum|extends|final|implements|native|private|'
+             r'protected|public|static|strictfp|super|synchronized|throws|'
+             r'transient|volatile)\b', Keyword.Declaration),
+            (r'(def|boolean|byte|char|double|float|int|long|short|void)\b',
+             Keyword.Type),
+            (r'(package)(\s+)', bygroups(Keyword.Namespace, Whitespace)),
+            (r'(true|false|null)\b', Keyword.Constant),
+            (r'(class|interface)(\s+)', bygroups(Keyword.Declaration, Whitespace),
+             'class'),
+            (r'(import)(\s+)', bygroups(Keyword.Namespace, Whitespace), 'import'),
+            (r'""".*?"""', String.Double),
+            (r"'''.*?'''", String.Single),
+            (r'"(\\\\|\\[^\\]|[^"\\])*"', String.Double),
+            (r"'(\\\\|\\[^\\]|[^'\\])*'", String.Single),
+            (r'\$/((?!/\$).)*/\$', String),
+            (r'/(\\\\|\\[^\\]|[^/\\])*/', String),
+            (r"'\\.'|'[^\\]'|'\\u[0-9a-fA-F]{4}'", String.Char),
+            (r'(\.)([a-zA-Z_]\w*)', bygroups(Operator, Name.Attribute)),
+            (r'[a-zA-Z_]\w*:', Name.Label),
+            (r'[a-zA-Z_$]\w*', Name),
+            (r'[~^*!%&\[\](){}<>|+=:;,./?-]', Operator),
+            (r'[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?', Number.Float),
+            (r'0x[0-9a-fA-F]+', Number.Hex),
+            (r'[0-9]+L?', Number.Integer),
+            (r'\n', Whitespace)
+        ],
+        'class': [
+            (r'[a-zA-Z_]\w*', Name.Class, '#pop')
+        ],
+        'import': [
+            (r'[\w.]+\*?', Name.Namespace, '#pop')
+        ],
+    }
+
+    def analyse_text(text):
+        return shebang_matches(text, r'groovy')

--- a/docs/ops/doc/examples/example_gaussian_subtraction.rst
+++ b/docs/ops/doc/examples/example_gaussian_subtraction.rst
@@ -9,7 +9,7 @@ SciJava Ops via Fiji's sripting engine with `script parameters`_:
 
 .. tabs::
 
-    .. code-tab:: fijigroovy
+    .. code-tab:: scijava-groovy
 
         #@ ImgPlus img
         #@ Double (label="Sigma:", value=5.0) sigma

--- a/docs/ops/doc/examples/example_gaussian_subtraction.rst
+++ b/docs/ops/doc/examples/example_gaussian_subtraction.rst
@@ -9,7 +9,7 @@ SciJava Ops via Fiji's sripting engine with `script parameters`_:
 
 .. tabs::
 
-    .. code-tab:: groovy
+    .. code-tab:: fijigroovy
 
         #@ ImgPlus img
         #@ Double (label="Sigma:", value=5.0) sigma


### PR DESCRIPTION
This PR adds a `lexers.py` module that contains a custom Groovy lexer that adds "#@" lines as comments. To use this custom lexer simply define your code block like so:

```text
.. code-block:: scijava-groovy
```

This PR resolves the annoying errors with "#@" in groovy scripts and stops the error highlighting in our scijava ops docs.