### PR TITLE
Refactor error messages

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/OpDescriptionGenerator.java
@@ -44,6 +44,9 @@ public interface OpDescriptionGenerator extends
 	Prioritized<OpDescriptionGenerator>
 {
 
+	public static final String NO_OP_MATCHES =
+		"No Ops found matching this request.";
+
 	/**
 	 * Returns a {@link String} with a "simple" description for each Op in
 	 * {@code env} matching {@code request}.

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
@@ -94,7 +94,7 @@ public class DefaultOpDescriptionGenerator implements OpDescriptionGenerator {
 			.map(s -> s.replaceAll("\n", "\n\t")) //
 			.distinct() //
 			.collect(Collectors.joining("\n\t- "));
-		if (opString.isEmpty()) return "No Ops found matching this request.";
+		if (opString.isEmpty()) return NO_OP_MATCHES;
 		return req.getName() + ":\n\t- " + opString;
 	}
 

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -385,16 +385,47 @@ public class DefaultOpEnvironment implements OpEnvironment {
 			return wrapOp(instance, conditions);
 		}
 		catch (OpMatchingException e) {
-			// Try and suggest close alternatives to the request
-			var msg = helpVerbose(request);
-			if (!msg.equals(OpDescriptionGenerator.NO_OP_MATCHES)) {
-				msg = "No matching Ops were found. Perhaps you meant one of these:\n" +
-					msg + "\n";
-			}
 			// Report the full exception trace for debugging purposes
-			log.debug("Op matching failed", e);
-			// Create a new exception with suggested Op text to avoid an overwhelming
-			// stack trace
+			log.debug("Op matching failed.", e);
+
+			var debugText = "See debugging output for full failure report.";
+
+			if (e instanceof DependencyMatchingException) {
+				// Preserve the specificity of the match but point to the original
+				// request instead of the dependency, and note the debug logging
+				throw new DependencyMatchingException(
+					"Error matching dependencies for request:\n\n" + request + "\n\n" +
+						debugText);
+			}
+
+			var failedRequest = "\n\n" + request + "\n\n";
+
+			// The directly suppressed exceptions will be from the individual matchers
+			// Check here for special cases of match failure
+			for (Throwable t : e.getSuppressed()) {
+				// Duplicate ops detected
+				if (t.getMessage().startsWith("Multiple") && t.getMessage().contains(
+					"ops of priority"))
+				{
+					throw new OpMatchingException(
+						"Multiple ops of equal priority detected for request:" +
+							failedRequest + "\n" + debugText);
+				}
+			}
+
+			var msg = helpVerbose(request);
+			// If we have some alternatives we can suggest them here
+			if (!msg.equals(OpDescriptionGenerator.NO_OP_MATCHES)) {
+				msg = OpDescriptionGenerator.NO_OP_MATCHES + failedRequest +
+					"Perhaps you meant one of these:\n" + msg + "\n\n";
+			}
+			else {
+				// Otherwise, not much to report
+				msg += failedRequest;
+			}
+
+			msg += debugText;
+
 			throw new OpMatchingException(msg);
 		}
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConversionMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConversionMatchingRoutine.java
@@ -86,8 +86,14 @@ public class ConversionMatchingRoutine extends RuntimeSafeMatchingRoutine {
 			});
 		}
 		final List<OpCandidate> matches = filterMatches(candidates);
-		return new MatchingResult(candidates, matches, Collections.singletonList(
-			request)).singleMatch();
+		try {
+			return new MatchingResult(candidates, matches, Collections.singletonList(
+				request)).singleMatch();
+		}
+		catch (OpMatchingException e) {
+			throw new OpMatchingException(
+				"Unable to find Op conversion pathway for " + convertConditions, e);
+		}
 	}
 
 	@Override

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/DefaultOpMatcher.java
@@ -70,7 +70,8 @@ public class DefaultOpMatcher implements OpMatcher {
 			}
 		}
 
-		// in the case of no matches, throw an agglomerated exception
+		// in the case of no matches, throw an agglomerated exception to retain the
+		// full exception history
 		throw agglomeratedException(conditions.request(), exceptions, env);
 	}
 
@@ -79,10 +80,8 @@ public class DefaultOpMatcher implements OpMatcher {
 		final List<OpMatchingException> list, //
 		final OpEnvironment env //
 	) {
-		// Develop help message
-		var msg = "No match found! Perhaps you meant: \n" + env.helpVerbose(
-			request);
-		OpMatchingException agglomerated = new OpMatchingException(msg);
+		OpMatchingException agglomerated = new OpMatchingException(
+			"No match found");
 		list.forEach(agglomerated::addSuppressed);
 		return agglomerated;
 	}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/util/Infos.java
@@ -148,7 +148,11 @@ public final class Infos {
 		// Step 2: Description (if present)
 		if (!info.description().isEmpty()) {
 			var desc = info.description().replaceAll("\n", "\n\t");
-			sb.append("\n\t").append(desc).append("\n");
+			// Each input prepends \n\t so we don't want to end with newlines.
+			if (desc.endsWith("\n\t")) {
+				desc = desc.substring(0, desc.lastIndexOf("\n\t"));
+			}
+			sb.append("\n\t").append(desc);
 		}
 
 		// Step 3: Inputs

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/OpEnvironmentTest.java
@@ -122,7 +122,7 @@ public class OpEnvironmentTest extends AbstractTestEnvironment {
 		OpEnvironment helpEnv = makeHelpEnv("help.verbose1", "help.verbose2");
 		// Finally assert a message is thrown when no Ops match
 		String descriptions = helpEnv.op("help.verbose1").input(null).helpVerbose();
-		String expected = "No Ops found matching this request.";
+		String expected = OpDescriptionGenerator.NO_OP_MATCHES;
 		Assertions.assertEquals(expected, descriptions);
 	}
 

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
@@ -136,8 +136,7 @@ public class DefaultOpDescriptionGeneratorTest extends AbstractTestEnvironment
 		String actual = ops.op("math.add").helpVerbose();
 		String expected = "math.add:\n" +
 			"\t- org.scijava.ops.engine.impl.DefaultOpDescriptionGeneratorTest$functionAdder\n" +
-			"\t\t" + TEST_DESC + "\n" + "\t\n" +
-			"\t\t> input1 : java.lang.Integer\n" +
+			"\t\t" + TEST_DESC + "\n" + "\t\t> input1 : java.lang.Integer\n" +
 			"\t\t> input2 : java.lang.Integer\n" + "\t\tReturns : java.lang.Integer";
 		// Assert that helpVerbose shows the description as a part of the result.
 		Assertions.assertEquals(expected, actual);

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGeneratorTest.java
@@ -36,6 +36,7 @@ import org.scijava.function.Computers;
 import org.scijava.function.Inplaces;
 import org.scijava.ops.api.OpInfo;
 import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.OpDescriptionGenerator;
 import org.scijava.ops.engine.describe.BaseDescriptors;
 import org.scijava.ops.spi.OpCollection;
 import org.scijava.ops.spi.OpField;
@@ -115,7 +116,7 @@ public class DefaultOpDescriptionGeneratorTest extends AbstractTestEnvironment
 		Assertions.assertEquals(expected, actual);
 		// Finally test that with no inputs we don't get any of the Ops
 		actual = ops.op("test.coalesceDescription").output(null).help();
-		expected = "No Ops found matching this request.";
+		expected = OpDescriptionGenerator.NO_OP_MATCHES;
 		Assertions.assertEquals(expected, actual);
 	}
 

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/OpMatchingExceptionTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/OpMatchingExceptionTest.java
@@ -39,6 +39,7 @@ import org.scijava.function.Computers;
 import org.scijava.ops.api.OpMatchingException;
 import org.scijava.ops.engine.DependencyMatchingException;
 import org.scijava.ops.engine.AbstractTestEnvironment;
+import org.scijava.ops.engine.OpDescriptionGenerator;
 import org.scijava.ops.engine.adapt.functional.ComputersToFunctionsViaFunction;
 import org.scijava.ops.engine.create.CreateOpCollection;
 import org.scijava.ops.spi.Op;
@@ -82,11 +83,9 @@ public class OpMatchingExceptionTest extends AbstractTestEnvironment implements
 			Assertions.fail();
 		}
 		catch (OpMatchingException e) {
-			Assertions.assertTrue(e.getMessage().startsWith("No match found!"));
-			Assertions.assertTrue(Arrays.stream(e.getSuppressed()).anyMatch(s -> s
-				.getMessage().startsWith("Multiple 'test.duplicateOp/" +
-					"java.util.function.Function<java.lang.Double, java.lang.Double>' " +
-					"ops of priority 0.0:")));
+			Assertions.assertTrue(e.getMessage().startsWith(
+				"Multiple ops of equal priority detected for request"));
+			Assertions.assertTrue(e.getMessage().contains("test.duplicateOp"));
 		}
 	}
 
@@ -102,7 +101,8 @@ public class OpMatchingExceptionTest extends AbstractTestEnvironment implements
 		}
 		catch (DependencyMatchingException e) {
 			String message = e.getMessage();
-			Assertions.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+			Assertions.assertTrue(message.contains(
+				"Name: \"test.missingDependencyOp\""));
 		}
 	}
 
@@ -118,9 +118,7 @@ public class OpMatchingExceptionTest extends AbstractTestEnvironment implements
 		}
 		catch (DependencyMatchingException e) {
 			String message = e.getMessage();
-			Assertions.assertTrue(message.contains(
-				"Name: \"test.missingDependencyOp\""));
-			Assertions.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+			Assertions.assertTrue(message.contains("Name: \"test.outsideOp\""));
 		}
 	}
 
@@ -137,8 +135,7 @@ public class OpMatchingExceptionTest extends AbstractTestEnvironment implements
 		}
 		catch (DependencyMatchingException e) {
 			String message = e.getMessage();
-			Assertions.assertTrue(message.contains("Adaptor:"));
-			Assertions.assertTrue(message.contains("Name: \"test.nonexistingOp\""));
+			Assertions.assertTrue(message.contains("Name: \"test.adaptMissingDep\""));
 
 		}
 	}

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/matcher/adapt/OpAdaptationInfoTest.java
@@ -82,7 +82,7 @@ public class OpAdaptationInfoTest extends AbstractTestEnvironment implements
 			"org.scijava.ops.engine.matcher.adapt.OpAdaptationInfoTest.adaptableOp(java.lang.Double,java.lang.Double)\n\t" +
 				"Adaptor: org.scijava.ops.engine.adapt.functional.FunctionsToComputers$Function2ToComputer2\n\t\t" +
 				"Depends upon: org.scijava.ops.engine.copy.CopyOpCollection$copyDoubleArray\n\t" //
-				+ TEST_DESC + "\n\n\t" //
+				+ TEST_DESC + "\n\t" //
 				+ "> input1 : java.lang.Double\n\t" //
 				+ "> input2 : java.lang.Double\n\t" //
 				+ "> output1 : @CONTAINER double[]";


### PR DESCRIPTION
This change reduces the number of `helpVerbose` calls during failed matches and shunts the full debugging stack trace of agglomerated exceptions to `log.debug`.

So in Fiji, for example, the script:
```groovy
#@ OpEnvironment ops

ops.op("deconvolve.richardsonLucyTV").input(1, 2, 3, 4, 5).function()
```

Produces the error message:
```
org.scijava.ops.api.OpMatchingException: No Ops found matching this request.
	at org.scijava.ops.engine.impl.DefaultOpEnvironment.findOp(DefaultOpEnvironment.java:397)
	at org.scijava.ops.engine.impl.DefaultOpEnvironment.op(DefaultOpEnvironment.java:212)
	at org.scijava.ops.api.OpBuilder.matchFunctionHelper(OpBuilder.java:21528)
	at org.scijava.ops.api.OpBuilder.matchFunction(OpBuilder.java:21297)
	at org.scijava.ops.api.OpBuilder$Arity5_IV_OU.function(OpBuilder.java:4043)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at New_.run(New_.groovy:3)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:331)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:161)
	at org.scijava.plugins.scripting.groovy.GroovyScriptLanguage$1.eval(GroovyScriptLanguage.java:97)
	at java.scripting/javax.script.AbstractScriptEngine.eval(AbstractScriptEngine.java:264)
	at org.scijava.script.ScriptModule.run(ScriptModule.java:173)
	at org.scijava.module.ModuleRunner.run(ModuleRunner.java:165)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:125)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:64)
	at org.scijava.thread.DefaultThreadService.lambda$wrap$2(DefaultThreadService.java:247)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

but still dumps the full 2k lines to debug