### PR TITLE
Change `ops.help()` output to only display namespaces

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
@@ -117,7 +117,7 @@ public class DefaultOpDescriptionGenerator implements OpDescriptionGenerator {
 		if (Strings.isNullOrEmpty(name)) {
 			// Return all namespaces
 			nsStream = publicOpStream(env);
-			nsStream = nsStream.map(s -> s.substring(0, s.lastIndexOf('.')))
+			nsStream = nsStream.map(s -> s.substring(0, s.indexOf('.')))
 				.distinct();
 			prefix = "Namespaces:\n\t> ";
 		}

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpDescriptionGenerator.java
@@ -117,8 +117,7 @@ public class DefaultOpDescriptionGenerator implements OpDescriptionGenerator {
 		if (Strings.isNullOrEmpty(name)) {
 			// Return all namespaces
 			nsStream = publicOpStream(env);
-			nsStream = nsStream.map(s -> s.substring(0, s.indexOf('.')))
-				.distinct();
+			nsStream = nsStream.map(s -> s.substring(0, s.indexOf('.'))).distinct();
 			prefix = "Namespaces:\n\t> ";
 		}
 		else if (env.infos(name).isEmpty()) {

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/impl/DefaultOpEnvironment.java
@@ -341,7 +341,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	 */
 	@Override
 	public String help(final OpRequest request) {
-		Optional<OpDescriptionGenerator> opt = metaDiscoverer.discoverMin(
+		Optional<OpDescriptionGenerator> opt = metaDiscoverer.discoverMax(
 			OpDescriptionGenerator.class);
 		if (opt.isEmpty()) {
 			return "";
@@ -364,7 +364,7 @@ public class DefaultOpEnvironment implements OpEnvironment {
 	 */
 	@Override
 	public String helpVerbose(final OpRequest request) {
-		Optional<OpDescriptionGenerator> opt = metaDiscoverer.discoverMin(
+		Optional<OpDescriptionGenerator> opt = metaDiscoverer.discoverMax(
 			OpDescriptionGenerator.class);
 		if (opt.isEmpty()) {
 			return "";


### PR DESCRIPTION
This commit cleans up the `ops.help()` output from:

```python
>>> ops.help()
'Namespaces:
	> coloc
	> convert
	> copy
	> create
	> deconvolve
	> expression
	> features.haralick
	> features
	> features.tamura
	> features.zernike
	> filter
	> flim
	> geom
	> image
	> imageMoments
	> labeling
	> linalg
	> logic
	> map
	> math
	> morphology
	> segment
	> stats
	> thread
	> threshold
	> topology
	> transform
	> types'
```

To:

```python
>>> ops.help()
'Namespaces:
	> coloc
	> convert
	> copy
	> create
	> deconvolve
	> expression
	> features
	> filter
	> flim
	> geom
	> image
	> imageMoments
	> labeling
	> linalg
	> logic
	> map
	> math
	> morphology
	> segment
	> stats
	> thread
	> threshold
	> topology
	> transform
	> types'
```

This prevents the `ops.help()` output from becoming too long with `namespace.sub_name` type ops like the `features` namespace.