### PR TITLE
Improved Identity Conversions

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/Conversions.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/Conversions.java
@@ -450,6 +450,7 @@ public final class Conversions {
 		Type[] typeParams = Types.typeParamsAgainstClass(t, Types.raw(t));
 		if (t instanceof TypeVariable<?>) {
 			TypeVariable<?> tv = (TypeVariable<?>) t;
+			// Create an Any with the type variable bounds
 			return Nil.of(new Any(tv.getBounds()));
 		}
 		var vars = new HashMap<TypeVariable<?>, Type>();
@@ -457,7 +458,7 @@ public final class Conversions {
 			if (typeParam instanceof TypeVariable<?>) {
 				// Get the type variable
 				TypeVariable<?> from = (TypeVariable<?>) typeParam;
-				// Create a wildcard type with the type variable bounds
+				// Create an Any with the type variable bounds
 				Type to = new Any(from.getBounds());
 				vars.put(from, to);
 			}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/IdentityCollection.java
@@ -40,12 +40,12 @@ import org.scijava.priority.Priority;
 import java.util.function.Function;
 
 /**
- * An {@link OpCollection} containing {@code identity} Ops.
+ * An {@link OpCollection} containing {@code engine.identity} Ops.
  *
  * @author Gabriel Selzer
  * @param <T>
  */
-public class IdentityCollection<T> implements OpCollection {
+public class IdentityCollection<T, U extends T> implements OpCollection {
 
 	/**
 	 * @input t the object to be converted
@@ -55,13 +55,13 @@ public class IdentityCollection<T> implements OpCollection {
 	@OpHints(hints = { Conversion.FORBIDDEN,
 		BaseOpHints.DependencyMatching.FORBIDDEN })
 	@OpField(names = "engine.convert, engine.identity", priority = Priority.FIRST)
-	public final Function<T, T> identity = (t) -> t;
+	public final Function<U, T> identity = t -> t;
 
 	/**
 	 * @mutable t the object to be "mutated"
 	 */
 	@OpHints(hints = { Conversion.FORBIDDEN })
 	@OpField(names = "engine.identity", priority = Priority.FIRST)
-	public final Inplaces.Arity1<T> inplace = (t) -> {};
+	public final Inplaces.Arity1<T> inplace = t -> {};
 
 }

--- a/scijava-types/src/main/java/org/scijava/types/inference/GenericAssignability.java
+++ b/scijava-types/src/main/java/org/scijava/types/inference/GenericAssignability.java
@@ -644,17 +644,11 @@ public final class GenericAssignability {
 					if (bound instanceof TypeVariable) {
 						// This bound might be seen if you write something like
 						// <O extends Number, I extends O> and are trying to infer I from a
-						// Double
-						// The O would be seen here. Right now, we want the O to be assigned
-						// to the broadest
-						// possible type for later assignment
+						// Double, the O would be seen here. It is important that the O
+						// be malleable, as it is not yet fixed, and could be changed to
+						// another type later
 						TypeVariable<?> tv = (TypeVariable<?>) bound;
-						if (tv.getBounds().length == 1) {
-							var b = tv.getBounds()[0];
-							var map = GenericAssignability.inferTypeVariables(b, inferFrom);
-							var mapped = Types.mapVarToTypes(b, map);
-							inferTypeVariables(tv, mapped, typeMappings, true);
-						}
+						inferTypeVariables(tv, inferFrom, typeMappings, true);
 					}
 					else {
 						// Else go into recursion as we encountered a new var.

--- a/scijava-types/src/main/java/org/scijava/types/inference/TypeMapping.java
+++ b/scijava-types/src/main/java/org/scijava/types/inference/TypeMapping.java
@@ -75,17 +75,13 @@ public class TypeMapping {
 	 * {@code typeVar} and {@code mappedType} <em>given</em> the existing
 	 * malleability of {@code mappedType} and the malleability imposed by
 	 * {@code newType}. If {@code newType} cannot be accommodated, a
-	 * {@link TypeInferenceException} will be thrown. Note that it is not a
-	 * guarantee that either the existing {@code mappedType} or {@code newType}
-	 * will become the new {@link #mappedType} after the method ends;
-	 * {@link #mappedType} could be a supertype of these two {@link Type}s.
+	 * {@link TypeInferenceException} will be thrown.
 	 *
 	 * @param otherType - the type that will be refined into {@link #mappedType}
 	 * @param newTypeMalleability - the malleability of {@code otherType},
 	 *          determined by the context from which {@code otherType} came.
 	 */
 	public void refine(Type otherType, boolean newTypeMalleability) {
-		malleable &= newTypeMalleability;
 		if (Any.is(mappedType)) {
 			mappedType = otherType;
 			return;
@@ -93,10 +89,8 @@ public class TypeMapping {
 		if (Any.is(otherType)) {
 			return;
 		}
-		if (mappedType.equals(otherType)) {
-			return;
-		}
 		if (otherType instanceof WildcardType) {
+			malleable &= newTypeMalleability;
 			WildcardType wType = (WildcardType) otherType;
 			if (wType.getLowerBounds().length == 0 && //
 				wType.getUpperBounds().length == 1 && //
@@ -105,11 +99,15 @@ public class TypeMapping {
 				return;
 			}
 		}
-		if (malleable && Types.isAssignable(otherType, mappedType)) {
+		if (malleable && Types.isAssignable(mappedType, otherType)) {
+			malleable &= newTypeMalleability;
 			mappedType = otherType;
 			return;
 		}
-		if (Objects.equal(mappedType, otherType)) return;
+		if (Objects.equal(mappedType, otherType)) {
+			malleable &= newTypeMalleability;
+			return;
+		}
 		throw new TypeInferenceException(typeVar +
 			" cannot simultaneously be mapped to " + otherType + " and " +
 			mappedType);

--- a/scijava-types/src/test/java/org/scijava/types/inference/InferTypeVariablesTest.java
+++ b/scijava-types/src/test/java/org/scijava/types/inference/InferTypeVariablesTest.java
@@ -309,12 +309,12 @@ public class InferTypeVariablesTest {
 		Map<TypeVariable<?>, TypeMapping> typeAssigns = new HashMap<>();
 		GenericAssignability.inferTypeVariables(type, inferFrom, typeAssigns);
 
-		// We expect I= Double, O = Number
+		// We expect I= Double, O = Double
 		Map<TypeVariable<?>, TypeMapping> expected = new HashMap<>();
 		TypeVariable<?> typeVarI = (TypeVariable<?>) new Nil<I>() {}.getType();
 		expected.put(typeVarI, new TypeMapping(typeVarI, Double.class, false));
 		TypeVariable<?> typeVarO = (TypeVariable<?>) new Nil<O>() {}.getType();
-		expected.put(typeVarO, new TypeMapping(typeVarO, Number.class, true));
+		expected.put(typeVarO, new TypeMapping(typeVarO, Double.class, true));
 
 		Assertions.assertEquals(expected, typeAssigns);
 	}


### PR DESCRIPTION
As a byproduct, ambiguous type variables are now mapped to the narrowest possible mapping, not the broadest, and are widened, not narrowed.