### PR TITLE
Remove OpEnvironment.infoTree()

### DIFF
--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/OpEnvironment.java
@@ -161,41 +161,6 @@ public interface OpEnvironment extends Prioritized<OpEnvironment> {
 	<T> T op(final String opName, final Nil<T> specialType,
 		final Nil<?>[] inTypes, final Nil<?> outType, Hints hints);
 
-	/**
-	 * Returns an {@link InfoTree} fitting the provided arguments. NB
-	 * implementations of this method likely depend on the {@link Hints} set by
-	 * {@link OpEnvironment#setDefaultHints(Hints)}, which provides no guarantee
-	 * of thread-safety. Users interested in parallel Op matching should consider
-	 * using {@link OpEnvironment#op(String, Nil, Nil[], Nil, Hints)} instead.
-	 *
-	 * @param opName the name of the Op
-	 * @param specialType the generic {@link Type} of the Op
-	 * @param inTypes the arguments (inputs) to the Op
-	 * @param outType the return of the Op (note that it may also be an argument)
-	 * @return an instance of an Op aligning with the search parameters
-	 */
-	default InfoTree infoTree( //
-		final String opName, //
-		final Nil<?> specialType, //
-		final Nil<?>[] inTypes, //
-		final Nil<?> outType //
-	) {
-		return infoTree(opName, specialType, inTypes, outType, getDefaultHints());
-	}
-
-	/**
-	 * Returns an {@link InfoTree} fitting the provided arguments.
-	 *
-	 * @param opName the name of the Op
-	 * @param specialType the generic {@link Type} of the Op
-	 * @param inTypes the arguments (inputs) to the Op
-	 * @param outType the return of the Op (note that it may also be an argument)
-	 * @param hints the {@link Hints} that should guide this matching call
-	 * @return an instance of an Op aligning with the search parameters
-	 */
-	InfoTree infoTree(final String opName, final Nil<?> specialType,
-		final Nil<?>[] inTypes, final Nil<?> outType, Hints hints);
-
 	default <T> T opFromInfoChain(InfoTree tree, Nil<T> specialType) {
 		return opFromInfoChain(tree, specialType, getDefaultHints());
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -213,13 +213,6 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	}
 
 	@Override
-	public InfoTree infoTree(String opName, Nil<?> specialType, Nil<?>[] inTypes,
-		Nil<?> outType, Hints hints)
-	{
-		return findOp(opName, specialType, inTypes, outType, hints).infoTree();
-	}
-
-	@Override
 	public InfoTree treeFromInfo(OpInfo info, Nil<?> specialType, Hints hints) {
 		return findOp(info, specialType, hints).infoTree();
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/adapt/AdaptationMatchingRoutine.java
@@ -42,14 +42,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.scijava.ops.api.Hints;
-import org.scijava.ops.api.InfoTree;
-import org.scijava.ops.api.OpMatchingException;
+import org.scijava.ops.api.*;
 import org.scijava.ops.engine.*;
 import org.scijava.ops.engine.OpCandidate.StatusCode;
-import org.scijava.ops.api.OpEnvironment;
-import org.scijava.ops.api.OpInfo;
-import org.scijava.ops.api.OpRequest;
 import org.scijava.ops.engine.matcher.MatchingRoutine;
 import org.scijava.ops.engine.matcher.OpMatcher;
 import org.scijava.ops.engine.matcher.impl.DefaultOpRequest;
@@ -140,8 +135,12 @@ public class AdaptationMatchingRoutine implements MatchingRoutine {
 						Nil<?>[] args = Arrays.stream(request.getArgs()).map(Nil::of)
 							.toArray(Nil[]::new);
 						Nil<?> outType = Nil.of(request.getOutType());
-						return env.infoTree(request.getName(), type, args, outType,
+						var op = env.op(request.getName(), type, args, outType,
 							adaptationHints);
+						// NB the dependency is interested in the INFOTREE of the match,
+						// not the Op itself. We want to instantiate the dependencies
+						// separately, so they can e.g. operate silently.
+						return Ops.infoTree(op);
 					}).collect(Collectors.toList());
 				// And return the Adaptor, wrapped up into an OpCandidate
 				Type adapterOpType = Types.substituteTypeVariables(adaptor.output()


### PR DESCRIPTION
Was no longer necessary with the `Ops.infoTree()` utility method

The only reason I can think of to keep this is because it is extensible. Notably, `Ops.infoTree()` only works if the passed argument is a `RichOp`, which is *not* a requirement of `OpEnvironment.op()`, or the `OpBuilder` calls. Therefore, removing this method could prevent us from obtaining `InfoTree`s from future `OpEnvironment` implementations. This could be a YAGNI at the end of the day, looking for others' opinions. 