### PR TITLE
Add OpInfo.description

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInfo.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpInfo.java
@@ -29,14 +29,14 @@
 
 package org.scijava.ops.api;
 
+import org.scijava.struct.Member;
+import org.scijava.struct.Struct;
+import org.scijava.struct.StructInstance;
+
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.scijava.struct.Member;
-import org.scijava.struct.Struct;
-import org.scijava.struct.StructInstance;
 
 /**
  * Metadata about an Op implementation.
@@ -130,4 +130,9 @@ public interface OpInfo extends Comparable<OpInfo> {
 
 	/** A unique identifier for an Op */
 	String id();
+
+	/** A description of the Op's behavior */
+	default String description() {
+		return "";
+	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -262,8 +262,14 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	public OpInfo opify(final Class<?> opClass, final double priority,
 		String... names)
 	{
-		return new OpClassInfo(opClass, Versions.getVersion(opClass), new Hints(),
-			priority, names);
+		return new OpClassInfo( //
+			opClass, //
+			Versions.getVersion(opClass), //
+			"", //
+			new Hints(), //
+			priority, //
+			names //
+		);
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpClassOpInfoGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpClassOpInfoGenerator.java
@@ -29,19 +29,18 @@
 
 package org.scijava.ops.engine.impl;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.scijava.meta.Versions;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.Ops;
 import org.scijava.ops.engine.OpInfoGenerator;
 import org.scijava.ops.engine.matcher.impl.OpClassInfo;
 import org.scijava.ops.engine.util.Infos;
 import org.scijava.ops.spi.Op;
 import org.scijava.ops.spi.OpClass;
 import org.scijava.ops.spi.OpHints;
+
+import java.util.Collections;
+import java.util.List;
 
 public class OpClassOpInfoGenerator implements OpInfoGenerator {
 
@@ -53,13 +52,14 @@ public class OpClassOpInfoGenerator implements OpInfoGenerator {
 	protected List<OpInfo> processClass(Class<?> c) {
 		OpClass p = c.getAnnotation(OpClass.class);
 		if (p == null) return Collections.emptyList();
-
-		String[] parsedOpNames = Infos.parseNames(p.names());
-		String version = Versions.getVersion(c);
-		Hints hints = formHints(c.getAnnotation(OpHints.class));
-		double priority = p.priority();
-		return Collections.singletonList(new OpClassInfo(c, version, hints,
-			priority, parsedOpNames));
+		return Collections.singletonList(new OpClassInfo( //
+			c, //
+			Versions.getVersion(c), //
+			p.description(), //
+			formHints(c.getAnnotation(OpHints.class)), //
+			p.priority(), //
+			Infos.parseNames(p.names()) //
+		));
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpCollectionInfoGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/OpCollectionInfoGenerator.java
@@ -96,23 +96,28 @@ public class OpCollectionInfoGenerator implements OpInfoGenerator {
 	{
 		final boolean isStatic = Modifier.isStatic(field.getModifiers());
 		OpField annotation = field.getAnnotation(OpField.class);
-		String unparsedOpNames = annotation.names();
-		String[] parsedOpNames = Infos.parseNames(unparsedOpNames);
-		double priority = annotation.priority();
-		Hints hints = formHints(field.getAnnotation(OpHints.class));
-		return new OpFieldInfo(isStatic ? null : instance, field, version, hints,
-			priority, parsedOpNames);
+		return new OpFieldInfo( //
+			isStatic ? null : instance, //
+			field, //
+			version, //
+			annotation.description(), //
+			formHints(field.getAnnotation(OpHints.class)), //
+			annotation.priority(), //
+			Infos.parseNames(annotation.names()) //
+		);
 	}
 
 	private OpMethodInfo generateMethodInfo(Method method, String version) {
 		OpMethod annotation = method.getAnnotation(OpMethod.class);
-		Class<?> opType = annotation.type();
-		String unparsedOpNames = annotation.names();
-		String[] parsedOpNames = Infos.parseNames(unparsedOpNames);
-		Hints hints = formHints(method.getAnnotation(OpHints.class));
-		double priority = annotation.priority();
-		return new OpMethodInfo(method, opType, version, hints, priority,
-			parsedOpNames);
+		return new OpMethodInfo( //
+			method, //
+			annotation.type(), //
+			version, //
+			annotation.description(), //
+			formHints(method.getAnnotation(OpHints.class)), //
+			annotation.priority(), //
+			Infos.parseNames(annotation.names()) //
+		);
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfo.java
@@ -86,6 +86,11 @@ public class OpAdaptationInfo implements OpInfo {
 	}
 
 	@Override
+	public String description() {
+		return srcInfo.description();
+	}
+
+	@Override
 	public List<String> names() {
 		return srcInfo.names();
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedOpInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedOpInfo.java
@@ -199,6 +199,11 @@ public class ConvertedOpInfo implements OpInfo {
 	}
 
 	@Override
+	public String description() {
+		return srcInfo().description();
+	}
+
+	@Override
 	public Type opType() {
 		return opType;
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpClassInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpClassInfo.java
@@ -29,25 +29,23 @@
 
 package org.scijava.ops.engine.matcher.impl;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-
-import org.scijava.meta.Versions;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.engine.OpDependencyMember;
 import org.scijava.ops.engine.struct.ClassOpDependencyMemberParser;
 import org.scijava.ops.engine.struct.ClassParameterMemberParser;
 import org.scijava.ops.engine.util.Infos;
-import org.scijava.priority.Priority;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
 import org.scijava.struct.Structs;
 import org.scijava.types.Types;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Metadata about an Op implementation defined as a class.
@@ -62,26 +60,21 @@ public class OpClassInfo implements OpInfo {
 	private final String version;
 	private final Struct struct;
 	private final double priority;
+	private final String description;
 	private final Hints hints;
 
-	public OpClassInfo(final Class<?> opClass, final Hints hints,
-		final String... names)
-	{
-		this(opClass, Versions.getVersion(opClass), hints, Priority.NORMAL, names);
-	}
-
-	public OpClassInfo(final Class<?> opClass, final String version,
-		final Hints hints, final String... names)
-	{
-		this(opClass, version, hints, Priority.NORMAL, names);
-	}
-
-	public OpClassInfo(final Class<?> opClass, final String version,
-		final Hints hints, final double priority, final String... names)
-	{
+	public OpClassInfo( //
+		final Class<?> opClass, //
+		final String version, //
+		final String description, //
+		final Hints hints, //
+		final double priority, //
+		final String... names //
+	) {
 		this.opClass = opClass;
 		this.version = version;
 		this.names = Arrays.asList(names);
+		this.description = description;
 		this.priority = priority;
 		this.hints = hints;
 
@@ -96,6 +89,11 @@ public class OpClassInfo implements OpInfo {
 	}
 
 	// -- OpInfo methods --
+
+	@Override
+	public String description() {
+		return this.description;
+	}
 
 	@Override
 	public List<String> names() {

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpFieldInfo.java
@@ -29,14 +29,6 @@
 
 package org.scijava.ops.engine.matcher.impl;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-
-import org.scijava.meta.Versions;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.engine.exceptions.impl.PrivateOpException;
@@ -44,11 +36,17 @@ import org.scijava.ops.engine.struct.FieldInstance;
 import org.scijava.ops.engine.struct.FieldParameterMemberParser;
 import org.scijava.ops.engine.util.Infos;
 import org.scijava.ops.spi.OpField;
-import org.scijava.priority.Priority;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
 import org.scijava.struct.Structs;
 import org.scijava.types.Types;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Metadata about an Op implementation defined as a field.
@@ -60,38 +58,25 @@ public class OpFieldInfo implements OpInfo {
 	private final Object instance;
 	private final Field field;
 	private final String version;
+	private final String description;
 	private final List<String> names;
 	private final double priority;
 
-	private Struct struct;
+	private final Struct struct;
 	private final Hints hints;
 
-	public OpFieldInfo(final Object instance, final Field field,
-		final Hints hints, final String... names)
-	{
-		this(instance, field, Versions.getVersion(field.getDeclaringClass()), hints,
-			Priority.NORMAL, names);
-	}
-
-	public OpFieldInfo(final Object instance, final Field field,
-		final Hints hints, final double priority, final String... names)
-	{
-		this(instance, field, Versions.getVersion(field.getDeclaringClass()), hints,
-			priority, names);
-	}
-
-	public OpFieldInfo(final Object instance, final Field field,
-		final String version, final Hints hints, final String... names)
-	{
-		this(instance, field, version, hints, Priority.NORMAL, names);
-	}
-
-	public OpFieldInfo(final Object instance, final Field field,
-		final String version, final Hints hints, final double priority,
-		final String... names)
-	{
+	public OpFieldInfo( //
+		final Object instance, //
+		final Field field, //
+		final String version, //
+		final String description, //
+		final Hints hints, //
+		final double priority, //
+		final String... names //
+	) {
 		this.instance = instance;
 		this.version = version;
+		this.description = description;
 		this.field = field;
 		this.names = Arrays.asList(names);
 		this.priority = priority;
@@ -130,6 +115,11 @@ public class OpFieldInfo implements OpInfo {
 	@Override
 	public List<String> names() {
 		return names;
+	}
+
+	@Override
+	public String description() {
+		return description;
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/OpMethodInfo.java
@@ -29,16 +29,6 @@
 
 package org.scijava.ops.engine.matcher.impl;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-
-import org.scijava.meta.Versions;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.engine.exceptions.impl.InstanceOpMethodException;
@@ -50,12 +40,20 @@ import org.scijava.ops.engine.util.Infos;
 import org.scijava.ops.engine.util.Lambdas;
 import org.scijava.ops.engine.util.internal.OpMethodUtils;
 import org.scijava.ops.spi.OpMethod;
-import org.scijava.priority.Priority;
 import org.scijava.struct.Member;
 import org.scijava.struct.Struct;
 import org.scijava.struct.StructInstance;
 import org.scijava.struct.Structs;
 import org.scijava.types.Types;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Marcel Wiedenmann
@@ -63,6 +61,7 @@ import org.scijava.types.Types;
 public class OpMethodInfo implements OpInfo {
 
 	private final Method method;
+	private final String description;
 	private final String version;
 	private final List<String> names;
 	private final Type opType;
@@ -71,32 +70,18 @@ public class OpMethodInfo implements OpInfo {
 
 	private final Hints hints;
 
-	public OpMethodInfo(final Method method, final Class<?> opType,
-		final Hints hints, final String... names)
-	{
-		this(method, opType, Versions.getVersion(method.getDeclaringClass()), hints,
-			Priority.NORMAL, names);
-	}
-
-	public OpMethodInfo(final Method method, final Class<?> opType,
-		final Hints hints, final double priority, final String... names)
-	{
-		this(method, opType, Versions.getVersion(method.getDeclaringClass()), hints,
-			priority, names);
-	}
-
-	public OpMethodInfo(final Method method, final Class<?> opType,
-		final String version, final Hints hints, final String... names)
-	{
-		this(method, opType, version, hints, Priority.NORMAL, names);
-	}
-
-	public OpMethodInfo(final Method method, final Class<?> opType,
-		final String version, final Hints hints, final double priority,
-		final String... names)
-	{
+	public OpMethodInfo( //
+		final Method method, //
+		final Class<?> opType, //
+		final String version, //
+		final String description, //
+		final Hints hints, //
+		final double priority, //
+		final String... names //
+	) {
 		this.method = method;
 		this.version = version;
+		this.description = description;
 		this.names = Arrays.asList(names);
 		this.hints = hints;
 		this.priority = priority;
@@ -140,6 +125,11 @@ public class OpMethodInfo implements OpInfo {
 	@Override
 	public List<String> names() {
 		return names;
+	}
+
+	@Override
+	public String description() {
+		return description;
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/reduce/ReducedOpInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/reduce/ReducedOpInfo.java
@@ -164,6 +164,11 @@ public class ReducedOpInfo implements OpInfo {
 	}
 
 	@Override
+	public String description() {
+		return srcInfo.description();
+	}
+
+	@Override
 	public double priority() {
 		return srcInfo.priority();
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
@@ -29,6 +29,15 @@
 
 package org.scijava.ops.engine.util;
 
+import org.scijava.ops.api.OpInfo;
+import org.scijava.ops.engine.OpDependencyMember;
+import org.scijava.ops.engine.exceptions.impl.InvalidOpNameException;
+import org.scijava.ops.engine.exceptions.impl.MultipleOutputsOpException;
+import org.scijava.ops.engine.exceptions.impl.UnnamedOpException;
+import org.scijava.struct.ItemIO;
+import org.scijava.struct.Member;
+import org.scijava.types.Types;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -36,22 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import org.scijava.ops.api.Hints;
-import org.scijava.ops.api.OpEnvironment;
-import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.OpMatchingException;
-import org.scijava.ops.engine.BaseOpHints;
-import org.scijava.ops.engine.OpDependencyMember;
-import org.scijava.ops.engine.exceptions.impl.InvalidOpNameException;
-import org.scijava.ops.engine.exceptions.impl.MultipleOutputsOpException;
-import org.scijava.ops.engine.exceptions.impl.UnnamedOpException;
-import org.scijava.struct.ItemIO;
-import org.scijava.struct.Member;
-import org.scijava.types.Nil;
-import org.scijava.types.Types;
 
 /**
  * Utility methods for working with {@link OpInfo}s.
@@ -151,7 +145,13 @@ public final class Infos {
 	 */
 	public static String describe(final OpInfo info) {
 		final StringBuilder sb = new StringBuilder(info.implementationName());
-		// Step 2: Inputs
+		// Step 2: Description (if present)
+		if (!info.description().isEmpty()) {
+			var desc = info.description().replaceAll("\n", "\n\t");
+			sb.append("\n\t").append(desc).append("\n");
+		}
+
+		// Step 3: Inputs
 		for (var member : info.inputs()) {
 			sb.append("\n\t");
 			sb.append("> ").append(member.getKey()) //
@@ -170,7 +170,7 @@ public final class Infos {
 					"\n\t\t"));
 			}
 		}
-		// Step 3: Output
+		// Step 4: Output
 		Member<?> output = info.output();
 		if (output.getIOType() == ItemIO.OUTPUT) {
 			sb.append("\n\tReturns : ").append(typeString(output.getType(), true));

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/AbstractYAMLOpInfoCreator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/AbstractYAMLOpInfoCreator.java
@@ -63,10 +63,12 @@ public abstract class AbstractYAMLOpInfoCreator implements YAMLOpInfoCreator {
 		final String version = yaml.get("version").toString();
 		// Parse names
 		final String[] names = parseNames(yaml, identifier);
+		final String description = yaml.get("description").toString();
 		// Create the OpInfo
 		OpInfo info;
 		try {
-			info = create(srcString, names, parsePriority(yaml), version, yaml);
+			info = create(srcString, names, description, parsePriority(yaml), version,
+				yaml);
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
@@ -177,9 +179,14 @@ public abstract class AbstractYAMLOpInfoCreator implements YAMLOpInfoCreator {
 		return new RenamedMember<>(member, name, desc);
 	}
 
-	protected abstract OpInfo create(final String identifier,
-		final String[] names, final double priority, final String version,
-		Map<String, Object> yaml) throws Exception;
+	protected abstract OpInfo create( //
+		final String identifier, //
+		final String[] names, //
+		final String description, //
+		final double priority, //
+		final String version, //
+		Map<String, Object> yaml //
+	) throws Exception;
 
 	private static class RenamedMember<T> implements Member<T> {
 

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaClassYAMLOpInfoCreator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaClassYAMLOpInfoCreator.java
@@ -53,12 +53,13 @@ public class JavaClassYAMLOpInfoCreator extends AbstractYAMLOpInfoCreator {
 
 	@Override
 	protected OpInfo create(final String identifier, final String[] names,
-		final double priority, String version, Map<String, Object> yaml)
-		throws Exception
+		final String description, final double priority, String version,
+		Map<String, Object> yaml) throws Exception
 	{
 		// parse class
 		Class<?> src = Classes.load(identifier);
 		// Create the OpInfo
-		return new OpClassInfo(src, version, new Hints(), priority, names);
+		return new OpClassInfo(src, version, description, new Hints(), priority,
+			names);
 	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaFieldYAMLOpInfoCreator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaFieldYAMLOpInfoCreator.java
@@ -53,9 +53,14 @@ public class JavaFieldYAMLOpInfoCreator extends AbstractYAMLOpInfoCreator {
 	}
 
 	@Override
-	protected OpInfo create(String identifier, String[] names, double priority,
-		String version, Map<String, Object> yaml) throws Exception
-	{
+	protected OpInfo create( //
+		final String identifier, //
+		final String[] names, //
+		final String description, //
+		final double priority, //
+		final String version, //
+		final Map<String, Object> yaml //
+	) throws Exception {
 		// parse class
 		int clsIndex = identifier.indexOf('$');
 		String clsString = identifier.substring(0, clsIndex);
@@ -66,7 +71,14 @@ public class JavaFieldYAMLOpInfoCreator extends AbstractYAMLOpInfoCreator {
 		Field field = cls.getDeclaredField(fieldString);
 
 		// Create the OpInfo
-		return new OpFieldInfo(instance, field, version, new Hints(), priority,
-			names);
+		return new OpFieldInfo( //
+			instance, //
+			field, //
+			version, //
+			description, //
+			new Hints(), //
+			priority, //
+			names //
+		);
 	}
 }

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaMethodYAMLInfoCreator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/JavaMethodYAMLInfoCreator.java
@@ -58,8 +58,8 @@ public class JavaMethodYAMLInfoCreator extends AbstractYAMLOpInfoCreator {
 	}
 
 	@Override
-	protected OpInfo create(String identifier, String[] names, double priority,
-		String version, Map<String, Object> yaml) throws Exception
+	protected OpInfo create(String identifier, String[] names, String description,
+		double priority, String version, Map<String, Object> yaml) throws Exception
 	{
 		// first, remove generics
 		String rawIdentifier = sanitizeGenerics(identifier);
@@ -84,7 +84,15 @@ public class JavaMethodYAMLInfoCreator extends AbstractYAMLOpInfoCreator {
 		String typeString = (String) tags.getOrDefault("type", "");
 		opType = deriveOpType(identifier, typeString, method);
 
-		return new OpMethodInfo(method, opType, new Hints(), priority, names);
+		return new OpMethodInfo( //
+			method, //
+			opType, //
+			version, //
+			description, //
+			new Hints(), //
+			priority, //
+			names //
+		);
 	}
 
 	private Class<?> deriveOpType(String identifier, String typeString,

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
@@ -34,12 +34,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.function.Computers;
 import org.scijava.function.Inplaces;
+import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.engine.describe.BaseDescriptors;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
 
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -114,6 +116,29 @@ public class DefaultOpDescriptionGeneratorTest extends AbstractTestEnvironment
 		// Finally test that with no inputs we don't get any of the Ops
 		actual = ops.op("test.coalesceDescription").output(null).help();
 		expected = "No Ops found matching this request.";
+		Assertions.assertEquals(expected, actual);
+	}
+
+	private static final String TEST_DESC = "Adds two integers";
+
+	@OpField(names = "math.add", description = TEST_DESC)
+	public final BiFunction<Integer, Integer, Integer> functionAdder = //
+		Integer::sum;
+
+	/**
+	 * Tests that, when an {@link OpInfo} provides a description, it is included
+	 * in the description. The double usage of descriptions is definitely
+	 * confusing!
+	 */
+	@Test
+	public void testDescriptionWithDescription() {
+		String actual = ops.op("math.add").helpVerbose();
+		String expected = "math.add:\n" +
+			"\t- org.scijava.ops.engine.impl.DefaultOpDescriptionGeneratorTest$functionAdder\n" +
+			"\t\t" + TEST_DESC + "\n" + "\t\n" +
+			"\t\t> input1 : java.lang.Integer\n" +
+			"\t\t> input2 : java.lang.Integer\n" + "\t\tReturns : java.lang.Integer";
+		// Assert that helpVerbose shows the description as a part of the result.
 		Assertions.assertEquals(expected, actual);
 	}
 

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/OpMethodDependencyPositionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/OpMethodDependencyPositionTest.java
@@ -65,12 +65,15 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 			List.class, //
 			List.class //
 		);
-		var info = new OpMethodInfo( //
+		// The below call should not throw an Exception
+		Assertions.assertDoesNotThrow(() -> new OpMethodInfo( //
 			m, //
 			Computers.Arity1.class, //
-			new Hints(), //
+			"1.0", //
+			"", new Hints(), //
+			1.0, //
 			"test.dependencyBeforeInput" //
-		);
+		));
 	}
 
 	public static void badDep( //
@@ -126,7 +129,10 @@ public class OpMethodDependencyPositionTest extends AbstractTestEnvironment
 			() -> new OpMethodInfo( //
 				m, //
 				arity, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				names));
 	}
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.scijava.function.Computers;
 import org.scijava.ops.api.Hints;
+import org.scijava.ops.api.Ops;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.engine.adapt.functional.FunctionsToComputers;
 import org.scijava.ops.engine.copy.CopyOpCollection;
@@ -56,17 +57,15 @@ public class OpAdaptationInfoTest extends AbstractTestEnvironment implements
 		ops.register(new FunctionsToComputers.Function2ToComputer2<>());
 	}
 
-	@OpMethod(names = "test.adaptationDescription", type = BiFunction.class)
+	private static final String TEST_DESC = "This is an Op that is being adapted";
+
+	@OpMethod( //
+		names = "test.adaptationDescription", //
+		type = BiFunction.class, //
+		description = TEST_DESC //
+	)
 	public static double[] adaptableOp(final Double t, final Double u) {
 		return new double[] { t, u };
-	}
-
-	static class ClassOp implements BiFunction<Double, Double, Double> {
-
-		@Override
-		public Double apply(Double t, Double u) {
-			return t + u;
-		}
 	}
 
 	@Test
@@ -76,10 +75,14 @@ public class OpAdaptationInfoTest extends AbstractTestEnvironment implements
 			.inType(Double.class, Double.class) //
 			.outType(double[].class) //
 			.computer();
+		var info = Ops.info(adapted);
+		Assertions.assertInstanceOf(OpAdaptationInfo.class, info);
+		Assertions.assertEquals(TEST_DESC, info.description());
 		String expected =
 			"org.scijava.ops.engine.matcher.adapt.OpAdaptationInfoTest.adaptableOp(java.lang.Double,java.lang.Double)\n\t" +
 				"Adaptor: org.scijava.ops.engine.adapt.functional.FunctionsToComputers$Function2ToComputer2\n\t\t" +
 				"Depends upon: org.scijava.ops.engine.copy.CopyOpCollection$copyDoubleArray\n\t" //
+				+ TEST_DESC + "\n\n\t" //
 				+ "> input1 : java.lang.Double\n\t" //
 				+ "> input2 : java.lang.Double\n\t" //
 				+ "> output1 : @CONTAINER double[]";

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/convert/ConversionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/convert/ConversionTest.java
@@ -42,9 +42,7 @@ import org.scijava.ops.engine.conversionLoss.impl.PrimitiveLossReporters;
 import org.scijava.ops.engine.copy.CopyOpCollection;
 import org.scijava.ops.engine.create.CreateOpCollection;
 import org.scijava.ops.engine.matcher.impl.LossReporterWrapper;
-import org.scijava.ops.spi.OpCollection;
-import org.scijava.ops.spi.OpField;
-import org.scijava.ops.spi.OpMethod;
+import org.scijava.ops.spi.*;
 
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -75,7 +73,8 @@ public class ConversionTest extends AbstractTestEnvironment implements
 			new PrimitiveConverters<>(), //
 			new PrimitiveLossReporters(), //
 			new ConversionTest(), //
-			new UtilityConverters() //
+			new UtilityConverters(), //
+			new DivOp() //
 		);
 	}
 
@@ -232,6 +231,32 @@ public class ConversionTest extends AbstractTestEnvironment implements
 			.inType(Double.class, Double.class) //
 			.outType(Number.class) //
 			.function();
+	}
+
+	private static final String TEST_DESC = "This Op will be converted";
+
+	@OpClass(names = "math.div", description = TEST_DESC)
+	private static class DivOp implements BiFunction<Integer, Integer, Integer>,
+		Op
+	{
+
+		@Override
+		public Integer apply(Integer i1, Integer i2) {
+			return i1 / i2;
+		}
+	}
+
+	/**
+	 * Tests that {@link ConvertedOpInfo#description()} returns the source
+	 * {@link OpInfo} description
+	 */
+	@Test
+	public void testConversionDescription() {
+		var op = ops.op("math.div").input(5.0, 2.0).function();
+		var info = Ops.info(op);
+		Assertions.assertInstanceOf(ConvertedOpInfo.class, info);
+		Assertions.assertEquals(TEST_DESC, info.description());
+		Assertions.assertTrue(info.toString().contains(TEST_DESC));
 	}
 
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpClassInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpClassInfoTest.java
@@ -57,7 +57,10 @@ public class OpClassInfoTest {
 		Assertions.assertThrows(FinalOpDependencyFieldException.class, () -> //
 		new OpClassInfo( //
 			FinalOpDependency.class, //
+			"1.0", //
+			"", //
 			new Hints(), //
+			1.0, //
 			"finalDependency" //
 		));
 	}
@@ -73,7 +76,10 @@ public class OpClassInfoTest {
 		Assertions.assertThrows(FunctionalTypeOpException.class,
 			() -> new OpClassInfo( //
 				ImmutableOutput.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"finalDependency" //
 			));
 	}

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpDescriptionTest.java
@@ -54,8 +54,14 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testOpClassDescription() {
-		OpClassInfo info = new OpClassInfo(ClassOp.class, new Hints(),
-			"test.classDescription");
+		OpClassInfo info = new OpClassInfo( //
+			ClassOp.class, //
+			"1.0", //
+			"", //
+			new Hints(), //
+			1.0, //
+			"test.classDescription" //
+		);
 
 		String expected =
 			"org.scijava.ops.engine.matcher.impl.OpDescriptionTest$ClassOp\n\t" //
@@ -74,8 +80,15 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 	public void testOpMethodDescription() throws NoSuchMethodException {
 		Method method = OpDescriptionTest.class.getMethod("methodOp", Double.class,
 			Double.class);
-		OpMethodInfo info = new OpMethodInfo(method, BiFunction.class, new Hints(),
-			"test.methodDescription");
+		OpMethodInfo info = new OpMethodInfo( //
+			method, //
+			BiFunction.class, //
+			"1.0", //
+			"", //
+			new Hints(), //
+			1.0, //
+			"test.methodDescription" //
+		);
 		String expected =
 			"org.scijava.ops.engine.matcher.impl.OpDescriptionTest.methodOp(java.lang.Double,java.lang.Double)\n\t" //
 				+ "> input1 : java.lang.Double\n\t" //
@@ -90,8 +103,15 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 	@Test
 	public void testOpFieldDescription() throws NoSuchFieldException {
 		Field field = OpDescriptionTest.class.getDeclaredField("fieldOp");
-		OpFieldInfo info = new OpFieldInfo(this, field, new Hints(),
-			"test.fieldDescription");
+		OpFieldInfo info = new OpFieldInfo( //
+			this, //
+			field, //
+			"", //
+			"", //
+			new Hints(), //
+			1.0, //
+			"test.fieldDescription" //
+		);
 		String expected =
 			"org.scijava.ops.engine.matcher.impl.OpDescriptionTest$fieldOp\n\t" //
 				+ "> input1 : java.lang.Double\n\t" //
@@ -103,8 +123,14 @@ public class OpDescriptionTest extends AbstractTestEnvironment {
 
 	@Test
 	public void testReducedDescription() {
-		OpClassInfo info = new OpClassInfo(ClassOp.class, new Hints(),
-			"test.reductionDescription");
+		OpClassInfo info = new OpClassInfo( //
+			ClassOp.class, //
+			"1.0", //
+			"", //
+			new Hints(), //
+			1.0, //
+			"test.reductionDescription" //
+		);
 
 		Type opType = Types.parameterize(Function.class, new Type[] { Double.class,
 			Double.class });

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpFieldInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpFieldInfoTest.java
@@ -52,7 +52,9 @@ public class OpFieldInfoTest implements OpCollection {
 				this, //
 				field, //
 				Versions.getVersion(this.getClass()), //
+				"", //
 				new Hints(), //
+				1.0, //
 				"foo" //
 			));
 	}
@@ -67,7 +69,9 @@ public class OpFieldInfoTest implements OpCollection {
 				this, //
 				field, //
 				Versions.getVersion(this.getClass()), //
+				"", //
 				new Hints(), //
+				1.0, //
 				"bar" //
 			));
 	}

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpMethodInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/impl/OpMethodInfoTest.java
@@ -53,7 +53,10 @@ public class OpMethodInfoTest {
 			() -> new OpMethodInfo( //
 				m, //
 				Producer.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"privateOp"));
 	}
 
@@ -68,7 +71,10 @@ public class OpMethodInfoTest {
 			() -> new OpMethodInfo( //
 				m, //
 				Producer.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"instanceOp"));
 	}
 
@@ -83,7 +89,10 @@ public class OpMethodInfoTest {
 			() -> new OpMethodInfo( //
 				m, //
 				getClass(), //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"staticOp"));
 	}
 
@@ -94,7 +103,10 @@ public class OpMethodInfoTest {
 			() -> new OpMethodInfo( //
 				m, //
 				Function.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"staticOp"));
 	}
 
@@ -108,7 +120,10 @@ public class OpMethodInfoTest {
 			() -> new OpMethodInfo( //
 				m, //
 				Computers.Arity1.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"mutateDouble"));
 	}
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/reduce/NullableArgumentsFromIFaceTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/reduce/NullableArgumentsFromIFaceTest.java
@@ -32,6 +32,7 @@ package org.scijava.ops.engine.reduce;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.scijava.meta.Versions;
 import org.scijava.ops.api.Hints;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.engine.exceptions.InvalidOpException;
@@ -148,7 +149,10 @@ public class NullableArgumentsFromIFaceTest extends AbstractTestEnvironment
 			() -> new OpMethodInfo(//
 				m, //
 				BiFunctionWithNullable.class, //
+				"1.0", //
+				"", //
 				new Hints(), //
+				1.0, //
 				"test.optionalOnIFaceAndOp" //
 			));
 	}
@@ -177,7 +181,10 @@ public class NullableArgumentsFromIFaceTest extends AbstractTestEnvironment
 			() -> new OpFieldInfo(//
 				this, //
 				f, //
+				Versions.getVersion(this.getClass()), //
+				"This is an invalid OpFieldInfo", //
 				new Hints(), //
+				1.0, //
 				"test.optionalOnIFaceAndOp" //
 			));
 	}

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/reduce/NullableArgumentsTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/reduce/NullableArgumentsTest.java
@@ -35,14 +35,17 @@ import org.junit.jupiter.api.Test;
 import org.scijava.function.Computers;
 import org.scijava.function.Container;
 import org.scijava.function.Functions;
+import org.scijava.ops.api.Ops;
 import org.scijava.ops.engine.AbstractTestEnvironment;
 import org.scijava.ops.engine.describe.BaseDescriptors;
+import org.scijava.ops.engine.matcher.reduce.ReducedOpInfo;
 import org.scijava.ops.spi.Nullable;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
 import org.scijava.ops.spi.OpMethod;
 
 import java.util.Arrays;
+import java.util.function.BiFunction;
 
 public class NullableArgumentsTest extends AbstractTestEnvironment //
 	implements OpCollection
@@ -217,5 +220,27 @@ public class NullableArgumentsTest extends AbstractTestEnvironment //
 		var expected = PERMUTED_NAME +
 			":\n\t- (number[], number[] = null, @CONTAINER number[], number[] = null) -> None";
 		Assertions.assertEquals(expected, ops.op("test.nullableOr").help());
+	}
+
+	private static final String TEST_DESC = "This Op should be reduced";
+
+	@OpMethod( //
+		names = "math.sub", //
+		type = BiFunction.class, //
+		description = TEST_DESC //
+	)
+	public static Double nullableFunction(Double in1, @Nullable Double in2) {
+		if (in2 == null) return in1;
+		return in1 - in2;
+	}
+
+	@Test
+	public void testToString() {
+		// Add in a couple Ops needed for conversion
+		var op = ops.op("math.sub").input(1.0).function();
+		var info = Ops.info(op);
+		Assertions.assertInstanceOf(ReducedOpInfo.class, info);
+		Assertions.assertEquals(TEST_DESC, info.description());
+		Assertions.assertTrue(info.toString().contains(TEST_DESC));
 	}
 }

--- a/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpClass.java
+++ b/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpClass.java
@@ -41,6 +41,13 @@ public @interface OpClass {
 
 	String names();
 
+	/**
+	 * Returns a description of the Op's behavior.
+	 *
+	 * @return a description of the Op
+	 */
+	String description() default "";
+
 	// the names of the parameters (inputs and outputs) that will appear in a call
 	// to help().
 	String[] params() default "";

--- a/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpField.java
+++ b/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpField.java
@@ -46,6 +46,13 @@ public @interface OpField {
 
 	String names();
 
+	/**
+	 * Returns a description of the Op's behavior.
+	 *
+	 * @return a description of the Op
+	 */
+	String description() default "";
+
 	// the names of the parameters (inputs and outputs) that will appear in a call
 	// to help().
 	// TODO: add default names support in OpFieldInfo

--- a/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpMethod.java
+++ b/scijava-ops-spi/src/main/java/org/scijava/ops/spi/OpMethod.java
@@ -43,6 +43,13 @@ public @interface OpMethod {
 
 	String names();
 
+	/**
+	 * Returns a description of the Op's behavior.
+	 *
+	 * @return a description of the Op
+	 */
+	String description() default "";
+
 	Class<?> type();
 
 	/**


### PR DESCRIPTION
This PR adds the field `OpInfo.description()`, allowing Ops to describe their behavior and have that description presented in calls to `OpEnvironment.helpVerbose()"

The mechanism for defining that description depends on the discovery mechanism used. If the Op is defined using JPMS, then the description can be added as a part of the `@OpClass`, `@OpMethod` or `@OpField` annotation (new to this PR). If the Op is defined using YAML, it can be defined within that YAML (existing feature). Note that for Ops declared in Javadoc and discovered using the Ops Indexer, the description is copied from the Javadoc description.

TODO:
* [x] Further test the descriptions of e.g. `OpAdaptationInfo` and other transformations